### PR TITLE
Ensure consistent Vec and Mat types to enable use of PETSc GPU backends

### DIFF
--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -1787,6 +1787,7 @@ PetscErrorCode SVMLoadTrainingDataset_Binary(SVM svm,PetscViewer v)
   TRY( MatSetFromOptions(Xt_training) );
 
   TRY( VecCreate(comm,&y_training) );
+  TRY( VecSetFromOptions(y_training) );
   TRY( PetscObjectSetName((PetscObject) y_training,"y_training") );
 
   TRY( PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0) );

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -2567,6 +2567,7 @@ PetscErrorCode SVMLoadTestDataset(SVM svm,PetscViewer v)
   TRY( MatSetFromOptions(Xt_test) );
   /* Create label vector of test samples */
   TRY( VecCreate(comm,&y_test) );
+  TRY( VecSetFromOptions(y_test) );
   TRY( PetscObjectSetName((PetscObject) y_test,"y_test") );
 
   TRY( PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0) );

--- a/src/svm/utils/matutils.c
+++ b/src/svm/utils/matutils.c
@@ -145,6 +145,7 @@ PetscErrorCode MatCreateSubMatrix_Biased(Mat A,IS isrow,IS iscol,MatReuse cll,Ma
   Mat         A_sub;
   PetscInt    m,n,M,N;
   Mat         mat_inner;
+  VecType     vtype;
 
   void        *ptr     = NULL;
   MatCtx      *ctx     = NULL;
@@ -179,6 +180,10 @@ PetscErrorCode MatCreateSubMatrix_Biased(Mat A,IS isrow,IS iscol,MatReuse cll,Ma
   TRY( MatShellSetOperation(mat_inner,MATOP_MULT_TRANSPOSE  ,(void(*)(void))MatMultTranspose_Biased) );
   TRY( MatShellSetOperation(mat_inner,MATOP_CREATE_SUBMATRIX,(void(*)(void))MatCreateSubMatrix_Biased) );
   TRY( PetscObjectComposeFunction((PetscObject) mat_inner,"MatGetOwnershipIS_C",MatGetOwnershipIS_Biased) );
+
+  /* Set the default vector type for the shell to be the same as for the matrix A */
+  TRY( MatGetVecType(A,&vtype) );
+  TRY( MatShellSetVecType(mat_inner,vtype) );
 
   *out = mat_inner;
   PetscFunctionReturn(0);
@@ -284,6 +289,7 @@ PetscErrorCode MatBiasedCreate(Mat A,PetscReal bias,Mat *A_biased)
   Mat         A_biased_inner;
   PetscInt    m,n,M,N;
   MatCtx      *ctx = NULL;
+  VecType     vtype;
 
   const char  *A_name,*A_prefix;
   char        A_name_inner[50];
@@ -314,6 +320,10 @@ PetscErrorCode MatBiasedCreate(Mat A,PetscReal bias,Mat *A_biased)
   TRY( MatShellSetOperation(A_biased_inner,MATOP_MULT_TRANSPOSE  ,(void(*)(void))MatMultTranspose_Biased) );
   TRY( MatShellSetOperation(A_biased_inner,MATOP_CREATE_SUBMATRIX,(void(*)(void))MatCreateSubMatrix_Biased) );
   TRY( PetscObjectComposeFunction((PetscObject) A_biased_inner,"MatGetOwnershipIS_C",MatGetOwnershipIS_Biased) );
+
+  /* Set the default vector type for the shell to be the same as for the matrix A */
+  TRY( MatGetVecType(A,&vtype) );
+  TRY( MatShellSetVecType(A_biased_inner,vtype) );
 
   /* Set name of biased mat */
   TRY( PetscObjectGetName((PetscObject) A,&A_name) );


### PR DESCRIPTION
This PR adds calls to `MatShellSetVecType()` when creating shell matrices, and calls to `VecSetFromOptions()` after `VecCreate()`calls.

These changes are needed to ensure that the correct GPU vector types are used when targeting execution on GPUs. With them, it is possible to execute things using the PETSc GPU backends by specifying command lines like `-Xt_test_mat_type aijcusparse -Xt_training_mat_type aijcusparse -vec_type cuda` to the `permonsvmfile` executable.

This is really small set of changes but it took me an embarrassing amount of time to figure out what was needed! :grin: (Tried some kludgy fixes first that worked but added a lot of code that is not necessary if I do the simple stuff in this PR.)