### PR TITLE
Platt scalling

### DIFF
--- a/include/permon/private/svmimpl.h
+++ b/include/permon/private/svmimpl.h
@@ -27,8 +27,6 @@ struct _SVMOps {
   PetscErrorCode (*computemodelparams)(SVM);
   PetscErrorCode (*loadgramian)(SVM,PetscViewer);
   PetscErrorCode (*viewgramian)(SVM,PetscViewer);
-  PetscErrorCode (*loadtrainingdataset)(SVM,PetscViewer);
-  PetscErrorCode (*viewtrainingdataset)(SVM,PetscViewer);
   PetscErrorCode (*viewtrainingpredictions)(SVM,PetscViewer);
   PetscErrorCode (*viewtestpredictions)(SVM,PetscViewer);
 };
@@ -42,10 +40,12 @@ struct _p_SVM {
   ModelScore          hopt_score_types[7];
   PetscInt            hopt_nscore_types;
   CrossValidationType cv_type;
+
   PetscInt            penalty_type;
   PetscReal           C,C_old;
   PetscReal           Cp,Cp_old;
   PetscReal           Cn,Cn_old;
+
   PetscReal           logC_base,logC_start,logC_end,logC_step;
   PetscReal           logCp_base,logCp_start,logCp_end,logCp_step;
   PetscReal           logCn_base,logCn_start,logCn_end,logCn_step;
@@ -53,6 +53,7 @@ struct _p_SVM {
 
   SVMLossType         loss_type;
   PetscInt            svm_mod;
+  PetscReal           user_bias;
 
   PetscBool           warm_start;
 

--- a/include/permon/private/svmimpl.h
+++ b/include/permon/private/svmimpl.h
@@ -37,7 +37,7 @@ struct _p_SVM {
   Mat                 Xt_test;
   Vec                 y_test;
 
-  ModelScore          hopt_score_types[7];
+  ModelScore          hopt_score_types[6];
   PetscInt            hopt_nscore_types;
   CrossValidationType cv_type;
 

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -167,6 +167,8 @@ FLLOP_EXTERN PetscErrorCode SVMComputeOperator(SVM,Mat *);
 
 FLLOP_EXTERN PetscErrorCode SVMSetTrainingDataset(SVM,Mat,Vec);
 FLLOP_EXTERN PetscErrorCode SVMGetTrainingDataset(SVM,Mat *,Vec *);
+FLLOP_EXTERN PetscErrorCode SVMSetCalibrationDataset(SVM,Mat,Vec);
+FLLOP_EXTERN PetscErrorCode SVMGetCalibrationDataset(SVM,Mat *,Vec *);
 FLLOP_EXTERN PetscErrorCode SVMSetTestDataset(SVM,Mat,Vec);
 FLLOP_EXTERN PetscErrorCode SVMGetTestDataset(SVM,Mat *,Vec *);
 
@@ -189,6 +191,8 @@ FLLOP_EXTERN PetscErrorCode SVMSetSeparatingHyperplane(SVM,Vec,PetscReal);
 FLLOP_EXTERN PetscErrorCode SVMGetSeparatingHyperplane(SVM,Vec *,PetscReal *);
 FLLOP_EXTERN PetscErrorCode SVMSetBias(SVM,PetscReal);
 FLLOP_EXTERN PetscErrorCode SVMGetBias(SVM,PetscReal *);
+FLLOP_EXTERN PetscErrorCode SVMSetUserBias(SVM,PetscReal);
+FLLOP_EXTERN PetscErrorCode SVMGetUserBias(SVM,PetscReal *);
 
 FLLOP_EXTERN PetscErrorCode SVMTrain(SVM);
 FLLOP_EXTERN PetscErrorCode SVMPostTrain(SVM);
@@ -254,6 +258,8 @@ FLLOP_EXTERN PetscErrorCode SVMLoadTrainingDataset(SVM,PetscViewer);
 FLLOP_EXTERN PetscErrorCode SVMViewTrainingDataset(SVM,PetscViewer);
 FLLOP_EXTERN PetscErrorCode SVMLoadTestDataset(SVM,PetscViewer);
 FLLOP_EXTERN PetscErrorCode SVMViewTestDataset(SVM,PetscViewer);
+FLLOP_EXTERN PetscErrorCode SVMLoadCalibrationDataset(SVM,PetscViewer);
+FLLOP_EXTERN PetscErrorCode SVMViewCalibrationDataset(SVM,PetscViewer);
 
 FLLOP_EXTERN PetscErrorCode SVMViewTrainingPredictions(SVM,PetscViewer);
 FLLOP_EXTERN PetscErrorCode SVMViewTestPredictions(SVM,PetscViewer);

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -19,8 +19,9 @@ typedef struct _p_SVM* SVM;
 FLLOP_EXTERN PetscClassId SVM_CLASSID;
 #define SVM_CLASS_NAME  "svm"
 
-#define SVMType       char*
-#define SVM_BINARY    "binary"
+#define SVMType  char*
+#define SVM_BINARY      "binary"
+#define SVM_PROBABILITY "probability"
 
 /*E
   SVMLossType - Determines the loss function for soft-margin SVM (non-separable samples).

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -172,6 +172,8 @@ FLLOP_EXTERN PetscErrorCode SVMGetCalibrationDataset(SVM,Mat *,Vec *);
 FLLOP_EXTERN PetscErrorCode SVMSetTestDataset(SVM,Mat,Vec);
 FLLOP_EXTERN PetscErrorCode SVMGetTestDataset(SVM,Mat *,Vec *);
 
+FLLOP_EXTERN PetscErrorCode SVMGetLabels(SVM,const PetscReal *[]);
+
 FLLOP_EXTERN PetscErrorCode SVMSetMod(SVM,PetscInt);
 FLLOP_EXTERN PetscErrorCode SVMGetMod(SVM,PetscInt *);
 FLLOP_EXTERN PetscErrorCode SVMSetLossType(SVM,SVMLossType);

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -254,12 +254,12 @@ FLLOP_EXTERN PetscErrorCode SVMGetTao(SVM,Tao *);
 FLLOP_EXTERN PetscErrorCode SVMGetInnerSVM(SVM,SVM *);
 
 /* SVM probability */
-FLLOP_EXTERN PetscErrorCode SVMProbSetConvertLabelsToTargetProbability(SVM,PetscBool);
-FLLOP_EXTERN PetscErrorCode SVMProbGetConvertLabelsToTargetProbability(SVM,PetscBool *);
-FLLOP_EXTERN PetscErrorCode SVMProbGetSigmoidParams(SVM,PetscReal *,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMProbSetThreshold(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMProbGetThreshold(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMProbConvertProbabilityToLabels(SVM,Vec);
+FLLOP_EXTERN PetscErrorCode SVMProbabilitySetConvertLabelsToTargetProbability(SVM,PetscBool);
+FLLOP_EXTERN PetscErrorCode SVMProbabilityGetConvertLabelsToTargetProbability(SVM,PetscBool *);
+FLLOP_EXTERN PetscErrorCode SVMProbabilityGetSigmoidParams(SVM,PetscReal *,PetscReal *);
+FLLOP_EXTERN PetscErrorCode SVMProbabilitySetThreshold(SVM,PetscReal);
+FLLOP_EXTERN PetscErrorCode SVMProbabilityGetThreshold(SVM,PetscReal *);
+FLLOP_EXTERN PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM,Vec);
 
 /* Input/Output functions */
 FLLOP_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -199,6 +199,7 @@ FLLOP_EXTERN PetscErrorCode SVMPostTrain(SVM);
 FLLOP_EXTERN PetscErrorCode SVMReconstructHyperplane(SVM);
 FLLOP_EXTERN PetscErrorCode SVMSetAutoPostTrain(SVM,PetscBool);
 FLLOP_EXTERN PetscErrorCode SVMGetAutoPostTrain(SVM,PetscBool *);
+FLLOP_EXTERN PetscErrorCode SVMGetDistancesFromHyperplane(SVM,Mat,Vec *);
 FLLOP_EXTERN PetscErrorCode SVMPredict(SVM,Mat,Vec *);
 FLLOP_EXTERN PetscErrorCode SVMTest(SVM);
 
@@ -253,6 +254,7 @@ FLLOP_EXTERN PetscErrorCode SVMGetInnerSVM(SVM,SVM *);
 /* SVM probability */
 FLLOP_EXTERN PetscErrorCode SVMProbSetConvertLabelsToTargetProbability(SVM,PetscBool);
 FLLOP_EXTERN PetscErrorCode SVMProbGetConvertLabelsToTargetProbability(SVM,PetscBool *);
+FLLOP_EXTERN PetscErrorCode SVMProbGetSigmoidParams(SVM,PetscReal *,PetscReal *);
 
 /* Input/Output functions */
 FLLOP_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -257,6 +257,7 @@ FLLOP_EXTERN PetscErrorCode SVMProbGetConvertLabelsToTargetProbability(SVM,Petsc
 FLLOP_EXTERN PetscErrorCode SVMProbGetSigmoidParams(SVM,PetscReal *,PetscReal *);
 FLLOP_EXTERN PetscErrorCode SVMProbSetThreshold(SVM,PetscReal);
 FLLOP_EXTERN PetscErrorCode SVMProbGetThreshold(SVM,PetscReal *);
+FLLOP_EXTERN PetscErrorCode SVMProbConvertProbabilityToLabels(SVM,Vec);
 
 /* Input/Output functions */
 FLLOP_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -255,6 +255,8 @@ FLLOP_EXTERN PetscErrorCode SVMGetInnerSVM(SVM,SVM *);
 FLLOP_EXTERN PetscErrorCode SVMProbSetConvertLabelsToTargetProbability(SVM,PetscBool);
 FLLOP_EXTERN PetscErrorCode SVMProbGetConvertLabelsToTargetProbability(SVM,PetscBool *);
 FLLOP_EXTERN PetscErrorCode SVMProbGetSigmoidParams(SVM,PetscReal *,PetscReal *);
+FLLOP_EXTERN PetscErrorCode SVMProbSetThreshold(SVM,PetscReal);
+FLLOP_EXTERN PetscErrorCode SVMProbGetThreshold(SVM,PetscReal *);
 
 /* Input/Output functions */
 FLLOP_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -198,6 +198,7 @@ FLLOP_EXTERN PetscErrorCode SVMTrain(SVM);
 FLLOP_EXTERN PetscErrorCode SVMPostTrain(SVM);
 FLLOP_EXTERN PetscErrorCode SVMReconstructHyperplane(SVM);
 FLLOP_EXTERN PetscErrorCode SVMSetAutoPostTrain(SVM,PetscBool);
+FLLOP_EXTERN PetscErrorCode SVMGetAutoPostTrain(SVM,PetscBool *);
 FLLOP_EXTERN PetscErrorCode SVMPredict(SVM,Mat,Vec *);
 FLLOP_EXTERN PetscErrorCode SVMTest(SVM);
 
@@ -245,6 +246,13 @@ FLLOP_EXTERN PetscErrorCode SVMSetWarmStart(SVM,PetscBool);
 FLLOP_EXTERN PetscErrorCode SVMSetOptionsPrefix(SVM svm,const char []);
 FLLOP_EXTERN PetscErrorCode SVMAppendOptionsPrefix(SVM svm,const char []);
 FLLOP_EXTERN PetscErrorCode SVMGetOptionsPrefix(SVM svm,const char *[]);
+
+FLLOP_EXTERN PetscErrorCode SVMGetTao(SVM,Tao *);
+FLLOP_EXTERN PetscErrorCode SVMGetInnerSVM(SVM,SVM *);
+
+/* SVM probability */
+FLLOP_EXTERN PetscErrorCode SVMProbSetConvertLabelsToTargetProbability(SVM,PetscBool);
+FLLOP_EXTERN PetscErrorCode SVMProbGetConvertLabelsToTargetProbability(SVM,PetscBool *);
 
 /* Input/Output functions */
 FLLOP_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -2219,11 +2219,11 @@ PetscErrorCode SVMMonitorScores_Binary(QPS qps,PetscInt it,PetscReal rnorm,void 
 
   PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_test=%.2f",it,(double)(svm_binary->model_scores[0])));
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_test=%.2f",(double)svm_binary->model_scores[4]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_test=%.2f"   ,(double)svm_binary->model_scores[7]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_test=%.2f,"      ,(double)svm_binary->model_scores[10]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_test=%.2f," ,(double)svm_binary->model_scores[13]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_test=%.2f\n"     ,(double)svm_binary->model_scores[14]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_test=%.2f",(double)svm_binary->model_scores[3]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_test=%.2f"   ,(double)svm_binary->model_scores[6]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_test=%.2f,"      ,(double)svm_binary->model_scores[9]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_test=%.2f," ,(double)svm_binary->model_scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_test=%.2f\n"     ,(double)svm_binary->model_scores[13]));
   PetscCall(PetscViewerASCIIPopTab(v));
 
   PetscCall(VecDestroy(&y_pred));
@@ -2264,11 +2264,11 @@ PetscErrorCode SVMMonitorTrainingScores_Binary(QPS qps,PetscInt it,PetscReal rno
 
   PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_training=%.2f",it,(double)(svm_binary->model_scores[0])));
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_training=%.2f",(double)svm_binary->model_scores[4]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_training=%.2f"   ,(double)svm_binary->model_scores[7]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_training=%.2f"       ,(double)svm_binary->model_scores[10]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_training=%.2f"  ,(double)svm_binary->model_scores[13]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_training=%.2f\n"     ,(double)svm_binary->model_scores[14]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_training=%.2f",(double)svm_binary->model_scores[3]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_training=%.2f"   ,(double)svm_binary->model_scores[6]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_training=%.2f"       ,(double)svm_binary->model_scores[9]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_training=%.2f"  ,(double)svm_binary->model_scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_training=%.2f\n"     ,(double)svm_binary->model_scores[13]));
   PetscCall(PetscViewerASCIIPopTab(v));
 
   PetscCall(VecDestroy(&y_pred));

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -1457,6 +1457,7 @@ PetscErrorCode SVMGetDistancesFromHyperplane_Binary(SVM svm,Mat Xt_pred,Vec *dis
 
   /* Predict labels of unseen samples */
   PetscCall(MatCreateVecs(Xt_pred,NULL,&dist));
+  PetscCall(VecSetFromOptions(dist));
 
   PetscCall(MatMult(Xt_pred,w,dist));
   PetscCall(VecShift(dist,b)); /* shifting is not performed in case of b = 0 (inner implementation) */

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -73,26 +73,28 @@ PetscErrorCode SVMDestroy_Binary(SVM svm)
   SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetGramian_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetGramian_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOperator_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOperator_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMComputeOperator_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetQPS_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQPS_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQP_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetBias_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetBias_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetSeparatingHyperplane_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetSeparatingHyperplane_C",NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetGramian_C"                ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetGramian_C"                ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOperator_C"               ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOperator_C"               ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C"        ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C"        ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetLabels_C"                 ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMComputeOperator_C"           ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetQPS_C"                    ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQPS_C"                    ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQP_C"                     ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetBias_C"                   ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetBias_C"                   ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetSeparatingHyperplane_C"   ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetSeparatingHyperplane_C"   ,NULL));
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetDistancesFromHyperplane_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetModelScore_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMKFoldCrossValidation_C",NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetModelScore_C"             ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C"          ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C"          ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C"       ,NULL));
+
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMKFoldCrossValidation_C"          ,NULL));
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMStratifiedKFoldCrossValidation_C",NULL));
 
   PetscCall(QPSDestroy(&svm_binary->qps));
@@ -383,18 +385,27 @@ PetscErrorCode SVMGetTrainingDataset_Binary(SVM svm,Mat *Xt_training,Vec *y_trai
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+PetscErrorCode SVMGetLabels_Binary(SVM svm,const PetscReal *labels[])
+{
+  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+
+  PetscFunctionBegin;
+  *labels = svm_binary->y_map;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetUp_Remapy_Binary_Private"
 static PetscErrorCode SVMSetUp_Remapy_Binary_Private(SVM svm)
 {
   SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
 
-  Vec         y;
-  PetscInt    i,n;
+  Vec               y;
+  PetscInt          i,n;
 
-  PetscScalar min,max;
+  PetscScalar       min,max;
   const PetscScalar *y_arr;
-  PetscScalar *y_inner_arr;
+  PetscScalar       *y_inner_arr;
 
   PetscFunctionBegin;
   PetscCall(SVMGetTrainingDataset(svm,NULL,&y));
@@ -2186,27 +2197,28 @@ PetscErrorCode SVMCreate_Binary(SVM svm)
   svm->ops->viewtrainingpredictions = SVMViewTrainingPredictions_Binary;
   svm->ops->viewtestpredictions     = SVMViewTestPredictions_Binary;
 
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetGramian_C",SVMSetGramian_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetGramian_C",SVMGetGramian_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOperator_C",SVMSetOperator_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOperator_C",SVMGetOperator_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C",SVMSetTrainingDataset_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C",SVMGetTrainingDataset_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMComputeOperator_C",SVMComputeOperator_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetQPS_C",SVMSetQPS_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQPS_C",SVMGetQPS_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQP_C",SVMGetQP_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetBias_C",SVMSetBias_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetBias_C",SVMGetBias_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetSeparatingHyperplane_C",SVMSetSeparatingHyperplane_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetSeparatingHyperplane_C",SVMGetSeparatingHyperplane_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetGramian_C"                ,SVMSetGramian_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetGramian_C"                ,SVMGetGramian_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOperator_C"               ,SVMSetOperator_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOperator_C"               ,SVMGetOperator_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C"        ,SVMSetTrainingDataset_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C"        ,SVMGetTrainingDataset_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetLabels_C"                 ,SVMGetLabels_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMComputeOperator_C"           ,SVMComputeOperator_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetQPS_C"                    ,SVMSetQPS_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQPS_C"                    ,SVMGetQPS_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQP_C"                     ,SVMGetQP_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetBias_C"                   ,SVMSetBias_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetBias_C"                   ,SVMGetBias_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetSeparatingHyperplane_C"   ,SVMSetSeparatingHyperplane_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetSeparatingHyperplane_C"   ,SVMGetSeparatingHyperplane_Binary));
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetDistancesFromHyperplane_C",SVMGetDistancesFromHyperplane_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetModelScore_C",SVMGetModelScore_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C",SVMSetOptionsPrefix_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C",SVMGetOptionsPrefix_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C",SVMAppendOptionsPrefix_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetModelScore_C"             ,SVMGetModelScore_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C"          ,SVMSetOptionsPrefix_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C"          ,SVMGetOptionsPrefix_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C"       ,SVMAppendOptionsPrefix_Binary));
 
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMKFoldCrossValidation_C",SVMKFoldCrossValidation_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMKFoldCrossValidation_C"          ,SVMKFoldCrossValidation_Binary));
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMStratifiedKFoldCrossValidation_C",SVMStratifiedKFoldCrossValidation_Binary));
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -1320,10 +1320,10 @@ PetscErrorCode SVMSetFromOptions_Binary(PetscOptionItems *PetscOptionsObject,SVM
 
   PetscFunctionBegin;
   PetscObjectOptionsBegin((PetscObject) svm);
-  PetscCall(PetscOptionsReal("-svm_bias","","SVMSetBias",svm_binary->b,&b,&flg));
-  if (flg) {
-    PetscCall(SVMSetBias(svm,b));
-  }
+//  PetscCall(PetscOptionsReal("-svm_bias","","SVMSetBias",svm_binary->b,&b,&flg));
+//  if (flg) {
+//    PetscCall(SVMSetBias(svm,b));
+//  }
   PetscOptionsEnd();
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2159,8 +2159,6 @@ PetscErrorCode SVMCreate_Binary(SVM svm)
   svm->ops->computemodelparams      = SVMComputeModelParams_Binary;
   svm->ops->loadgramian             = SVMLoadGramian_Binary;
   svm->ops->viewgramian             = SVMViewGramian_Binary;
-  svm->ops->loadtrainingdataset     = SVMLoadTrainingDataset_Binary;
-  svm->ops->viewtrainingdataset     = SVMViewTrainingDataset_Binary;
   svm->ops->viewtrainingpredictions = SVMViewTrainingPredictions_Binary;
   svm->ops->viewtestpredictions     = SVMViewTestPredictions_Binary;
 

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -207,7 +207,7 @@ PetscErrorCode SVMViewScore_Binary(SVM svm,PetscViewer v)
       PetscCall(PetscViewerASCIIPrintf(v,"model performance score with training parameters C+=%.3f, C-=%.3f, mod=%" PetscInt_FMT ", loss=%s:\n",(double)Cp,(double)Cn,mod,SVMLossTypes[loss_type]));
     }
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(SVMPrintBinaryClassificationReport(svm,svm_binary->confusion_matrix,svm_binary->model_scores,v));
+    PetscCall(SVMViewBinaryClassificationReport(svm,svm_binary->confusion_matrix,svm_binary->model_scores,v));
     PetscCall(PetscViewerASCIIPopTab(v));
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
@@ -1509,7 +1509,7 @@ PetscErrorCode SVMPredict_Binary(SVM svm,Mat Xt_pred,Vec *y_out)
   PetscCall(VecDuplicate(dist,&y));
   PetscCall(VecDuplicate(dist,&o));
 
-  PetscCall(VecSet(o,0));
+  PetscCall(VecSet(o,0.));
 
   PetscCall(VecWhichGreaterThan(dist,o,&is_p));
   PetscCall(ISComplement(is_p,lo,hi,&is_n));

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -166,7 +166,7 @@ PetscErrorCode SVMView_Binary(SVM svm,PetscViewer v)
 
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewScore", ((PetscObject)v)->type_name);
+    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMView", ((PetscObject)v)->type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -43,7 +43,7 @@ PetscErrorCode SVMReset_Binary(SVM svm)
 
   PetscCall(PetscMemzero(svm_binary->y_map,2 * sizeof(PetscScalar)));
   PetscCall(PetscMemzero(svm_binary->confusion_matrix,4 * sizeof(PetscInt)));
-  PetscCall(PetscMemzero(svm_binary->model_scores,7 * sizeof(PetscReal)));
+  PetscCall(PetscMemzero(svm_binary->model_scores,16 * sizeof(PetscReal)));
 
   svm_binary->w           = NULL;
   svm_binary->Xt_training = NULL;
@@ -1710,7 +1710,7 @@ PetscErrorCode SVMConvergedDualityGap_Binary(QPS qps,KSPConvergedReason *reason)
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
-  if (gap <= rtol * P) {
+  if (gap <= rtol * PetscAbs(P)) {
     *reason = KSP_CONVERGED_RTOL;
     PetscCall(PetscInfo(qps,"QP solver has converged. Duality gap %14.12e at iteration %" PetscInt_FMT "\n",(double) gap,it));
   }
@@ -1766,7 +1766,7 @@ PetscErrorCode SVMGetModelScore_Binary(SVM svm,ModelScore score_type,PetscReal *
   PetscFunctionBegin;
   PetscValidRealPointer(s,3);
 
-  *s = svm_binary->model_scores[score_type];
+  *s = svm_binary->model_scores[3 * score_type];
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1975,7 +1975,7 @@ PetscErrorCode SVMViewTrainingPredictions_Binary(SVM svm,PetscViewer v)
 
   /* View predictions on training samples */
   PetscCall(SVMPredict(svm,Xt_training,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_training_predictions"));
+  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
   PetscCall(VecView(y_pred,v));
 
   /* Free memory */
@@ -1999,7 +1999,7 @@ PetscErrorCode SVMViewTestPredictions_Binary(SVM svm,PetscViewer v)
 
   /* View predictions on test samples */
   PetscCall(SVMPredict(svm,Xt_test,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_test_predictions"));
+  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
   PetscCall(VecView(y_pred,v));
 
   /* Free memory */
@@ -2037,7 +2037,7 @@ PetscErrorCode SVMCreate_Binary(SVM svm)
 
   PetscCall(PetscMemzero(svm_binary->y_map,2 * sizeof(PetscScalar)));
   PetscCall(PetscMemzero(svm_binary->confusion_matrix,4 * sizeof(PetscInt)));
-  PetscCall(PetscMemzero(svm_binary->model_scores,7 * sizeof(PetscReal)));
+  PetscCall(PetscMemzero(svm_binary->model_scores,16 * sizeof(PetscReal)));
 
   for (i = 0; i < 3; ++i) {
     svm_binary->work[i] = NULL;
@@ -2224,7 +2224,7 @@ PetscErrorCode SVMMonitorScores_Binary(QPS qps,PetscInt it,PetscReal rnorm,void 
   PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_test=%.2f"   ,(double)svm_binary->model_scores[6]));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_test=%.2f,"      ,(double)svm_binary->model_scores[9]));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_test=%.2f," ,(double)svm_binary->model_scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_test=%.2f\n"     ,(double)svm_binary->model_scores[13]));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_test=%.2f\n"     ,(double)svm_binary->model_scores[15]));
   PetscCall(PetscViewerASCIIPopTab(v));
 
   PetscCall(VecDestroy(&y_pred));
@@ -2269,7 +2269,7 @@ PetscErrorCode SVMMonitorTrainingScores_Binary(QPS qps,PetscInt it,PetscReal rno
   PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_training=%.2f"   ,(double)svm_binary->model_scores[6]));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_training=%.2f"       ,(double)svm_binary->model_scores[9]));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_training=%.2f"  ,(double)svm_binary->model_scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_training=%.2f\n"     ,(double)svm_binary->model_scores[13]));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_training=%.2f\n"     ,(double)svm_binary->model_scores[15]));
   PetscCall(PetscViewerASCIIPopTab(v));
 
   PetscCall(VecDestroy(&y_pred));

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -33,11 +33,14 @@ PetscErrorCode SVMReset_Binary(SVM svm)
   }
   PetscCall(VecDestroy(&svm_binary->w));
   PetscCall(MatDestroy(&svm_binary->Xt_training));
+
   PetscCall(MatDestroy(&svm_binary->G));
   PetscCall(MatDestroy(&svm_binary->J));
   PetscCall(VecDestroy(&svm_binary->diag));
+
   PetscCall(VecDestroy(&svm_binary->y_training));
   PetscCall(VecDestroy(&svm_binary->y_inner));
+
   PetscCall(ISDestroy(&svm_binary->is_p));
   PetscCall(ISDestroy(&svm_binary->is_n));
 
@@ -2051,18 +2054,24 @@ PetscErrorCode SVMCreate_Binary(SVM svm)
 
   svm_binary->w           = NULL;
   svm_binary->b           = 1.;
+
   svm_binary->qps         = NULL;
+
   svm_binary->Xt_training = NULL;
+
   svm_binary->G           = NULL;
   svm_binary->J           = NULL;
   svm_binary->diag        = NULL;
+
   svm_binary->y_training  = NULL;
   svm_binary->y_inner     = NULL;
+
   svm_binary->is_p        = NULL;
   svm_binary->is_n        = NULL;
 
   svm_binary->nsv         = 0;
   svm_binary->is_sv       = NULL;
+
   svm_binary->chop_tol    = PETSC_MACHINE_EPSILON;
 
   PetscCall(PetscMemzero(svm_binary->y_map,2 * sizeof(PetscScalar)));

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -340,8 +340,6 @@ PetscErrorCode SVMSetTrainingDataset_Binary(SVM svm,Mat Xt_training,Vec y_traini
   PetscCall(VecMax(y_training,NULL,&max));
 
   PetscCall(VecDuplicate(y_training,&tmp));
-  PetscCall(VecSetFromOptions(tmp));
-
   PetscCall(VecSet(tmp,max));
 
   /* Index set for positive samples */
@@ -409,9 +407,7 @@ static PetscErrorCode SVMSetUp_Remapy_Binary_Private(SVM svm)
     PetscCall(PetscObjectReference((PetscObject) y));
   } else {
     PetscCall(VecGetLocalSize(y,&n));
-
     PetscCall(VecDuplicate(y,&svm_binary->y_inner));
-    PetscCall(VecSetFromOptions(svm_binary->y_inner));
 
     PetscCall(VecGetArrayRead(y,&y_arr));
     PetscCall(VecGetArray(svm_binary->y_inner,&y_inner_arr));
@@ -714,7 +710,6 @@ PetscErrorCode SVMComputeOperator_Binary(SVM svm,Mat *A)
 
       PetscCall(VecDestroy(&svm_binary->diag));
       PetscCall(VecDuplicate(y,&svm_binary->diag));
-      PetscCall(VecSetFromOptions(svm_binary->diag));
 
       diag = svm_binary->diag;
 
@@ -798,8 +793,6 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
 
   /* Set RHS */
   PetscCall(VecDuplicate(y,&e));  /* creating vector e same size and type as y_training */
-  PetscCall(VecSetFromOptions(e));
-
   PetscCall(VecSet(e,1.));
   PetscCall(QPSetRhs(qp,e));      /* set linear term of QP problem */
 
@@ -814,7 +807,6 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
 
   /* Create box constraint */
   PetscCall(VecDuplicate(y,&lb));  /* create lower bound constraint */
-  PetscCall(VecSetFromOptions(lb));
   PetscCall(VecSet(lb,0.));
 
   PetscCall(SVMGetPenaltyType(svm,&p));
@@ -828,7 +820,6 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
   PetscCall(SVMGetLossType(svm,&loss_type));
   if (loss_type == SVM_L1) {
     PetscCall(VecDuplicate(lb,&ub));
-    PetscCall(VecSetFromOptions(ub));
 
     if (p == 1) {
       PetscCall(VecSet(ub,C));
@@ -850,7 +841,6 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
   /* TODO create public method for setting initial vector */
   /* Set initial guess */
   PetscCall(VecDuplicate(lb,&x_init));
-  PetscCall(VecSetFromOptions(x_init));
 
   if (p == 1) {
     PetscCall(VecSet(x_init,C - 100 * PETSC_MACHINE_EPSILON));
@@ -940,10 +930,6 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
   PetscCall(VecDuplicate(svm_binary->work[0],&svm_binary->work[1]));
   PetscCall(VecDuplicate(svm_binary->work[0],&svm_binary->work[2]));
 
-  for (i = 0; i < 3; ++i) {
-    PetscCall(VecSetFromOptions(svm_binary->work[i]));
-  }
-
   /* Decreasing reference counts using destroy methods */
   PetscCall(MatDestroy(&H));
   PetscCall(MatDestroy(&Be));
@@ -1032,9 +1018,7 @@ PetscErrorCode SVMReconstructHyperplane_Binary(SVM svm)
   /* Reconstruction of hyperplane normal */
   PetscCall(SVMGetQP(svm,&qp));
   PetscCall(QPGetSolutionVector(qp,&x));
-
   PetscCall(VecDuplicate(x,&yx));
-  PetscCall(VecSetFromOptions(yx));
 
   PetscCall(VecPointwiseMult(yx,y,x)); /* yx = y.*x */
   PetscCall(MatCreateVecs(Xt,&w_inner,NULL));
@@ -1059,8 +1043,6 @@ PetscErrorCode SVMReconstructHyperplane_Binary(SVM svm)
     PetscCall(VecGetSubVector(svm_binary->work[2],svm_binary->is_sv,&Xtw_sv)); /* Xtw_sv = Xt(is_sv) */
 
     PetscCall(VecDuplicate(y_sv,&t));
-    PetscCall(VecSetFromOptions(t));
-
     PetscCall(VecWAXPY(t,-1.,Xtw_sv,y_sv));
 
     PetscCall(VecRestoreSubVector(y,svm_binary->is_sv,&y_sv));
@@ -1525,10 +1507,7 @@ PetscErrorCode SVMPredict_Binary(SVM svm,Mat Xt_pred,Vec *y_out)
   PetscCall(VecGetOwnershipRange(dist,&lo,&hi));
 
   PetscCall(VecDuplicate(dist,&y));
-  PetscCall(VecSetFromOptions(y));
-
   PetscCall(VecDuplicate(dist,&o));
-  PetscCall(VecSetFromOptions(o));
 
   PetscCall(VecSet(o,0));
 

--- a/src/svm/impls/binary/binaryimpl.h
+++ b/src/svm/impls/binary/binaryimpl.h
@@ -30,8 +30,8 @@ typedef struct {
 
     QPS         qps;
 
-    PetscInt    confusion_matrix[4]; // TODO move to _p_SVM
-    PetscReal   model_scores[7];     // TODO move to _p_SVM
+    PetscInt    confusion_matrix[4];
+    PetscReal   model_scores[15];
 
     /* Work vecs */
     Vec         work[3]; /* xi, c, Xtw */

--- a/src/svm/impls/binary/binaryimpl.h
+++ b/src/svm/impls/binary/binaryimpl.h
@@ -30,8 +30,8 @@ typedef struct {
 
     QPS         qps;
 
-    PetscInt    confusion_matrix[4];
-    PetscReal   model_scores[7];
+    PetscInt    confusion_matrix[4]; // TODO move to _p_SVM
+    PetscReal   model_scores[7];     // TODO move to _p_SVM
 
     /* Work vecs */
     Vec         work[3]; /* xi, c, Xtw */

--- a/src/svm/impls/binary/binaryimpl.h
+++ b/src/svm/impls/binary/binaryimpl.h
@@ -31,7 +31,7 @@ typedef struct {
     QPS         qps;
 
     PetscInt    confusion_matrix[4];
-    PetscReal   model_scores[15];
+    PetscReal   model_scores[16];
 
     /* Work vecs */
     Vec         work[3]; /* xi, c, Xtw */

--- a/src/svm/impls/makefile
+++ b/src/svm/impls/makefile
@@ -2,7 +2,7 @@
 ALL: lib
 
 LIBBASE  = libpermon
-DIRS     = binary
+DIRS     = binary probability
 LOCDIR   = src/svm/impls/
 MANSEX   = SVM
 

--- a/src/svm/impls/probability/makefile
+++ b/src/svm/impls/probability/makefile
@@ -1,0 +1,16 @@
+
+ALL: lib
+
+CFLAGS   =
+FFLAGS   =
+SOURCEC  = prob.c
+SOURCEF  =
+SOURCEH  =
+OBJSC    = ${SOURCEC:.c=.o}
+OBJSF    =
+LIBBASE  = libpermon
+MANSEC   = SVM
+LOCDIR   = src/svm/impls/probability/
+
+include ${PERMON_SVM_DIR}/lib/permonsvm/conf/permonsvm_variables
+include ${PERMON_SVM_DIR}/lib/permonsvm/conf/permonsvm_rules

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -373,6 +373,8 @@ static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SV
   PetscCall(SVMGetLabels(svm,&labels));
   PetscCall(VecDuplicate(y_calib,&vec_labels));
   PetscCall(VecDuplicate(y_calib,&vec_targets));
+  PetscCall(VecSetFromOptions(vec_labels));
+  PetscCall(VecSetFromOptions(vec_targets));
 
   for (i = 0; i < 2; ++i) {
     PetscCall(VecSet(vec_labels,labels[i]));
@@ -412,7 +414,7 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec pa
   PetscInt        N_works    = 2;
 
   IS              is_p,is_n;
-  PetscInt        N;
+  PetscInt        i,N;
 
   PetscReal       A,B;
   const PetscReal *params_sigmoid_arr = NULL;
@@ -422,6 +424,9 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec pa
 
   if (!svm_prob->work_vecs) {
     PetscCall(VecDuplicateVecs(svm_prob->vec_dist,N_works,&work_vecs));
+    for (i = 0; i < N_works; ++i) {
+      PetscCall(VecSetFromOptions(work_vecs[i]));
+    }
     svm_prob->work_vecs = work_vecs;
   } else {
     work_vecs = svm_prob->work_vecs;
@@ -522,7 +527,7 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec params_sigm
   PetscInt        N_works    = 2;
 
   IS              is_p,is_n;
-  PetscInt        N;
+  PetscInt        i,N;
 
   PetscReal       A,B;
   const PetscReal *params_sigmoid_arr = NULL;
@@ -532,6 +537,9 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec params_sigm
 
   if (!svm_prob->work_vecs) {
     PetscCall(VecDuplicateVecs(svm_prob->vec_dist,N_works,&work_vecs));
+    for (i = 0; i < N_works; ++i) {
+      PetscCall(VecSetFromOptions(work_vecs[i]));
+    }
     svm_prob->work_vecs = work_vecs;
   } else {
     work_vecs = svm_prob->work_vecs;
@@ -626,8 +634,15 @@ static PetscErrorCode SVMSetUp_Tao_Private(SVM svm)
   PetscFunctionBegin;
   /* Create Hessian */
   PetscCall(MatCreateSeqDense(MPI_COMM_SELF,2,2,NULL,&H));
+  PetscCall(PetscObjectSetName((PetscObject) H,"H_bce"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) H,"H_bce_"));
+  PetscCall(MatSetFromOptions(H));
+
   PetscCall(VecCreateSeq(MPI_COMM_SELF,2,&g));
+  PetscCall(VecSetFromOptions(g));
+
   PetscCall(VecCreateSeq(MPI_COMM_SELF,2,&x_init));
+  PetscCall(VecSetFromOptions(x_init));
 
   PetscCall(SVMGetTao(svm,&tao));
 

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -376,8 +376,6 @@ static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SV
   PetscCall(SVMGetLabels(svm,&labels));
   PetscCall(VecDuplicate(y_calib,&vec_labels));
   PetscCall(VecDuplicate(y_calib,&vec_targets));
-  PetscCall(VecSetFromOptions(vec_labels));
-  PetscCall(VecSetFromOptions(vec_targets));
 
   for (i = 0; i < 2; ++i) {
     PetscCall(VecSet(vec_labels,labels[i]));
@@ -418,7 +416,7 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec pa
   PetscInt        N_works    = 2;
 
   IS              is_p,is_n;
-  PetscInt        i,N;
+  PetscInt        N;
 
   PetscReal       A,B;
   const PetscReal *params_sigmoid_arr = NULL;
@@ -428,9 +426,6 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec pa
 
   if (!svm_prob->work_vecs) {
     PetscCall(VecDuplicateVecs(svm_prob->vec_dist,N_works,&work_vecs));
-    for (i = 0; i < N_works; ++i) {
-      PetscCall(VecSetFromOptions(work_vecs[i]));
-    }
     svm_prob->work_vecs = work_vecs;
   } else {
     work_vecs = svm_prob->work_vecs;
@@ -531,7 +526,7 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec params_sigm
   PetscInt        N_works    = 2;
 
   IS              is_p,is_n;
-  PetscInt        i,N;
+  PetscInt        N;
 
   PetscReal       A,B;
   const PetscReal *params_sigmoid_arr = NULL;
@@ -541,9 +536,6 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec params_sigm
 
   if (!svm_prob->work_vecs) {
     PetscCall(VecDuplicateVecs(svm_prob->vec_dist,N_works,&work_vecs));
-    for (i = 0; i < N_works; ++i) {
-      PetscCall(VecSetFromOptions(work_vecs[i]));
-    }
     svm_prob->work_vecs = work_vecs;
   } else {
     work_vecs = svm_prob->work_vecs;

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -55,8 +55,8 @@ PetscErrorCode SVMSetTrainingDataset_Probability(SVM svm,Mat Xt_training,Vec y_t
 {
   SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
 
-  Mat      Xt_calib;
-  PetscInt k,l,n;
+  Mat             Xt_calib;
+  PetscInt        k,l,n;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
@@ -68,8 +68,9 @@ PetscErrorCode SVMSetTrainingDataset_Probability(SVM svm,Mat Xt_training,Vec y_t
   PetscCall(MatGetSize(Xt_training,&k,NULL));
   PetscCall(VecGetSize(y_training,&l));
   if (k != l) {
-    SETERRQ(PetscObjectComm((PetscObject) Xt_training),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, X_training(%" PetscInt_FMT
-                                                                         ",) != y_training(%" PetscInt_FMT ")",k,l);
+    SETERRQ(PetscObjectComm((PetscObject) Xt_training),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, "
+                                                                         "X_training(%" PetscInt_FMT ",) !="
+                                                                         "y_training(%" PetscInt_FMT ")",k,l);
   }
 
   PetscCall(SVMGetCalibrationDataset(svm,&Xt_calib,NULL));
@@ -112,14 +113,13 @@ PetscErrorCode SVMGetTrainingDataset_Probability(SVM svm,Mat *Xt_training,Vec *y
 
 static PetscErrorCode SVMGetNumberPositiveNegativeSamples_Probability_Private(Vec y,PetscInt *ntarget_lo,PetscInt *ntarget_hi)
 {
-  Vec      tmp;
-  IS       is_p,is_n;
+  Vec       tmp;
+  IS        is_p,is_n;
 
-  PetscInt lo,hi,n;
+  PetscInt  lo,hi,n;
   PetscReal max;
 
   PetscFunctionBegin;
-
   /* Determine index sets of positive and negative samples */
   PetscCall(VecGetOwnershipRange(y,&lo,&hi));
   PetscCall(VecMax(y,NULL,&max));
@@ -146,12 +146,12 @@ PetscErrorCode SVMSetCalibrationDataset_Probability(SVM svm,Mat Xt_calib,Vec y_c
 {
   SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
 
-  Mat      Xt_training;
+  Mat             Xt_training;
 
-  PetscInt k,l;
-  PetscInt n;
+  PetscInt        k,l;
+  PetscInt        n;
 
-  PetscInt ntargets_lo,ntargets_hi;
+  PetscInt        ntargets_lo,ntargets_hi;
 
   PetscFunctionBegin;
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
@@ -163,8 +163,9 @@ PetscErrorCode SVMSetCalibrationDataset_Probability(SVM svm,Mat Xt_calib,Vec y_c
   PetscCall(MatGetSize(Xt_calib,&k,NULL));
   PetscCall(VecGetSize(y_calib,&l));
   if (k != l) {
-    SETERRQ(PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, X_calib(%" PetscInt_FMT
-                                                                      ",) != y_calib(%" PetscInt_FMT ")",k,l);
+    SETERRQ(PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, "
+                                                                      "X_calib(%" PetscInt_FMT ",) != "
+                                                                      "y_calib(%" PetscInt_FMT ")",k,l);
   }
 
   PetscCall(SVMGetTrainingDataset(svm,&Xt_training,NULL));
@@ -191,7 +192,6 @@ PetscErrorCode SVMSetCalibrationDataset_Probability(SVM svm,Mat Xt_calib,Vec y_c
   PetscCall(SVMGetNumberPositiveNegativeSamples_Probability_Private(y_calib,&ntargets_lo,&ntargets_hi));
   svm_prob->Nn_calib = ntargets_lo;
   svm_prob->Np_calib = ntargets_hi;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -204,6 +204,7 @@ PetscErrorCode SVMGetCalibrationDataset_Probability(SVM svm,Mat *Xt_calib,Vec *y
     PetscValidPointer(Xt_calib,2);
     *Xt_calib = svm_prob->Xt_calib;
   }
+
   if (y_calib) {
     PetscValidPointer(y_calib,3);
     *y_calib = svm_prob->y_calib;
@@ -213,10 +214,10 @@ PetscErrorCode SVMGetCalibrationDataset_Probability(SVM svm,Mat *Xt_calib,Vec *y
 
 static PetscErrorCode SVMCreateTAO_Probability_Private(SVM svm,Tao *tao)
 {
-  Tao tao_inner;
+  Tao        tao_inner;
 
-  KSP ksp;
-  PC  pc;
+  KSP        ksp;
+  PC         pc;
 
   const char *prefix = NULL;
 
@@ -238,15 +239,13 @@ static PetscErrorCode SVMCreateTAO_Probability_Private(SVM svm,Tao *tao)
 
   /* Clean up */
   PetscCall(PCDestroy(&pc));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode SVMGetTao_Probability(SVM svm,Tao *tao)
 {
   SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
-
-  Tao tao_inner;
+  Tao             tao_inner;
 
   PetscFunctionBegin;
   if (!svm_prob->tao) {
@@ -261,24 +260,28 @@ PetscErrorCode SVMGetTao_Probability(SVM svm,Tao *tao)
 
 static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SVM svm)
 {
-    SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
-    SVM         svm_inner;
+    SVM_Probability   *svm_prob = (SVM_Probability *) svm->data;
+    SVM               svm_inner;
 
-    Mat         Xt_calib;
-    Vec         y_calib;
+    MPI_Comm          comm;
+    PetscMPIInt       rank;
 
-    Vec         w;
-    PetscReal   b;
+    Mat               Xt_calib;
+    Vec               y_calib;
+    Vec               y_seq;
 
-    Vec         Xtw,Xtw_seq;
-    VecScatter  scatter;
+    Vec               w;
+    PetscReal         b;
 
-    PetscBool   label_to_target_prob;
-    PetscReal   hi_target;
-    PetscReal   lo_target;
+    Vec               Xtw,Xtw_seq;
+    VecScatter        scatter;
 
-    PetscInt    i;
-    PetscInt    N,Np,Nn;
+    PetscBool         label_to_target_prob;
+    PetscReal         hi_target;
+    PetscReal         lo_target;
+
+    PetscInt          i;
+    PetscInt          N,Np,Nn;
 
     const PetscScalar *Xtw_arr = NULL;
     const PetscScalar *y_arr   = NULL;
@@ -292,8 +295,14 @@ static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SV
     PetscCall(SVMGetSeparatingHyperplane(svm_inner,&w,&b));
     PetscCall(MatCreateVecs(Xt_calib,NULL,&Xtw));
     PetscCall(MatMult(Xt_calib,w,Xtw));
+    PetscCall(VecShift(Xtw,b));
 
-    /* Scatter Xtw to root process */
+    /* Scatter labels to a root process */
+    PetscCall(VecScatterCreateToZero(y_calib,&scatter,&y_seq));
+    PetscCall(VecScatterBegin(scatter,y_calib,y_seq,INSERT_VALUES,SCATTER_FORWARD));
+    PetscCall(VecScatterEnd(scatter,y_calib,y_seq,INSERT_VALUES,SCATTER_FORWARD));
+
+    /* Scatter Xtw to a root process */
     PetscCall(VecScatterCreateToZero(Xtw,&scatter,&Xtw_seq));
     PetscCall(VecScatterBegin(scatter,Xtw,Xtw_seq,INSERT_VALUES,SCATTER_FORWARD));
     PetscCall(VecScatterEnd(scatter,Xtw,Xtw_seq,INSERT_VALUES,SCATTER_FORWARD));
@@ -303,44 +312,48 @@ static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SV
     PetscCall(PetscFree(svm_prob->target));
 
     /* Alloc helper arrays again (distance sample from hyperplane and target) */
-    PetscCall(VecGetSize(Xtw_seq,&N));
-    PetscCall(PetscMalloc(N * sizeof(PetscReal),&svm_prob->deci));
-    PetscCall(PetscMalloc(N * sizeof(PetscReal),&svm_prob->target));
+    PetscCall(PetscObjectGetComm((PetscObject)svm,&comm));
+    PetscCallMPI(MPI_Comm_rank(comm,&rank));
 
-    PetscCall(SVMProbGetConvertLabelsToTargetProbability(svm,&label_to_target_prob));
-    if (label_to_target_prob) {
+    if (rank == 0) {
+      PetscCall(VecGetSize(Xtw_seq,&N));
+
+      PetscCall(PetscMalloc(N * sizeof(PetscReal),&svm_prob->deci));
+      PetscCall(PetscMalloc(N * sizeof(PetscReal),&svm_prob->target));
+
+      PetscCall(SVMProbGetConvertLabelsToTargetProbability(svm,&label_to_target_prob));
+
+      if (label_to_target_prob) {
         /*
          Transform labels to target probabilities as it proposed in
          http://www.cs.colorado.edu/~mozer/Teaching/syllabi/6622/papers/Platt1999.pdf
         */
-        Nn = svm_prob->Nn_calib;
-        Np = svm_prob->Np_calib;
-
-        PetscCall(SVMGetNumberPositiveNegativeSamples_Probability_Private(y_calib,&Np,&Nn));
+        PetscCall(SVMGetNumberPositiveNegativeSamples_Probability_Private(y_seq,&Np,&Nn));
         lo_target = 1. / (Nn + 2);
         hi_target = (Np + 1.) / (Np + 2.);
-    } else {
+      } else {
         lo_target = 0.;
         hi_target = 1.;
+      }
+
+      PetscCall(VecGetArrayRead(Xtw_seq,&Xtw_arr));
+      PetscCall(VecGetArrayRead(y_seq,&y_arr));
+
+      for (i = 0; i < N; ++i) {
+        svm_prob->deci[i]   = Xtw_arr[i];                                // distance from hyperplane
+        svm_prob->target[i] = (y_arr[i] == -1.) ? lo_target : hi_target; // labels converted to probability
+      }
+
+      PetscCall(VecRestoreArrayRead(Xtw_seq,&Xtw_arr));
+      PetscCall(VecRestoreArrayRead(Xtw_seq,&y_arr));
     }
-
-    PetscCall(VecGetArrayRead(Xtw_seq,&Xtw_arr));
-    PetscCall(VecGetArrayRead(y_calib,&y_arr));
-
-    for (i = 0; i < N; ++i) {
-        svm_prob->deci[i]   = Xtw_arr[i]; // distance from hyperplane
-        svm_prob->target[i] = (y_arr[i] == -1) ? lo_target : hi_target; // labels converted to probability
-    }
-
-    PetscCall(VecRestoreArrayRead(Xtw_seq,&Xtw_arr));
-    PetscCall(VecRestoreArrayRead(Xtw_seq,&y_arr));
 
     /* Clean up */
     PetscCall(SVMDestroy(&svm_inner));
     PetscCall(VecScatterDestroy(&scatter));
     PetscCall(VecDestroy(&Xtw));
     PetscCall(VecDestroy(&Xtw_seq));
-
+    PetscCall(VecDestroy(&y_seq));
     PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -349,27 +362,23 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec x,
   SVM             svm   = (SVM) ctx;
   SVM_Probability *prob = (SVM_Probability *) svm->data;
 
-  PetscReal fnc_inner = 0.;
+  PetscReal       fnc_inner = 0.;
 
-  PetscReal g_arr[2] = {0.,0.};
-  PetscInt  idx[2]   = {0,1};
+  PetscReal       g_arr[2]  = {0.,0.};
+  PetscInt        idx[2]    = {0,1};
 
-  PetscReal ApB;
-  PetscReal p;
+  PetscReal       ApB;
+  PetscReal       p;
 
-  PetscInt  i,N;
+  PetscInt        i,N;
 
+  Vec             y;
   const PetscReal *x_arr = NULL;
-  Vec   y;
 
   PetscFunctionBegin;
-
-  if (!prob->deci && !prob->target) {
-    PetscCall(SVMTransformUncalibratedPredictions_Probability_Private(svm));
-  }
-
   PetscCall(SVMGetCalibrationDataset(svm,NULL,&y));
   PetscCall(VecGetSize(y,&N));
+
   PetscCall(VecGetArrayRead(x,&x_arr));
 
   /*
@@ -394,13 +403,13 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec x,
 
   PetscCall(VecRestoreArrayRead(x,&x_arr));
 
+  /* Update a value of objective function */
   *fnc = fnc_inner;
 
-  /* update gradient */
+  /* Update gradient */
   PetscCall(VecSetValues(g,2,idx,g_arr,INSERT_VALUES));
   PetscCall(VecAssemblyBegin(g));
   PetscCall(VecAssemblyEnd(g));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -418,22 +427,15 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec x,Mat H,Mat
 
   PetscInt        i,N;
 
+  Vec             y;
   const PetscReal *x_arr = NULL;
-  Vec   y;
 
   PetscFunctionBegin;
-
-  if (!prob->deci && !prob->target) {
-      PetscCall(SVMTransformUncalibratedPredictions_Probability_Private(svm));
-  }
-
   PetscCall(SVMGetCalibrationDataset(svm,NULL,&y));
   PetscCall(VecGetSize(y,&N));
   PetscCall(VecGetArrayRead(x,&x_arr));
 
-  /*
-    Hessian evaluation. Implementation proposed in https://www.csie.ntu.edu.tw/~cjlin/papers/plattprob.pdf.
-   */
+  /* Hessian evaluation. Implementation proposed in https://www.csie.ntu.edu.tw/~cjlin/papers/plattprob.pdf. */
   for (i = 0; i < N; ++i) {
 
     AdpB = prob->deci[i] * x_arr[0] + x_arr[1];
@@ -463,24 +465,22 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec x,Mat H,Mat
   PetscCall(MatSetValues(H,2,idxm,2,idxn,H_arr,INSERT_VALUES));
   PetscCall(MatAssemblyBegin(H,MAT_FINAL_ASSEMBLY));
   PetscCall(MatAssemblyEnd(H,MAT_FINAL_ASSEMBLY));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 static PetscErrorCode SVMSetUp_Tao_Private(SVM svm)
 {
   SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
-  Tao tao;
+  Tao             tao;
 
-  Mat H;
-  Vec x_init;
-  Vec g;
+  Mat             H;
+  Vec             g;
+  Vec             x_init;
 
-  PetscInt  Nn,Np;
-  PetscReal v;
+  PetscInt        Nn,Np;
+  PetscReal       v;
 
   PetscFunctionBegin;
-
   /* Create Hessian */
   PetscCall(MatCreateSeqDense(MPI_COMM_SELF,2,2,NULL,&H));
   PetscCall(VecCreateSeq(MPI_COMM_SELF,2,&g));
@@ -519,23 +519,21 @@ static PetscErrorCode SVMSetUp_Tao_Private(SVM svm)
   PetscCall(VecDestroy(&x_init));
 
   svm->setupcalled = PETSC_TRUE;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode SVMSetUp_Probability(SVM svm)
 {
-  MPI_Comm comm;
-
-  SVM      svm_binary;
-
-  Mat      Xt_training;
-  Vec      y_training;
-
-  Mat      Xt_calib;
-  Vec      y_calib;
-
+  MPI_Comm    comm;
   PetscMPIInt rank;
+
+  SVM         svm_binary;
+
+  Mat         Xt_training;
+  Vec         y_training;
+
+  Mat         Xt_calib;
+  Vec         y_calib;
 
   PetscFunctionBegin;
   if (svm->setupcalled) PetscFunctionReturn(0);
@@ -557,11 +555,9 @@ PetscErrorCode SVMSetUp_Probability(SVM svm)
   PetscCall(SVMSetTrainingDataset(svm_binary,Xt_training,y_training));
   PetscCall(SVMSetUp(svm_binary));
 
-  /*
-    Set up TAO solver. Since problem is small (dim=2), it is being solved on a root process.
-  */
+  /* Set up TAO solver. Since problem is small (dim=2), it is being solved on a root process. */
   PetscCall(PetscObjectGetComm((PetscObject)svm,&comm));
-  MPI_Comm_rank(comm,&rank);
+  PetscCallMPI(MPI_Comm_rank(comm,&rank));
 
   if (rank == 0) {
     PetscCall(SVMSetUp_Tao_Private(svm));
@@ -569,7 +565,6 @@ PetscErrorCode SVMSetUp_Probability(SVM svm)
 
   /* Clean up */
   PetscCall(SVMDestroy(&svm_binary));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -608,8 +603,8 @@ PetscErrorCode SVMSetFromOptions_Probability(PetscOptionItems *PetscOptionsObjec
 {
   SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
 
-  PetscBool to_target_probs;
-  PetscBool flg;
+  PetscBool       to_target_probs;
+  PetscBool       flg;
 
   PetscFunctionBegin;
   PetscObjectOptionsBegin((PetscObject)svm);
@@ -629,31 +624,31 @@ PetscErrorCode SVMTrain_Probability(SVM svm)
   MPI_Comm    comm;
   PetscMPIInt rank;
 
-  SVM svm_binary;
-  Tao tao;
+  SVM         svm_binary;
+  Tao         tao;
 
-  PetscBool  post_train;
+  PetscBool   post_train;
 
   PetscFunctionBegin;
   PetscCall(SVMSetUp(svm));
   PetscCall(SVMGetInnerSVM(svm,&svm_binary));
 
-  // Train uncalibrated svm model
+  /* Train uncalibrated svm model */
   PetscCall(SVMGetAutoPostTrain(svm_binary,&post_train));
   PetscCall(SVMTrain(svm_binary));
 
-  // Train logistic regression over uncalibrated model (Platt's scaling)
+  /* Train logistic regression over uncalibrated model (Platt's scaling) */
   PetscCall(SVMTransformUncalibratedPredictions_Probability_Private(svm));
   PetscCall(SVMGetTao(svm,&tao));
 
-  // Solve on root process
+  /* Solve on root */
   PetscCall(PetscObjectGetComm((PetscObject)svm,&comm));
-  MPI_Comm_rank(comm,&rank);
+  PetscCallMPI(MPI_Comm_rank(comm,&rank));
   if (rank == 0) {
     PetscCall(TaoSolve(tao));
   }
 
-  // Run post-processing (training) of a trained probability model
+  /* Run post-processing (training) of a trained probability model */
   PetscCall(SVMGetAutoPostTrain(svm,&post_train));
   if (post_train) {
     PetscCall(SVMPostTrain(svm));
@@ -662,15 +657,36 @@ PetscErrorCode SVMTrain_Probability(SVM svm)
   /* Clean up */
   PetscCall(SVMDestroy(&svm_binary));
   PetscCall(TaoDestroy(&tao));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode SVMPostTrain_Probability(SVM svm)
 {
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+
+  MPI_Comm        comm;
+  PetscMPIInt     rank;
+
+  Tao             tao;
+  Vec             x;
+  const PetscReal *x_arr = NULL;
 
   PetscFunctionBegin;
-  // TODO implement
+  PetscCall(PetscObjectGetComm((PetscObject)svm,&comm));
+  PetscCallMPI(MPI_Comm_rank(comm,&rank));
+
+  if (rank == 0) {
+    PetscCall(SVMGetTao(svm,&tao));
+    PetscCall(TaoGetSolution(tao,&x));
+
+    PetscCall(VecGetArrayRead(x,&x_arr));
+    PetscCall(PetscMemcpy(svm_prob->sigmoid_params,x_arr,2 * sizeof(PetscReal)));
+    PetscCall(VecRestoreArrayRead(x,&x_arr));
+  }
+
+  /* Broad cast */
+  PetscCallMPI(MPI_Bcast(svm_prob->sigmoid_params,2,MPIU_REAL,0,comm));
+
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -699,10 +715,10 @@ PetscErrorCode SVMGetInnerSVM_Probability(SVM svm,SVM *inner_out)
 {
   SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
 
-  MPI_Comm   comm;
-  const char *prefix = NULL;
+  MPI_Comm        comm;
+  SVM             inner;
 
-  SVM        inner;
+  const char      *prefix = NULL;
 
   PetscFunctionBegin;
   if (!svm_prob->inner) {
@@ -710,8 +726,7 @@ PetscErrorCode SVMGetInnerSVM_Probability(SVM svm,SVM *inner_out)
     PetscCall(SVMCreate(comm,&inner));
     PetscCall(SVMSetType(inner,SVM_BINARY));
 
-    // Set prefix
-    PetscCall(SVMSetOptionsPrefix(inner,"prob_binary_"));
+    PetscCall(SVMSetOptionsPrefix(inner,"prob_binary_")); // TODO change prefix
     PetscCall(SVMGetOptionsPrefix(svm,&prefix));
     PetscCall(SVMAppendOptionsPrefix(inner,prefix));
 
@@ -760,7 +775,6 @@ PetscErrorCode SVMLoadCalibrationDataset_Probability(SVM svm,PetscViewer v)
   /* Clean up */
   PetscCall(MatDestroy(&Xt_calib));
   PetscCall(VecDestroy(&y_calib));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -795,13 +809,12 @@ PetscErrorCode SVMViewCalibrationDataset_Probability(SVM svm,PetscViewer v)
 
     SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewCalibrationDataset",type_name);
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode SVMCreate_Probability(SVM svm)
 {
-  SVM_Probability *svm_prob;
+  SVM_Probability *svm_prob = NULL;
 
   PetscFunctionBegin;
   PetscCall(PetscNew(&svm_prob));
@@ -845,7 +858,6 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C"      ,SVMSetOptionsPrefix_Probability));
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C"      ,SVMGetOptionsPrefix_Probability));
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C"   ,SVMAppendOptionsPrefix_Probability));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -2,7 +2,7 @@
 #include "probimpl.h"
 #include "../binary/binaryimpl.h"
 
-// #include "../../utils/report.h"
+#include "../../utils/report.h"
 
 
 PetscErrorCode SVMReset_Probability(SVM svm)
@@ -799,7 +799,7 @@ PetscErrorCode SVMTest_Probability(SVM svm)
   PetscCall(SVMPredict(svm,Xt_test,&y_pred));
 
   PetscCall(SVMProbConvertProbabilityToLabels(svm,y_pred));
-  // PetscCall(ClassificationReport(svm,y_pred,y_test));
+  PetscCall(ClassificationReport(svm,y_pred,y_test));
 
   /* Clean */
   PetscCall(VecDestroy(&y_pred));

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -780,10 +780,12 @@ PetscErrorCode SVMPredict_Probability(SVM svm,Mat Xt,Vec *y_out)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMComputeModelScores_Probability(SVM svm,Vec y_prob,Vec y_known)
+PetscErrorCode SVMComputeModelScores_Probability(SVM svm,Vec y,Vec y_known)
 {
-  // TODO remove
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+
   PetscFunctionBegin;
+  PetscCall(SVMGetBinaryClassificationReport(svm,y,y_known,svm_prob->confusion_matrix,svm_prob->model_scores));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -799,7 +801,7 @@ PetscErrorCode SVMTest_Probability(SVM svm)
   PetscCall(SVMPredict(svm,Xt_test,&y_pred));
 
   PetscCall(SVMProbConvertProbabilityToLabels(svm,y_pred));
-  PetscCall(ClassificationReport(svm,y_pred,y_test));
+  PetscCall(SVMComputeModelScores(svm,y_pred,y_test));
 
   /* Clean */
   PetscCall(VecDestroy(&y_pred));

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -3,8 +3,13 @@
 
 PetscErrorCode SVMReset_Probability(SVM svm)
 {
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
 
   PetscFunctionBegin;
+  PetscCall(MatDestroy(&svm_prob->Xt_training));
+  PetscCall(VecDestroy(&svm_prob->y_training));
+  PetscCall(MatDestroy(&svm_prob->Xt_calib));
+  PetscCall(VecDestroy(&svm_prob->y_calib));
   PetscFunctionReturn(0);
 }
 
@@ -12,6 +17,10 @@ PetscErrorCode SVMDestroy_Probability(SVM svm)
 {
 
   PetscFunctionBegin;
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C",NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C",NULL));
+
+  PetscCall(SVMDestroyDefault(svm));
   PetscFunctionReturn(0);
 }
 
@@ -29,10 +38,133 @@ PetscErrorCode SVMViewScore_Probability(SVM svm,PetscViewer v)
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode SVMSetUp_Probability(SVM svm)
+PetscErrorCode SVMSetTrainingDataset_Probability(SVM svm,Mat Xt_training,Vec y_training)
 {
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+
+  Mat      Xt_calib;
+  PetscInt k,l,n;
 
   PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(Xt_training,MAT_CLASSID,2);
+  PetscCheckSameComm(svm,1,Xt_training,2);
+  PetscValidHeaderSpecific(y_training,VEC_CLASSID,3);
+  PetscCheckSameComm(svm,1,y_training,3);
+
+  PetscCall(MatGetSize(Xt_training,&k,NULL));
+  PetscCall(VecGetSize(y_training,&l));
+  if (k != l) {
+    SETERRQ(PetscObjectComm((PetscObject) Xt_training),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, X_training(%" PetscInt_FMT
+                                                                         ",) != y_training(%" PetscInt_FMT ")",k,l);
+  }
+
+  PetscCall(SVMGetCalibrationDataset(svm,&Xt_calib,NULL));
+  if (Xt_calib != NULL) {
+    PetscCall(MatGetSize(Xt_training,NULL,&l));
+    PetscCall(MatGetSize(Xt_calib,NULL,&n));
+
+    if (l != n) {
+      SETERRQ(PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, "
+                                                                        "X_training(,%" PetscInt_FMT ") !="
+                                                                        "X_calib(,%" PetscInt_FMT ")",l,n);
+    }
+  }
+
+  PetscCall(MatDestroy(&svm_prob->Xt_training));
+  svm_prob->Xt_training = Xt_training;
+  PetscCall(PetscObjectReference((PetscObject) Xt_training));
+
+  PetscCall(VecDestroy(&svm_prob->y_training));
+  svm_prob->y_training = y_training;
+  PetscCall(PetscObjectReference((PetscObject) y_training));
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMGetTrainingDataset_Probability(SVM svm,Mat *Xt_training,Vec *y_training)
+{
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+
+  PetscFunctionBegin;
+  if (Xt_training) {
+    PetscValidPointer(Xt_training,2);
+    *Xt_training = svm_prob->Xt_training;
+  }
+  if (y_training) {
+    PetscValidPointer(y_training,3);
+    *y_training = svm_prob->y_training;
+  }
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMSetCalibrationDataset_Probability(SVM svm,Mat Xt_calib,Vec y_calib)
+{
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+
+  Mat      Xt_training;
+
+  PetscInt k,l;
+  PetscInt n;
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(Xt_calib,MAT_CLASSID,2);
+  PetscCheckSameComm(svm,1,Xt_calib,2);
+  PetscValidHeaderSpecific(y_calib,VEC_CLASSID,3);
+  PetscCheckSameComm(svm,1,y_calib,3);
+
+  PetscCall(MatGetSize(Xt_calib,&k,NULL));
+  PetscCall(VecGetSize(y_calib,&l));
+  if (k != l) {
+    SETERRQ(PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, X_calib(%" PetscInt_FMT
+                                                                      ",) != y_calib(%" PetscInt_FMT ")",k,l);
+  }
+
+  PetscCall(SVMGetTrainingDataset(svm,&Xt_training,NULL));
+  if (Xt_training != NULL) {
+    PetscCall(MatGetSize(Xt_calib,NULL,&l));
+    PetscCall(MatGetSize(Xt_training,NULL,&n));
+
+    if (l != n) {
+      SETERRQ(PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, "
+                                                                        "X_calib(,%" PetscInt_FMT ") !="
+                                                                        "X_training(,%" PetscInt_FMT ")",l,n);
+    }
+  }
+
+  PetscCall(MatDestroy(&svm_prob->Xt_calib));
+  svm_prob->Xt_calib = Xt_calib;
+  PetscCall(PetscObjectReference((PetscObject) Xt_calib));
+
+  PetscCall(VecDestroy(&svm_prob->y_calib));
+  svm_prob->y_calib = y_calib;
+  PetscCall(PetscObjectReference((PetscObject) y_calib));
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMGetCalibrationDataset_Probability(SVM svm,Mat *Xt_calib,Vec *y_calib)
+{
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+
+  PetscFunctionBegin;
+  if (Xt_calib) {
+    PetscValidPointer(Xt_calib,2);
+    *Xt_calib = svm_prob->Xt_calib;
+  }
+  if (y_calib) {
+    PetscValidPointer(y_calib,3);
+    *y_calib = svm_prob->y_calib;
+  }
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMSetUp_Probability(SVM svm)
+{
+  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+
+  PetscFunctionBegin;
+  if (svm->setupcalled) PetscFunctionReturn(0);
+
   PetscFunctionReturn(0);
 }
 
@@ -99,6 +231,80 @@ PetscErrorCode SVMTest_Probability(SVM svm)
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode SVMLoadCalibrationDataset_Probability(SVM svm,PetscViewer v)
+{
+  MPI_Comm  comm;
+
+  Mat       Xt_calib,Xt_biased;
+  Vec       y_calib;
+
+  PetscReal user_bias;
+  PetscInt  mod;
+
+  PetscFunctionBegin;
+  PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
+  PetscCall(MatCreate(comm,&Xt_calib));
+  /* Create matrix of calibration samples */
+  PetscCall(PetscObjectSetName((PetscObject) Xt_calib,"Xt_calib"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) Xt_calib,"Xt_calib_"));
+  PetscCall(MatSetFromOptions(Xt_calib));
+  /* Create label vector of calibration samples */
+  PetscCall(VecCreate(comm,&y_calib));
+  PetscCall(PetscObjectSetName((PetscObject) y_calib,"Xt_calib_"));
+  PetscCall(VecSetFromOptions(y_calib));
+
+  PetscCall(PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0));
+  PetscCall(PetscViewerLoadSVMDataset(Xt_calib,y_calib,v));
+  PetscCall(PetscLogEventEnd(SVM_LoadDataset,svm,0,0,0));
+
+  PetscCall(SVMGetMod(svm,&mod));
+  if (mod == 2) {
+    PetscCall(SVMGetUserBias(svm,&user_bias));
+    PetscCall(MatBiasedCreate(Xt_calib,user_bias,&Xt_biased));
+    Xt_calib = Xt_biased;
+  }
+  PetscCall(SVMSetCalibrationDataset(svm,Xt_calib,y_calib));
+
+  /* Clean up */
+  PetscCall(MatDestroy(&Xt_calib));
+  PetscCall(VecDestroy(&y_calib));
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMViewCalibrationDataset_Probability(SVM svm,PetscViewer v)
+{
+  MPI_Comm   comm;
+
+  Mat        Xt;
+  Vec        y;
+
+  PetscBool  isascii;
+  const char *type_name = NULL;
+
+  PetscFunctionBegin;
+  PetscCall(SVMGetCalibrationDataset(svm,&Xt,&y));
+  if (!Xt || !y) {
+    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
+    SETERRQ(comm,PETSC_ERR_ARG_NULL,"Calibration dataset is not set");
+  }
+
+  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  if (isascii) {
+    /* Print info related to svm type */
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+
+    PetscCall(PetscViewerASCIIPushTab(v));
+    PetscCall(SVMViewDataset(svm,Xt,y,v));
+    PetscCall(PetscViewerASCIIPopTab(v));
+  } else {
+    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
+    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
+
+    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewCalibrationDataset",type_name);
+  }
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode SVMCreate_Probability(SVM svm)
 {
   SVM_Probability *svm_prob;
@@ -106,6 +312,11 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
   PetscFunctionBegin;
   PetscCall(PetscNew(&svm_prob));
   svm->data = (void *) svm_prob;
+
+  svm_prob->Xt_training = NULL;
+  svm_prob->y_training  = NULL;
+  svm_prob->Xt_calib    = NULL;
+  svm_prob->y_calib     = NULL;
 
   svm->ops->setup              = SVMSetUp_Probability;
   svm->ops->reset              = SVMReset_Probability;
@@ -118,6 +329,13 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
   svm->ops->view               = SVMView_Probability;
   svm->ops->viewscore          = SVMViewScore_Probability;
   svm->ops->computemodelscores = SVMComputeModelScores_Probability;
+
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C",SVMSetTrainingDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C",SVMGetTrainingDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetCalibrationDataset_C",SVMSetCalibrationDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetCalibrationDataset_C",SVMGetCalibrationDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMLoadCalibrationDataset_C",SVMLoadCalibrationDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMViewCalibrationDataset_C",SVMViewCalibrationDataset_Probability));
 
   PetscFunctionReturn(0);
 }

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -32,6 +32,7 @@ PetscErrorCode SVMReset_Probability(SVM svm)
   svm_prob->tao         = NULL;
 
   svm_prob->work_vecs   = NULL;
+
   svm_prob->vec_dist    = NULL;
   svm_prob->vec_targets = NULL;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1148,6 +1149,9 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
   svm_prob->y_training  = NULL;
   svm_prob->Xt_calib    = NULL;
   svm_prob->y_calib     = NULL;
+
+  svm_prob->vec_dist    = NULL;
+  svm_prob->vec_targets = NULL;
 
   svm_prob->Np_calib    = -1;
   svm_prob->Nn_calib    = -1;

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -1,0 +1,123 @@
+
+#include "probimpl.h"
+
+PetscErrorCode SVMReset_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMDestroy_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMView_Probability(SVM svm,PetscViewer v)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMViewScore_Probability(SVM svm,PetscViewer v)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMSetUp_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMSetOptionsPrefix_Probability(PetscOptionItems *PetscOptionsObject,SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMAppendOptionsPrefix_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMGetOptionsPrefix_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMSetFromOptions_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMTrain_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMPostTrain_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMPredict_Probability(SVM svm,Mat Xt_pred,Vec *y_out)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMComputeModelScores_Probability(SVM svm,Vec y_pred,Vec y_known)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMTest_Probability(SVM svm)
+{
+
+  PetscFunctionBegin;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode SVMCreate_Probability(SVM svm)
+{
+  SVM_Probability *svm_prob;
+
+  PetscFunctionBegin;
+  PetscCall(PetscNew(&svm_prob));
+  svm->data = (void *) svm_prob;
+
+  svm->ops->setup              = SVMSetUp_Probability;
+  svm->ops->reset              = SVMReset_Probability;
+  svm->ops->destroy            = SVMDestroy_Probability;
+  svm->ops->setfromoptions     = SVMSetOptionsPrefix_Probability;
+  svm->ops->train              = SVMTrain_Probability;
+  svm->ops->posttrain          = SVMPostTrain_Probability;
+  svm->ops->predict            = SVMPredict_Probability;
+  svm->ops->test               = SVMTest_Probability;
+  svm->ops->view               = SVMView_Probability;
+  svm->ops->viewscore          = SVMViewScore_Probability;
+  svm->ops->computemodelscores = SVMComputeModelScores_Probability;
+
+  PetscFunctionReturn(0);
+}

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -1085,6 +1085,54 @@ PetscErrorCode SVMViewCalibrationDataset_Probability(SVM svm,PetscViewer v)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+PetscErrorCode SVMViewTrainingPredictions_Probability(SVM svm,PetscViewer v)
+{
+  MPI_Comm   comm;
+
+  Mat        Xt_training;
+  Vec        y_pred;
+
+  PetscFunctionBegin;
+  PetscCall(SVMGetTrainingDataset(svm,&Xt_training,NULL));
+  if (!Xt_training) {
+    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
+    SETERRQ(comm,PETSC_ERR_ARG_NULL,"Training dataset is not set");
+  }
+
+  /* View predictions on training samples */
+  PetscCall(SVMPredict(svm,Xt_training,&y_pred));
+  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_training_predictions"));
+  PetscCall(VecView(y_pred,v));
+
+  /* Free memory */
+  PetscCall(VecDestroy(&y_pred));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+PetscErrorCode SVMViewTestPredictions_Probability(SVM svm,PetscViewer v)
+{
+  MPI_Comm   comm;
+
+  Mat        Xt_test;
+  Vec        y_pred;
+
+  PetscFunctionBegin;
+  PetscCall(SVMGetTestDataset(svm,&Xt_test,NULL));
+  if (!Xt_test) {
+    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
+    SETERRQ(comm,PETSC_ERR_ARG_NULL,"Test dataset is not set");
+  }
+
+  /* View predictions on test samples */
+  PetscCall(SVMPredict(svm,Xt_test,&y_pred));
+  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_test_predictions"));
+  PetscCall(VecView(y_pred,v));
+
+  /* Free memory */
+  PetscCall(VecDestroy(&y_pred));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 PetscErrorCode SVMCreate_Probability(SVM svm)
 {
   SVM_Probability *svm_prob = NULL;
@@ -1108,17 +1156,19 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
 
   svm_prob->threshold   = .5;
 
-  svm->ops->setup              = SVMSetUp_Probability;
-  svm->ops->reset              = SVMReset_Probability;
-  svm->ops->destroy            = SVMDestroy_Probability;
-  svm->ops->setfromoptions     = SVMSetFromOptions_Probability;
-  svm->ops->train              = SVMTrain_Probability;
-  svm->ops->posttrain          = SVMPostTrain_Probability;
-  svm->ops->predict            = SVMPredict_Probability;
-  svm->ops->test               = SVMTest_Probability;
-  svm->ops->view               = SVMView_Probability;
-  svm->ops->viewscore          = SVMViewScore_Probability;
-  svm->ops->computemodelscores = SVMComputeModelScores_Probability;
+  svm->ops->setup                   = SVMSetUp_Probability;
+  svm->ops->reset                   = SVMReset_Probability;
+  svm->ops->destroy                 = SVMDestroy_Probability;
+  svm->ops->setfromoptions          = SVMSetFromOptions_Probability;
+  svm->ops->train                   = SVMTrain_Probability;
+  svm->ops->posttrain               = SVMPostTrain_Probability;
+  svm->ops->predict                 = SVMPredict_Probability;
+  svm->ops->test                    = SVMTest_Probability;
+  svm->ops->view                    = SVMView_Probability;
+  svm->ops->viewscore               = SVMViewScore_Probability;
+  svm->ops->computemodelscores      = SVMComputeModelScores_Probability;
+  svm->ops->viewtrainingpredictions = SVMViewTrainingPredictions_Probability;
+  svm->ops->viewtestpredictions     = SVMViewTestPredictions_Probability;
 
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetInnerSVM_C"           ,SVMGetInnerSVM_Probability));
   PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTao_C"                ,SVMGetTao_Probability));

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -1101,7 +1101,7 @@ PetscErrorCode SVMViewTrainingPredictions_Probability(SVM svm,PetscViewer v)
 
   /* View predictions on training samples */
   PetscCall(SVMPredict(svm,Xt_training,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_training_predictions"));
+  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
   PetscCall(VecView(y_pred,v));
 
   /* Free memory */
@@ -1125,7 +1125,7 @@ PetscErrorCode SVMViewTestPredictions_Probability(SVM svm,PetscViewer v)
 
   /* View predictions on test samples */
   PetscCall(SVMPredict(svm,Xt_test,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_test_predictions"));
+  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
   PetscCall(VecView(y_pred,v));
 
   /* Free memory */

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -79,8 +79,6 @@ PetscErrorCode SVMViewScore_Probability(SVM svm,PetscViewer v)
   } else {
     SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewScore", ((PetscObject)v)->type_name);
   }
-
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -654,6 +652,7 @@ PetscErrorCode SVMSetFromOptions_Probability(PetscOptionItems *PetscOptionsObjec
   SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
 
   PetscBool       to_target_probs;
+  PetscReal       threshold;
   PetscBool       flg;
 
   PetscFunctionBegin;
@@ -664,6 +663,13 @@ PetscErrorCode SVMSetFromOptions_Probability(PetscOptionItems *PetscOptionsObjec
                              svm_prob->labels_to_target_probs,&to_target_probs,&flg));
   if (flg) {
     PetscCall(SVMProbSetConvertLabelsToTargetProbability(svm,to_target_probs));
+  }
+  PetscCall(PetscOptionsReal("-svm_threshold",
+                             "Convert sample labels to target probability as suggested by Platt. Default (true).",
+                             "SVMProbSetConvertLabelsToTargetProbability",
+                             svm_prob->threshold,&threshold,&flg));
+  if (flg) {
+    PetscCall(SVMProbSetThreshold(svm,threshold));
   }
   PetscOptionsEnd();
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -5,18 +5,19 @@
 #include <permon/private/svmimpl.h>
 
 typedef struct {
-  Mat Xt_training;
-  Vec y_training;
+  Mat       Xt_training;
+  Vec       y_training;
 
-  Mat Xt_calib;
-  Vec y_calib;
+  Mat       Xt_calib;
+  Vec       y_calib;
 
-
-  SVM inner;
-  Tao tao;
+  SVM       inner;
+  Tao       tao;
 
   PetscReal *target;
   PetscReal *deci;
+
+  PetscReal sigmoid_params[2];
 
   PetscInt  Np_calib;
   PetscInt  Nn_calib;

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -14,10 +14,11 @@ typedef struct {
   SVM       inner;
   Tao       tao;
 
-  PetscReal *target;
-  PetscReal *deci;
+  PetscReal *target; // TODO as Vec
+  PetscReal *deci;   // TODO as Vec
 
   PetscReal sigmoid_params[2];
+  PetscReal threshold;
 
   PetscInt  Np_calib;
   PetscInt  Nn_calib;

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -25,6 +25,9 @@ typedef struct {
 
   PetscBool labels_to_target_probs;
 
+  PetscInt  confusion_matrix[4]; // TODO move to _p_SVM
+  PetscReal model_scores[15];    // TODO move to _p_SVM
+
 } SVM_Probability;
 
 #endif

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -14,7 +14,7 @@ typedef struct {
   PetscInt  Np_calib;
   PetscInt  Nn_calib;
 
-  SVM       inner;  // TODO change name to uncalibrated
+  SVM       inner;
 
   Vec       vec_dist;
   Vec       vec_targets;

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -14,8 +14,11 @@ typedef struct {
   SVM       inner;
   Tao       tao;
 
-  PetscReal *target; // TODO as Vec
-  PetscReal *deci;   // TODO as Vec
+  PetscReal *target; // TODO remove
+  PetscReal *deci;   // TODO remove
+
+  Vec       vec_dist;
+  Vec       vec_targets;
 
   PetscReal sigmoid_params[2];
   PetscReal threshold;
@@ -25,8 +28,8 @@ typedef struct {
 
   PetscBool labels_to_target_probs;
 
-  PetscInt  confusion_matrix[4]; // TODO move to _p_SVM
-  PetscReal model_scores[15];    // TODO move to _p_SVM
+  PetscInt  confusion_matrix[4];
+  PetscReal model_scores[15];
 
 } SVM_Probability;
 

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -23,8 +23,8 @@ typedef struct {
 
   Tao       tao;
 
-  Vec       sub_work[2];
-  Vec       *work;
+  Vec       *work_vecs;
+  Vec       work_sub[2];
 
   PetscReal sigmoid_params[2];
   PetscReal threshold;

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -14,8 +14,8 @@ typedef struct {
   SVM       inner;
   Tao       tao;
 
-  PetscReal *target; // TODO remove
-  PetscReal *deci;   // TODO remove
+  // PetscReal *target; // TODO remove
+  // PetscReal *deci;   // TODO remove
 
   Vec       vec_dist;
   Vec       vec_targets;

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -1,0 +1,11 @@
+
+#if !defined(__PROBIMPL_H)
+#define	__PROBIMPL_H
+
+#include <permon/private/svmimpl.h>
+
+typedef struct {
+
+} SVM_Probability;
+
+#endif

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -5,6 +5,13 @@
 #include <permon/private/svmimpl.h>
 
 typedef struct {
+  Mat Xt_training;
+  Vec y_training;
+
+  Mat Xt_calib;
+  Vec y_calib;
+
+  SVM svm_inner;
 
 } SVM_Probability;
 

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -11,22 +11,23 @@ typedef struct {
   Mat       Xt_calib;
   Vec       y_calib;
 
-  SVM       inner;
-  Tao       tao;
+  PetscInt  Np_calib;
+  PetscInt  Nn_calib;
 
-  // PetscReal *target; // TODO remove
-  // PetscReal *deci;   // TODO remove
+  SVM       inner;  // TODO change name to uncalibrated
 
   Vec       vec_dist;
   Vec       vec_targets;
 
+  PetscBool labels_to_target_probs;
+
+  Tao       tao;
+
+  Vec       sub_work[2];
+  Vec       *work;
+
   PetscReal sigmoid_params[2];
   PetscReal threshold;
-
-  PetscInt  Np_calib;
-  PetscInt  Nn_calib;
-
-  PetscBool labels_to_target_probs;
 
   PetscInt  confusion_matrix[4];
   PetscReal model_scores[15];

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -11,7 +11,17 @@ typedef struct {
   Mat Xt_calib;
   Vec y_calib;
 
-  SVM svm_inner;
+
+  SVM inner;
+  Tao tao;
+
+  PetscReal *target;
+  PetscReal *deci;
+
+  PetscInt  Np_calib;
+  PetscInt  Nn_calib;
+
+  PetscBool labels_to_target_probs;
 
 } SVM_Probability;
 

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -2255,7 +2255,7 @@ PetscErrorCode SVMTest(SVM svm)
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
   PetscCall(svm->ops->test(svm));
 
-  PetscCall(PetscOptionsGetViewer(((PetscObject)svm)->comm,NULL,((PetscObject)svm)->prefix,"-svm_view_score",&v,&format,&view));
+  PetscCall(PetscOptionsGetViewer(((PetscObject)svm)->comm,NULL,((PetscObject)svm)->prefix,"-svm_view_report",&v,&format,&view));
   if (view) {
     PetscCall(PetscViewerPushFormat(v,format));
     PetscCall(SVMViewScore(svm,v));

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -1432,7 +1432,7 @@ PetscErrorCode SVMGetInnerSVM(SVM svm,SVM *out)
   PetscFunctionBegin;
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
   PetscUseMethod(svm,"SVMGetInnerSVM_C",(SVM,SVM *),(svm,out));
-  PetscFunctionReturn(0);
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /*@
@@ -1444,7 +1444,7 @@ PetscErrorCode SVMGetTao(SVM svm,Tao *tao)
   PetscFunctionBegin;
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
   PetscUseMethod(svm,"SVMGetTao_C",(SVM,Tao *),(svm,tao));
-  PetscFunctionReturn(0);
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
@@ -1783,7 +1783,7 @@ PetscErrorCode SVMSetCalibrationDataset(SVM svm,Mat Xt_calib,Vec y_calib)
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
 
   PetscTryMethod(svm,"SVMSetCalibrationDataset_C",(SVM,Mat,Vec),(svm,Xt_calib,y_calib));
-  PetscFunctionReturn(0);
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /*@
@@ -1809,7 +1809,7 @@ PetscErrorCode SVMGetCalibrationDataset(SVM svm,Mat *Xt_calib,Vec *y_calib)
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
 
   PetscUseMethod(svm,"SVMGetCalibrationDataset_C",(SVM,Mat *,Vec *),(svm,Xt_calib,y_calib));
-  PetscFunctionReturn(0);
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -5,7 +5,7 @@
 PetscClassId  SVM_CLASSID;
 PetscLogEvent SVM_LoadDataset,SVM_LoadGramian;
 
-const char *const ModelScores[]={"accuracy","precision","sensitivity","F1","mcc","aucroc","G1","ModelScore","model_",0};
+const char *const ModelScores[]={"accuracy","precision","recall","F1","jaccard","aucroc","ModelScore","model_",0};
 const char *const CrossValidationTypes[]={"kfold","stratified_kfold","CrossValidationType","cv_",0};
 
 #undef __FUNCT__

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -1423,6 +1423,30 @@ PetscErrorCode SVMSetWarmStart(SVM svm,PetscBool flg)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+/*@
+
+@*/
+PetscErrorCode SVMGetInnerSVM(SVM svm,SVM *out)
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscUseMethod(svm,"SVMGetInnerSVM_C",(SVM,SVM *),(svm,out));
+  PetscFunctionReturn(0);
+}
+
+/*@
+
+@*/
+PetscErrorCode SVMGetTao(SVM svm,Tao *tao)
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscUseMethod(svm,"SVMGetTao_C",(SVM,Tao *),(svm,tao));
+  PetscFunctionReturn(0);
+}
+
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetUp"
 /*@
@@ -1870,8 +1894,6 @@ PetscErrorCode SVMGetTestDataset(SVM svm,Mat *Xt_test,Vec *y_test)
 
   Input Parameter:
 . svm - SVM context
-
-  Output Parameter:
 . flg - flag
 
   Level: developer
@@ -1887,6 +1909,29 @@ PetscErrorCode SVMSetAutoPostTrain(SVM svm,PetscBool flg)
 
   svm->autoposttrain = flg;
   PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*@
+  SVMGetAutoPostTrain - Returns auto post train flag.
+
+  Not Collective
+
+  Input Parameter:
+. svm - SVM context
+
+  Output Parameter:
+. flg - flag
+
+  Level: developer
+@*/
+PetscErrorCode SVMGetAutoPostTrain(SVM svm,PetscBool *flg)
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidPointer(flg,2);
+  *flg = svm->autoposttrain;
+  PetscFunctionReturn(0);
 }
 
 #undef __FUNCT__

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -61,7 +61,7 @@ PetscErrorCode SVMCreate(MPI_Comm comm,SVM *svm_out)
   svm->user_bias  = 1.;
   svm->svm_mod    = 2;
 
-  PetscCall(PetscMemzero(svm->hopt_score_types,7 * sizeof(ModelScore)));
+  PetscCall(PetscMemzero(svm->hopt_score_types,6* sizeof(ModelScore)));
 
   svm->penalty_type        = 1;
   svm->hyperoptset         = PETSC_FALSE;
@@ -2811,8 +2811,8 @@ PetscErrorCode SVMLoadTrainingDataset(SVM svm,PetscViewer v)
   PetscCall(MatSetFromOptions(Xt_training));
 
   PetscCall(VecCreate(comm,&y_training));
-  PetscCall(VecSetFromOptions(y_training));
   PetscCall(PetscObjectSetName((PetscObject) y_training,"y_training"));
+  PetscCall(VecSetFromOptions(y_training));
 
   PetscCall(PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0));
   PetscCall(PetscViewerLoadSVMDataset(Xt_training,y_training,v));

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -58,6 +58,7 @@ PetscErrorCode SVMCreate(MPI_Comm comm,SVM *svm_out)
   svm->logCn_step  =  1.;
 
   svm->loss_type  = SVM_L1;
+  svm->user_bias  = 1.;
   svm->svm_mod    = 2;
 
   PetscCall(PetscMemzero(svm->hopt_score_types,7 * sizeof(ModelScore)));
@@ -203,6 +204,7 @@ PetscErrorCode SVMSetFromOptions(SVM svm)
   PetscInt            svm_mod;
   SVMLossType         loss_type;
   PetscInt            penalty_type;
+  PetscReal           bias;
   PetscReal           C;
 
   PetscBool           hyperoptset;
@@ -221,45 +223,60 @@ PetscErrorCode SVMSetFromOptions(SVM svm)
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
 
   PetscObjectOptionsBegin((PetscObject)svm);
+  // TODO move to SetFromOptions_Binary
   PetscCall(PetscOptionsInt("-svm_binary_mod","","SVMSetMod",svm->svm_mod,&svm_mod,&flg));
   if (flg) {
     PetscCall(SVMSetMod(svm,svm_mod));
   }
+
   PetscCall(PetscOptionsEnum("-svm_loss_type","Specify the loss function for soft-margin SVM (non-separable samples).","SVMSetLossType",SVMLossTypes,(PetscEnum)svm->loss_type,(PetscEnum*)&loss_type,&flg));
   if (flg) {
     PetscCall(SVMSetLossType(svm,loss_type));
   }
+
   PetscCall(PetscOptionsInt("-svm_penalty_type","Set type of misclasification error penalty.","SVMSetPenaltyType",svm->penalty_type,&penalty_type,&flg));
   if (flg) {
     PetscCall(SVMSetPenaltyType(svm,penalty_type));
   }
+
+  PetscCall(PetscOptionsReal("-svm_user_bias","Set a user defined bias for a relaxed bias formulation.","SVMSetUserBias",svm->user_bias,&bias,&flg));
+  if (flg) {
+    PetscCall(SVMSetUserBias(svm,bias));
+  }
+
   PetscCall(PetscOptionsReal("-svm_C","Set SVM C (C).","SVMSetC",svm->C,&C,&flg));
   if (flg) {
     PetscCall(SVMSetC(svm,C));
   }
+
   PetscCall(PetscOptionsReal("-svm_Cp","Set SVM Cp (Cp).","SVMSetCp",svm->Cp,&C,&flg));
   if (flg) {
     PetscCall(SVMSetCp(svm,C));
   }
+
   PetscCall(PetscOptionsReal("-svm_Cn","Set SVM Cn (Cn).","SVMSetCn",svm->Cn,&C,&flg));
   if (flg) {
     PetscCall(SVMSetCn(svm,C));
   }
+
   /* Hyperparameter optimization options */
   PetscCall(PetscOptionsBool("-svm_hyperopt","Specify whether hyperparameter optimization will be performed.","SVMSetHyperOpt",svm->hyperoptset,&hyperoptset,&flg));
   if (flg) {
     PetscCall(SVMSetHyperOpt(svm,hyperoptset));
   }
+
   n = 7;
   PetscCall(PetscOptionsEnumArray("-svm_hyperopt_score_types","Specify the score types for evaluating performance of model during hyperparameter optimization.","SVMSetHyperOptScoreTypes",ModelScores,(PetscEnum *) hyperopt_score_types,&n,&flg));
   if (flg) {
     PetscCall(SVMSetHyperOptScoreTypes(svm,n,hyperopt_score_types));
   }
+
   /* Grid search options (penalty type 1) */
   PetscCall(PetscOptionsReal("-svm_gs_logC_base","Base of log of C values that specify grid (penalty type 1).","SVMGridSearchSetBaseLogC",svm->logC_base,&logC_base,&flg));
   if (flg) {
     PetscCall(SVMGridSearchSetBaseLogC(svm,logC_base));
   }
+
   n = 3;
   logC_stride[1] =  2.;
   logC_stride[2] =  1.;
@@ -267,11 +284,13 @@ PetscErrorCode SVMSetFromOptions(SVM svm)
   if (flg) {
     PetscCall(SVMGridSearchSetStrideLogC(svm,logC_stride[0],logC_stride[1],logC_stride[2]));
   }
+
   /* Grid search options (penalty type 2) */
   PetscCall(PetscOptionsReal("-svm_gs_logCp_base","Base of log of C+ values that specify grid (penalty type 2).","SVMGridSearchSetPositiveBaseLogC",svm->logCp_base,&logC_base,&flg));
   if (flg) {
     PetscCall(SVMGridSearchSetPositiveBaseLogC(svm,logC_base));
   }
+
   n = 3;
   logC_stride[1] = 2.;
   logC_stride[2] = 1.;
@@ -279,10 +298,12 @@ PetscErrorCode SVMSetFromOptions(SVM svm)
   if (flg) {
     PetscCall(SVMGridSearchSetPositiveStrideLogC(svm,logC_stride[0],logC_stride[1],logC_stride[2]));
   }
+
   PetscCall(PetscOptionsReal("-svm_gs_logCn_base","Base of log of C- values that specify grid (penalty type 2).","SVMGridSearchSetNegativeBaseLogC",svm->logCn_base,&logC_base,&flg));
   if (flg) {
     PetscCall(SVMGridSearchSetNegativeBaseLogC(svm,logC_base));
   }
+
   n = 3;
   logC_stride[1] = 2.;
   logC_stride[2] = 1.;
@@ -290,15 +311,18 @@ PetscErrorCode SVMSetFromOptions(SVM svm)
   if (flg) {
     PetscCall(SVMGridSearchSetNegativeStrideLogC(svm,logC_stride[0],logC_stride[1],logC_stride[2]));
   }
+
   /* Cross validation options */
   PetscCall(PetscOptionsEnum("-svm_cv_type","Specify the type of cross validation.","SVMSetCrossValidationType",CrossValidationTypes,(PetscEnum)svm->cv_type,(PetscEnum*)&cv_type,&flg));
   if (flg) {
     PetscCall(SVMSetCrossValidationType(svm,cv_type));
   }
+
   PetscCall(PetscOptionsInt("-svm_nfolds","Set number of folds (nfolds).","SVMSetNfolds",svm->nfolds,&nfolds,&flg));
   if (flg) {
     PetscCall(SVMSetNfolds(svm,nfolds));
   }
+
   /* Warm start */
   PetscCall(PetscOptionsBool("-svm_warm_start","Specify whether warm start is used in cross-validation.","SVMSetWarmStart",svm->warm_start,&warm_start,&flg));
   if (flg) {
@@ -1666,7 +1690,7 @@ PetscErrorCode SVMComputeOperator(SVM svm,Mat *A)
   Input Parameter:
 + svm - SVM context
 . Xt_training - samples data
-- y - known labels of training samples
+- y_training - known labels of training samples
 
   Level: beginner
 
@@ -1712,6 +1736,56 @@ PetscErrorCode SVMGetTrainingDataset(SVM svm,Mat *Xt_training,Vec *y_training)
 
   PetscUseMethod(svm,"SVMGetTrainingDataset_C",(SVM,Mat *,Vec *),(svm,Xt_training,y_training));
   PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*@
+  SVMSetCalibrationDataset - Sets the calibration samples and labels.
+
+  Not Collective
+
+  Input Parameter:
++ svm - SVM context
+. Xt_calib - calibration samples data
+- y_calib - known labels of calibration samples
+
+  Level: beginner
+
+.seealso SVMSetTrainingDataset(), SVMGetTrainingDataset(), SVMSetTestDataset(), SVMGetTestDataset()
+@*/
+PetscErrorCode SVMSetCalibrationDataset(SVM svm,Mat Xt_calib,Vec y_calib)
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+
+  PetscTryMethod(svm,"SVMSetCalibrationDataset_C",(SVM,Mat,Vec),(svm,Xt_calib,y_calib));
+  PetscFunctionReturn(0);
+}
+
+/*@
+  SVMGetTrainingDataset - Returns the calibration samples and labels.
+
+  Not Collective
+
+  Input Parameter:
+. svm - SVM context
+
+  Output Parameter:
++ Xt_calib- calibration samples
+- y_calib - known labels of calibration samples
+
+  Level: beginner
+
+.seealso SVMSetTrainingDataset(), SVMGetTrainingDataset(), SVMSetTestDataset(), SVMGetTestDataset()
+@*/
+PetscErrorCode SVMGetCalibrationDataset(SVM svm,Mat *Xt_calib,Vec *y_calib)
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+
+  PetscUseMethod(svm,"SVMGetCalibrationDataset_C",(SVM,Mat *,Vec *),(svm,Xt_calib,y_calib));
+  PetscFunctionReturn(0);
 }
 
 #undef __FUNCT__
@@ -1984,6 +2058,33 @@ PetscErrorCode SVMGetBias(SVM svm,PetscReal *bias)
 
   PetscUseMethod(svm,"SVMGetBias_C",(SVM,PetscReal *),(svm,bias));
   PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*@
+
+@*/
+PetscErrorCode SVMSetUserBias(SVM svm,PetscReal bias)
+{
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidLogicalCollectiveReal(svm,bias,2);
+
+  if (svm->user_bias != bias) {
+    svm->user_bias = bias;
+    svm->setupcalled = PETSC_FALSE;
+  }
+  PetscFunctionReturn(0);
+}
+
+/*@
+
+@*/
+PetscErrorCode SVMGetUserBias(SVM svm,PetscReal *bias)
+{
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  *bias = svm->user_bias;
+  PetscFunctionReturn(0);
 }
 
 #undef __FUNCT__
@@ -2590,25 +2691,58 @@ PetscErrorCode SVMLoadDataset(SVM svm,PetscViewer v,Mat Xt,Vec y)
 
   Level: intermediate
 
-.seealso SVMLoadTestDataset(), SVM
+.seealso SVMLoadCalibrationDataset(), SVMLoadTestDataset(), SVM
 @*/
 PetscErrorCode SVMLoadTrainingDataset(SVM svm,PetscViewer v)
 {
-  PetscBool  view_io,view_dataset;
+  MPI_Comm  comm;
+
+  Mat       Xt_training;
+  Mat       Xt_biased;
+  Vec       y_training;
+
+  PetscReal user_bias;
+  PetscInt  mod;
+
+  PetscBool view_io,view_dataset;
 
   PetscFunctionBeginI;
   PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
   PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
 
-  if (svm->ops->loadtrainingdataset) {
-    PetscCall(svm->ops->loadtrainingdataset(svm,v));
+  PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
+  /* Create matrix of training samples */
+  PetscCall(MatCreate(comm,&Xt_training));
+  PetscCall(PetscObjectSetName((PetscObject) Xt_training,"Xt_training"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) Xt_training,"Xt_training_"));
+  PetscCall(MatSetFromOptions(Xt_training));
+
+  PetscCall(VecCreate(comm,&y_training));
+  PetscCall(VecSetFromOptions(y_training));
+  PetscCall(PetscObjectSetName((PetscObject) y_training,"y_training"));
+
+  PetscCall(PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0));
+  PetscCall(PetscViewerLoadSVMDataset(Xt_training,y_training,v));
+  PetscCall(PetscLogEventEnd(SVM_LoadDataset,svm,0,0,0));
+
+  PetscCall(SVMGetMod(svm,&mod));
+  if (mod == 2) {
+    PetscCall(SVMGetUserBias(svm,&user_bias));
+    PetscCall(MatBiasedCreate(Xt_training,user_bias,&Xt_biased));
+    Xt_training = Xt_biased;
   }
+  PetscCall(SVMSetTrainingDataset(svm,Xt_training,y_training));
 
   PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_io",&view_io));
   PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_training_dataset",&view_dataset));
   if (view_io || view_dataset) {
     PetscCall(SVMViewTrainingDataset(svm,PETSC_VIEWER_STDOUT_(PetscObjectComm((PetscObject) v))));
   }
+
+  /* Free memory */
+  PetscCall(MatDestroy(&Xt_training));
+  PetscCall(VecDestroy(&y_training));
+
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -2631,13 +2765,34 @@ PetscErrorCode SVMLoadTrainingDataset(SVM svm,PetscViewer v)
 @*/
 PetscErrorCode SVMViewTrainingDataset(SVM svm,PetscViewer v)
 {
+  MPI_Comm   comm;
+
+  Mat        Xt;
+  Vec        y;
+
+  PetscBool  isascii;
+  const char *type_name = NULL;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
+  PetscCall(SVMGetTrainingDataset(svm,&Xt,&y));
+  if (!Xt || !y) {
+    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
+    SETERRQ(comm,PETSC_ERR_ARG_NULL,"Training dataset is not set");
+  }
 
-  if (svm->ops->viewtrainingdataset) {
-    PetscCall(svm->ops->viewtrainingdataset(svm,v) );
+  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  if (isascii) {
+    /* Print info related to svm type */
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+
+    PetscCall(PetscViewerASCIIPushTab(v));
+    PetscCall(SVMViewDataset(svm,Xt,y,v));
+    PetscCall(PetscViewerASCIIPopTab(v));
+  } else {
+    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
+    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
+
+    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewTrainingDataset",type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2653,7 +2808,7 @@ PetscErrorCode SVMViewTrainingDataset(SVM svm,PetscViewer v)
 
   Level: intermediate
 
-.seealso SVMLoadTrainingDataset(), SVM
+.seealso SVMLoadTrainingDataset(), SVMLoadCalibrationDataset(), SVM
 @*/
 PetscErrorCode SVMLoadTestDataset(SVM svm,PetscViewer v)
 {
@@ -2663,7 +2818,7 @@ PetscErrorCode SVMLoadTestDataset(SVM svm,PetscViewer v)
   Mat         Xt_biased;
   Vec         y_test;
 
-  PetscReal   bias;
+  PetscReal   user_bias;
   PetscInt    mod;
 
   PetscBool  view_io,view_test_dataset;
@@ -2689,8 +2844,8 @@ PetscErrorCode SVMLoadTestDataset(SVM svm,PetscViewer v)
 
   PetscCall(SVMGetMod(svm,&mod));
   if (mod == 2) {
-    PetscCall(SVMGetBias(svm,&bias));
-    PetscCall(MatBiasedCreate(Xt_test,bias,&Xt_biased));
+    PetscCall(SVMGetUserBias(svm,&user_bias));
+    PetscCall(MatBiasedCreate(Xt_test,user_bias,&Xt_biased));
     Xt_test = Xt_biased;
   }
   PetscCall(SVMSetTestDataset(svm,Xt_test,y_test));
@@ -2759,6 +2914,62 @@ PetscErrorCode SVMViewTestDataset(SVM svm,PetscViewer v)
 
     SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewTestDataset",type_name);
   }
+  PetscFunctionReturn(0);
+}
+
+#undef __FUNCT__
+#define __FUNCT__ "SVMLoadCalibrationDataset"
+/*@
+  SVMLoadCalibrationDataset - Loads calibration dataset.
+
+  Input Parameters:
++ svm - SVM context
+- v - viewer
+
+  Level: intermediate
+
+.seealso SVMLoadTrainingDataset(), SVMLoadTestDataset(), SVM
+@*/
+PetscErrorCode SVMLoadCalibrationDataset(SVM svm,PetscViewer v)
+{
+  MPI_Comm  comm;
+  PetscBool view_io,view_calibration_dataset;
+
+  PetscFunctionBeginI;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
+  PetscTryMethod(svm,"SVMLoadCalibrationDataset_C",(SVM,PetscViewer),(svm,v));
+
+  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_io",&view_io));
+  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_calibration_dataset",&view_calibration_dataset));
+  if (view_io || view_calibration_dataset) {
+    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
+    PetscCall(SVMViewCalibrationDataset(svm,PETSC_VIEWER_STDOUT_(comm)));
+  }
+  PetscFunctionReturnI(0);
+}
+
+/*@
+  SVMViewCalibrationDataset - Views details associated with calibration dataset such as number of positive and negative samples, features, etc.
+
+  Input Parameters:
++ svm - SVM context
+- v - visualization context
+
+  Level: beginner
+
+  Options Database Keys:
++ -svm_view_io - Prints info on calibration dataset (as well as training/Test dataset) at the end of SVMLoadCalibrationDataset(), and SVMLoadTrainingDataset()/SVMLoadTestDataset(), respectively.
+- -svm_view_calibration_dataset - Prints info just on calibration dataset at the end of SVMLoadCalibrationDataset().
+
+.seealso SVM, PetscViewer, SVMViewDataset(), SVMViewTrainingDataset(), SVMViewTestDataset()
+@*/
+PetscErrorCode SVMViewCalibrationDataset(SVM svm,PetscViewer v)
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscTryMethod(svm,"SVMViewCalibrationDataset_C",(SVM,PetscViewer),(svm,v));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -2156,6 +2156,32 @@ PetscErrorCode SVMReconstructHyperplane(SVM svm)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+/*@
+  SVMGetDistancesFromHyperplane - Gets distances of samples from a separating hyperplane.
+
+  Collected on SVM
+
+  Input Parameters:
++ svm - SVM context
+- Xt - matrix of samples
+
+  Output Parameter:
+. dist - distances of samples from hyperplane
+
+  Level: intermediate
+
+.seealso: SVMPredict()
+@*/
+PetscErrorCode SVMGetDistancesFromHyperplane(SVM svm,Mat Xt,Vec *dist)
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+
+  PetscUseMethod(svm,"SVMGetDistancesFromHyperplane_C",(SVM,Mat,Vec *),(svm,Xt,dist));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 #undef __FUNCT__
 #define __FUNCT__ "SVMPredict"
 /*@

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -3081,7 +3081,6 @@ PetscErrorCode SVMViewCalibrationDataset(SVM svm,PetscViewer v)
 @*/
 PetscErrorCode SVMViewDataset(SVM svm,Mat Xt,Vec y,PetscViewer v)
 {
-  /* */
   MPI_Comm   comm;
   const char *type_name = NULL;
 

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -3081,6 +3081,7 @@ PetscErrorCode SVMViewCalibrationDataset(SVM svm,PetscViewer v)
 @*/
 PetscErrorCode SVMViewDataset(SVM svm,Mat Xt,Vec y,PetscViewer v)
 {
+  /* */
   MPI_Comm   comm;
   const char *type_name = NULL;
 

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -1884,6 +1884,28 @@ PetscErrorCode SVMGetTestDataset(SVM svm,Mat *Xt_test,Vec *y_test)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+/*@
+  SVMGetLabels - Returns original labels related to each category.
+
+  Not Collective
+
+  Input Parameters:
+. svm - SVM context
+. labels - labels related to each category
+
+  Level: intermediate
+
+.seealso SVMSetTrainingDataset, SVMGetTrainingDataset
+@*/
+PetscErrorCode SVMGetLabels(SVM svm,const PetscReal *labels[])
+{
+
+  PetscFunctionBegin;
+  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscUseMethod(svm,"SVMGetLabels_C",(SVM,const PetscReal *[]),(svm,labels));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetAutoPostTrain"
@@ -1892,7 +1914,7 @@ PetscErrorCode SVMGetTestDataset(SVM svm,Mat *Xt_test,Vec *y_test)
 
   Logically Collective on SVM
 
-  Input Parameter:
+  Input Parameters:
 . svm - SVM context
 . flg - flag
 

--- a/src/svm/interface/svmregis.c
+++ b/src/svm/interface/svmregis.c
@@ -2,6 +2,7 @@
 #include <permon/private/svmimpl.h>
 
 FLLOP_EXTERN PetscErrorCode SVMCreate_Binary(SVM);
+FLLOP_EXTERN PetscErrorCode SVMCreate_Probability(SVM);
 
 /*
    Contains the list of registered Create routines of all SVM types
@@ -19,6 +20,7 @@ PetscErrorCode SVMRegisterAll()
   SVMRegisterAllCalled = PETSC_TRUE;
 
   PetscCall(SVMRegister(SVM_BINARY,SVMCreate_Binary));
+  PetscCall(SVMRegister(SVM_PROBABILITY,SVMCreate_Probability));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/svm/utils/makefile
+++ b/src/svm/utils/makefile
@@ -2,9 +2,9 @@ ALL: lib
 
 CFLAGS   =
 FFLAGS   =
-SOURCEC  = io.c matutils.c
+SOURCEC  = io.c report.c matutils.c
 SOURCEF  =
-SOURCEH  = io.h
+SOURCEH  = io.h report.h
 OBJSC    = ${SOURCEC:.c=.o}
 LIBBASE  = libpermon
 DIRS     =

--- a/src/svm/utils/matutils.c
+++ b/src/svm/utils/matutils.c
@@ -126,13 +126,28 @@ PetscErrorCode MatMultTranspose_Biased(Mat A,Vec x,Vec y)
 #define __FUNCT__ "MatGetOwnershipIS_Biased"
 PetscErrorCode MatGetOwnershipIS_Biased(Mat mat,IS *rows,IS *cols)
 {
-  void   *ptr;
-  MatCtx *ctx;
+  MPI_Comm comm;
+
+  void     *ptr;
+  MatCtx   *ctx;
+
+  PetscInt ncols;
+  IS       cols_inner;
 
   PetscFunctionBegin;
   PetscCall(MatShellGetContext(mat,&ptr));
   ctx = (MatCtx *) ptr;
-  PetscCall(MatGetOwnershipIS(ctx->inner,rows,cols));
+
+  if (rows) {
+    PetscCall(MatGetOwnershipIS(ctx->inner,rows,NULL));
+  }
+
+  if (cols) {
+    PetscCall(PetscObjectGetComm((PetscObject) mat,&comm));
+    PetscCall(MatGetSize(ctx->inner,NULL,&ncols));
+    PetscCall(ISCreateStride(comm,ncols,0,1,&cols_inner));
+    *cols = cols_inner;
+  }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/svm/utils/matutils.c
+++ b/src/svm/utils/matutils.c
@@ -126,8 +126,6 @@ PetscErrorCode MatMultTranspose_Biased(Mat A,Vec x,Vec y)
 #define __FUNCT__ "MatGetOwnershipIS_Biased"
 PetscErrorCode MatGetOwnershipIS_Biased(Mat mat,IS *rows,IS *cols)
 {
-  MPI_Comm comm;
-
   void     *ptr;
   MatCtx   *ctx;
 
@@ -143,9 +141,8 @@ PetscErrorCode MatGetOwnershipIS_Biased(Mat mat,IS *rows,IS *cols)
   }
 
   if (cols) {
-    PetscCall(PetscObjectGetComm((PetscObject) mat,&comm));
     PetscCall(MatGetSize(ctx->inner,NULL,&ncols));
-    PetscCall(ISCreateStride(comm,ncols,0,1,&cols_inner));
+    PetscCall(ISCreateStride(PetscObjectComm((PetscObject) mat),ncols,0,1,&cols_inner));
     *cols = cols_inner;
   }
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -1,0 +1,75 @@
+
+#include "report.h"
+
+PetscErrorCode ConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt confusion_mat[])
+{
+  PetscInt TP,FP,TN,FN; // confusion matrix values
+  PetscInt N;
+
+  Vec      y_known_sub;
+  Vec      y_pred_sub;
+
+  Vec      vec_label;
+  IS       is_label;
+
+  IS       is_eq;
+
+  const PetscReal *labels = NULL;
+
+  PetscFunctionBegin;
+
+  PetscCall(SVMGetLabels(svm,&labels));
+  PetscCall(VecDuplicate(y_pred,&vec_label));
+
+  /* TN and FN samples */
+  PetscCall(VecSet(vec_label,labels[0]));
+
+  PetscCall(VecWhichEqual(y_known,vec_label,&is_label));
+  PetscCall(VecGetSubVector(y_known,is_label,&y_known_sub));
+  PetscCall(VecGetSubVector(y_pred,is_label,&y_pred_sub));
+  PetscCall(VecWhichEqual(y_known_sub,y_pred_sub,&is_eq));
+
+  PetscCall(ISGetSize(is_eq,&TN));
+  PetscCall(VecGetSize(y_known_sub,&N));
+  FN = N - TN;
+
+  PetscCall(VecRestoreSubVector(y_known,is_label,&y_known_sub));
+  PetscCall(VecRestoreSubVector(y_pred,is_label,&y_pred_sub));
+  PetscCall(ISDestroy(&is_label));
+  PetscCall(ISDestroy(&is_eq));
+
+  /* TP and FP samples */
+  PetscCall(VecSet(vec_label,labels[1]));
+
+  PetscCall(VecWhichEqual(y_known,vec_label,&is_label));
+  PetscCall(VecGetSubVector(y_known,is_label,&y_known_sub));
+  PetscCall(VecGetSubVector(y_pred,is_label,&y_pred_sub));
+  PetscCall(VecWhichEqual(y_known_sub,y_pred_sub,&is_eq));
+
+  PetscCall(ISGetSize(is_eq,&TP));
+  PetscCall(VecGetSize(y_known_sub,&N));
+  FP = N - TP;
+
+  PetscCall(VecRestoreSubVector(y_known,is_label,&y_known_sub));
+  PetscCall(VecRestoreSubVector(y_pred,is_label,&y_pred_sub));
+  PetscCall(ISDestroy(&is_label));
+  PetscCall(ISDestroy(&is_eq));
+
+  confusion_mat[0] = TP;
+  confusion_mat[1] = FP;
+  confusion_mat[2] = FN;
+  confusion_mat[3] = TN;
+
+  /* Clen up */
+  PetscCall(VecDestroy(&vec_label));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+PetscErrorCode ClassificationReport(SVM svm,Vec y_pred,Vec y_known)
+{
+  PetscInt confusion_mat[4];
+
+  PetscFunctionBegin;
+  PetscCall(ConfusionMatrix(svm,y_pred,y_known,confusion_mat));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -161,4 +161,33 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
+PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscReal *scores,PetscViewer v)
+{
+  const PetscReal *labels;
+
+  PetscFunctionBegin;
+  PetscCall(SVMGetLabels(svm,&labels));
+
+  /* Print confusion matrix */
+  PetscCall(PetscViewerASCIIPrintf(v,"Confusion matrix:\n"));
+  PetscCall(PetscViewerASCIIPushTab(v));
+  PetscCall(PetscViewerASCIIPrintf(v,"TP = %4" PetscInt_FMT ""  ,cmat[0]));
+  PetscCall(PetscViewerASCIIPrintf(v,"FP = %4" PetscInt_FMT "\n",cmat[1]));
+  PetscCall(PetscViewerASCIIPrintf(v,"FN = %4" PetscInt_FMT ""  ,cmat[2]));
+  PetscCall(PetscViewerASCIIPrintf(v,"TN = %4" PetscInt_FMT "\n",cmat[3]));
+  PetscCall(PetscViewerASCIIPopTab(v));
+
+  /* Print classification report */
+  PetscCall(PetscViewerASCIIPrintf(v,"Classification report:\n"));
+  PetscCall(PetscViewerASCIIPushTab(v));
+  PetscCall(PetscViewerASCIIPrintf(v,"label\tprecision\trecall\tF1\tJaccard index\n"));
+  PetscCall(PetscViewerASCIIPrintf(v,"0.0  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",scores[2],scores[5],scores[8] ,scores[11]));
+  PetscCall(PetscViewerASCIIPrintf(v,"1.0  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",scores[3],scores[6],scores[9] ,scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean \t%.2f\t\t%.2f\t%.2f\t%.2f\n",scores[4],scores[7],scores[10],scores[13]));
+  PetscCall(PetscViewerASCIIPrintf(v,"accuracy          = %.2f%%\n",(double) scores[0] * 100));
+  PetscCall(PetscViewerASCIIPrintf(v,"accuracy_balanced = %.2f%%\n",(double) scores[1] * 100));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc           = %.2f%%\n",(double) scores[14] * 100));
+  PetscCall(PetscViewerASCIIPopTab(v));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
 /* TODO print classification report */

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -118,11 +118,11 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   /* Area under curve (trapezoidal rule) */
   specifity = (PetscReal) TN / (PetscReal) (TN + FP);
 
-  FPR = 1 - specifity;
+  FPR = 1. - specifity;
   TPR = sensitivity[0];
 
-  x[0] = 0; x[1] = FPR; x[2] = 1;
-  y[0] = 0; y[1] = TPR; y[2] = 1;
+  x[0] = 0.; x[1] = FPR; x[2] = 1.;
+  y[0] = 0.; y[1] = TPR; y[2] = 1.;
 
   auc_roc = 0.;
   for (i = 0; i < 2; ++i) {
@@ -159,7 +159,7 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscReal *scores,PetscViewer v)
+PetscErrorCode SVMViewBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscReal *scores,PetscViewer v)
 {
   const PetscReal *labels;
 

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -1,7 +1,7 @@
 
 #include "report.h"
 
-PetscErrorCode ConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt confusion_mat[])
+PetscErrorCode BinaryConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt confusion_mat[])
 {
   PetscInt TP,FP,TN,FN; // confusion matrix values
   PetscInt N;
@@ -60,16 +60,105 @@ PetscErrorCode ConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt confusion
   confusion_mat[2] = FN;
   confusion_mat[3] = TN;
 
-  /* Clen up */
+  /* Clean up */
   PetscCall(VecDestroy(&vec_label));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode ClassificationReport(SVM svm,Vec y_pred,Vec y_known)
+#undef __FUNCT__
+#define __FUNCT__ "SVMGetBinaryClassificationReport"
+PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,PetscInt *cmat, PetscReal *scores)
 {
-  PetscInt confusion_mat[4];
+  PetscInt  confusion_mat[4];
+  PetscInt  TP,FP,TN,FN;
 
-  PetscFunctionBegin;
-  PetscCall(ConfusionMatrix(svm,y_pred,y_known,confusion_mat));
-  PetscFunctionReturn(PETSC_SUCCESS);
+  PetscReal accuracy[2];
+  PetscReal auc_roc;
+  PetscReal precision[3];
+  PetscReal sensitivity[3];
+  PetscReal F1[3];
+  PetscReal jaccard_index[3];
+
+  PetscReal specifity;
+  PetscReal TPR,FPR;
+  PetscReal x[3],y[3],dx;
+
+  PetscInt  i;
+
+  PetscFunctionBeginI;
+  PetscCall(BinaryConfusionMatrix(svm,y_pred,y_known,confusion_mat));
+
+  TP = confusion_mat[0];
+  FP = confusion_mat[1];
+  FN = confusion_mat[2];
+  TN = confusion_mat[3];
+
+  if (cmat != NULL) {
+    PetscCall(PetscMemcpy(cmat,confusion_mat,4 * sizeof(PetscInt)));
+  }
+
+  if (scores == NULL) {
+    PetscFunctionReturnI(PETSC_SUCCESS);
+  }
+
+  precision[0] = (PetscReal) TP / (PetscReal) (TP + FP); /* precision (positive class) */
+  precision[1] = (PetscReal) TN / (PetscReal) (TN + FN); /* precision (negative class) */
+  precision[2] = (precision[0] + precision[1]) / 2.;     /* precision (average)        */
+
+  sensitivity[0] = (PetscReal) TP / (PetscReal) (TP + FN); /* sensitivity (positive class) */
+  sensitivity[1] = (PetscReal) TN / (PetscReal) (TN + FP); /* sensitivity (negative class) */
+  sensitivity[2] = (sensitivity[0] + sensitivity[1]) / 2.; /* sensitivity (average)        */
+
+  F1[0] = 2. * (precision[0] * sensitivity[0]) / (precision[0] + sensitivity[0]); /* F1 (positive class) */
+  F1[1] = 2. * (precision[1] * sensitivity[1]) / (precision[1] + sensitivity[1]); /* F1 (negative class) */
+  F1[2] = (F1[0] + F1[1]) / 2.;                                                   /* F1 (average) */
+
+  jaccard_index[0] = (PetscReal) TP / (PetscReal) (TP + FP + FN); /* Jaccard index (positive class) */
+  jaccard_index[1] = (PetscReal) TN / (PetscReal) (TN + FN + FP); /* Jaccard index (negative class) */
+  jaccard_index[2] = (jaccard_index[0] + jaccard_index[1]) / 2.;  /* Jaccard index (negative class) */
+
+  /* Area under curve (trapezoidal rule) */
+  specifity = (PetscReal) TN / (PetscReal) (TN + FP);
+
+  FPR = 1 - specifity;
+  TPR = sensitivity[0];
+
+  x[0] = 0; x[1] = FPR; x[2] = 1;
+  y[0] = 0; y[1] = TPR; y[2] = 1;
+
+  auc_roc = 0.;
+  for (i = 0; i < 2; ++i) {
+    dx = x[i+1] - x[i];
+    auc_roc += ((y[i] + y[i+1]) / 2.) * dx;
+  }
+
+  /* Accuracy */
+  accuracy[0] = (PetscReal) (TP + TN) / (PetscReal) (TP + TN + FP + FN);
+  accuracy[1] = (specifity + sensitivity[0]) / 2.; /* Balanced accuracy */
+
+  /* Set scores */
+  scores[0] = accuracy[0];
+  scores[1] = accuracy[1];
+
+  scores[2] = precision[0];
+  scores[3] = precision[1];
+  scores[4] = precision[2];
+
+  scores[5] = sensitivity[0];
+  scores[6] = sensitivity[1];
+  scores[7] = sensitivity[2];
+
+  scores[8]  = F1[0];
+  scores[9]  = F1[1];
+  scores[10] = F1[2];
+
+  scores[11] = jaccard_index[0];
+  scores[12] = jaccard_index[1];
+  scores[13] = jaccard_index[2];
+
+  scores[14] = auc_roc;
+
+  PetscFunctionReturnI(PETSC_SUCCESS);
 }
+
+/* TODO print classification report */

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -99,20 +99,20 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
-  precision[0] = (PetscReal) TP / (PetscReal) (TP + FP); /* precision (positive class) */
-  precision[1] = (PetscReal) TN / (PetscReal) (TN + FN); /* precision (negative class) */
+  precision[0] = (PetscReal) TN / (PetscReal) (TN + FP); /* precision (negative class) */
+  precision[1] = (PetscReal) TP / (PetscReal) (TP + FN); /* precision (positive class) */
   precision[2] = (precision[0] + precision[1]) / 2.;     /* precision (average)        */
 
-  sensitivity[0] = (PetscReal) TP / (PetscReal) (TP + FN); /* sensitivity (positive class) */
-  sensitivity[1] = (PetscReal) TN / (PetscReal) (TN + FP); /* sensitivity (negative class) */
+  sensitivity[0] = (PetscReal) TN / (PetscReal) (TN + FN); /* sensitivity (negative class) */
+  sensitivity[1] = (PetscReal) TP / (PetscReal) (TP + FP); /* sensitivity (positive class) */
   sensitivity[2] = (sensitivity[0] + sensitivity[1]) / 2.; /* sensitivity (average)        */
 
-  F1[0] = 2. * (precision[0] * sensitivity[0]) / (precision[0] + sensitivity[0]); /* F1 (positive class) */
-  F1[1] = 2. * (precision[1] * sensitivity[1]) / (precision[1] + sensitivity[1]); /* F1 (negative class) */
+  F1[0] = 2. * (precision[0] * sensitivity[0]) / (precision[0] + sensitivity[0]); /* F1 (negative class) */
+  F1[1] = 2. * (precision[1] * sensitivity[1]) / (precision[1] + sensitivity[1]); /* F1 (positive class) */
   F1[2] = (F1[0] + F1[1]) / 2.;                                                   /* F1 (average) */
 
-  jaccard_index[0] = (PetscReal) TP / (PetscReal) (TP + FP + FN); /* Jaccard index (positive class) */
-  jaccard_index[1] = (PetscReal) TN / (PetscReal) (TN + FN + FP); /* Jaccard index (negative class) */
+  jaccard_index[0] = (PetscReal) TN / (PetscReal) (TN + FN + FP); /* Jaccard index (negative class) */
+  jaccard_index[1] = (PetscReal) TP / (PetscReal) (TP + FP + FN); /* Jaccard index (positive class) */
   jaccard_index[2] = (jaccard_index[0] + jaccard_index[1]) / 2.;  /* Jaccard index (average) */
 
   /* Area under curve (trapezoidal rule) */
@@ -152,7 +152,9 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   scores[11] = jaccard_index[1];
   scores[12] = jaccard_index[2];
 
-  scores[13] = auc_roc;
+  scores[13] = -1.;
+  scores[14] = -1.;
+  scores[15] = auc_roc;
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -178,11 +180,11 @@ PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscRe
   /* Header */
   PetscCall(PetscViewerASCIIPushTab(v));
   PetscCall(PetscViewerASCIIPrintf(v,"label\tprecision\trecall\tF1\tJaccard index\n"));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[0],scores[2],scores[5],scores[8],scores[11]));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[1],scores[1],scores[4],scores[7],scores[10]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[0],scores[1],scores[4],scores[7],scores[10]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[1],scores[2],scores[5],scores[8],scores[11]));
   PetscCall(PetscViewerASCIIPrintf(v,"mean  \t%.4f\t\t%.4f\t%.4f\t%.4f\n"          ,scores[3],scores[6],scores[9],scores[12]));
   PetscCall(PetscViewerASCIIPrintf(v,"accuracy = %.4f\n",(double) scores[0]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc  = %.4f\n",(double) scores[13]));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc  = %.4f\n",(double) scores[15]));
   PetscCall(PetscViewerASCIIPopTab(v));
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -132,29 +132,27 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
 
   /* Accuracy */
   accuracy[0] = (PetscReal) (TP + TN) / (PetscReal) (TP + TN + FP + FN);
-  accuracy[1] = (specifity + sensitivity[0]) / 2.; /* Balanced accuracy */
 
   /* Set scores */
   scores[0] = accuracy[0];
-  scores[1] = accuracy[1];
 
-  scores[2] = precision[0];
-  scores[3] = precision[1];
-  scores[4] = precision[2];
+  scores[1] = precision[0];
+  scores[2] = precision[1];
+  scores[3] = precision[2];
 
-  scores[5] = sensitivity[0];
-  scores[6] = sensitivity[1];
-  scores[7] = sensitivity[2];
+  scores[4] = sensitivity[0];
+  scores[5] = sensitivity[1];
+  scores[6] = sensitivity[2];
 
-  scores[8]  = F1[0];
-  scores[9]  = F1[1];
-  scores[10] = F1[2];
+  scores[7] = F1[0];
+  scores[8] = F1[1];
+  scores[9] = F1[2];
 
-  scores[11] = jaccard_index[0];
-  scores[12] = jaccard_index[1];
-  scores[13] = jaccard_index[2];
+  scores[10] = jaccard_index[0];
+  scores[11] = jaccard_index[1];
+  scores[12] = jaccard_index[2];
 
-  scores[14] = auc_roc;
+  scores[13] = auc_roc;
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -180,12 +178,11 @@ PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscRe
   /* Header */
   PetscCall(PetscViewerASCIIPushTab(v));
   PetscCall(PetscViewerASCIIPrintf(v,"label\tprecision\trecall\tF1\tJaccard index\n"));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[0],scores[3],scores[6] ,scores[9] ,scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[1],scores[2],scores[5] ,scores[8] ,scores[11]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean  \t%.2f\t\t%.2f\t%.2f\t%.2f\n" ,scores[4],scores[7],scores[10],scores[13]));
-  PetscCall(PetscViewerASCIIPrintf(v,"accuracy          = %.2f%%\n",(double) scores[0] * 100));
-  PetscCall(PetscViewerASCIIPrintf(v,"accuracy_balanced = %.2f%%\n",(double) scores[1] * 100));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc           = %.2f%%\n",(double) scores[14] * 100));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[0],scores[2],scores[5],scores[8],scores[11]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[1],scores[1],scores[4],scores[7],scores[10]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean  \t%.2f\t\t%.2f\t%.2f\t%.2f\n"          ,scores[3],scores[6],scores[9],scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v,"accuracy = %.2f%%\n",(double) scores[0] * 100));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc  = %.2f%%\n",(double) scores[13] * 100));
   PetscCall(PetscViewerASCIIPopTab(v));
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -181,9 +181,9 @@ PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscRe
   PetscCall(PetscViewerASCIIPrintf(v,"Classification report:\n"));
   PetscCall(PetscViewerASCIIPushTab(v));
   PetscCall(PetscViewerASCIIPrintf(v,"label\tprecision\trecall\tF1\tJaccard index\n"));
-  PetscCall(PetscViewerASCIIPrintf(v,"0.0  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",scores[2],scores[5],scores[8] ,scores[11]));
-  PetscCall(PetscViewerASCIIPrintf(v,"1.0  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",scores[3],scores[6],scores[9] ,scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean \t%.2f\t\t%.2f\t%.2f\t%.2f\n",scores[4],scores[7],scores[10],scores[13]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[0],scores[2],scores[5] ,scores[8] ,scores[11]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[1],scores[3],scores[6] ,scores[9] ,scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean \t%.2f\t\t%.2f\t%.2f\t%.2f\n" ,scores[4],scores[7],scores[10],scores[13]));
   PetscCall(PetscViewerASCIIPrintf(v,"accuracy          = %.2f%%\n",(double) scores[0] * 100));
   PetscCall(PetscViewerASCIIPrintf(v,"accuracy_balanced = %.2f%%\n",(double) scores[1] * 100));
   PetscCall(PetscViewerASCIIPrintf(v,"auc_roc           = %.2f%%\n",(double) scores[14] * 100));

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -178,11 +178,11 @@ PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscRe
   /* Header */
   PetscCall(PetscViewerASCIIPushTab(v));
   PetscCall(PetscViewerASCIIPrintf(v,"label\tprecision\trecall\tF1\tJaccard index\n"));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[0],scores[2],scores[5],scores[8],scores[11]));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[1],scores[1],scores[4],scores[7],scores[10]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean  \t%.2f\t\t%.2f\t%.2f\t%.2f\n"          ,scores[3],scores[6],scores[9],scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"accuracy = %.2f%%\n",(double) scores[0] * 100));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc  = %.2f%%\n",(double) scores[13] * 100));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[0],scores[2],scores[5],scores[8],scores[11]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[1],scores[1],scores[4],scores[7],scores[10]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean  \t%.4f\t\t%.4f\t%.4f\t%.4f\n"          ,scores[3],scores[6],scores[9],scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v,"accuracy = %.4f\n",(double) scores[0]));
+  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc  = %.4f\n",(double) scores[13]));
   PetscCall(PetscViewerASCIIPopTab(v));
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -65,8 +65,6 @@ PetscErrorCode BinaryConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt con
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-#undef __FUNCT__
-#define __FUNCT__ "SVMGetBinaryClassificationReport"
 PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,PetscInt *cmat, PetscReal *scores)
 {
   PetscInt  confusion_mat[4];
@@ -85,7 +83,7 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
 
   PetscInt  i;
 
-  PetscFunctionBeginI;
+  PetscFunctionBegin;
   PetscCall(BinaryConfusionMatrix(svm,y_pred,y_known,confusion_mat));
 
   TP = confusion_mat[0];
@@ -98,7 +96,7 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   }
 
   if (scores == NULL) {
-    PetscFunctionReturnI(PETSC_SUCCESS);
+    PetscFunctionReturn(PETSC_SUCCESS);
   }
 
   precision[0] = (PetscReal) TP / (PetscReal) (TP + FP); /* precision (positive class) */
@@ -115,7 +113,7 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
 
   jaccard_index[0] = (PetscReal) TP / (PetscReal) (TP + FP + FN); /* Jaccard index (positive class) */
   jaccard_index[1] = (PetscReal) TN / (PetscReal) (TN + FN + FP); /* Jaccard index (negative class) */
-  jaccard_index[2] = (jaccard_index[0] + jaccard_index[1]) / 2.;  /* Jaccard index (negative class) */
+  jaccard_index[2] = (jaccard_index[0] + jaccard_index[1]) / 2.;  /* Jaccard index (average) */
 
   /* Area under curve (trapezoidal rule) */
   specifity = (PetscReal) TN / (PetscReal) (TN + FP);
@@ -158,7 +156,7 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
 
   scores[14] = auc_roc;
 
-  PetscFunctionReturnI(PETSC_SUCCESS);
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscReal *scores,PetscViewer v)
@@ -179,15 +177,15 @@ PetscErrorCode SVMPrintBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscRe
 
   /* Print classification report */
   PetscCall(PetscViewerASCIIPrintf(v,"Classification report:\n"));
+  /* Header */
   PetscCall(PetscViewerASCIIPushTab(v));
   PetscCall(PetscViewerASCIIPrintf(v,"label\tprecision\trecall\tF1\tJaccard index\n"));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[0],scores[2],scores[5] ,scores[8] ,scores[11]));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[1],scores[3],scores[6] ,scores[9] ,scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean \t%.2f\t\t%.2f\t%.2f\t%.2f\n" ,scores[4],scores[7],scores[10],scores[13]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[0],scores[3],scores[6] ,scores[9] ,scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.2f\t\t%.2f\t%.2f\t%.2f\n",labels[1],scores[2],scores[5] ,scores[8] ,scores[11]));
+  PetscCall(PetscViewerASCIIPrintf(v,"mean  \t%.2f\t\t%.2f\t%.2f\t%.2f\n" ,scores[4],scores[7],scores[10],scores[13]));
   PetscCall(PetscViewerASCIIPrintf(v,"accuracy          = %.2f%%\n",(double) scores[0] * 100));
   PetscCall(PetscViewerASCIIPrintf(v,"accuracy_balanced = %.2f%%\n",(double) scores[1] * 100));
   PetscCall(PetscViewerASCIIPrintf(v,"auc_roc           = %.2f%%\n",(double) scores[14] * 100));
   PetscCall(PetscViewerASCIIPopTab(v));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
-/* TODO print classification report */

--- a/src/svm/utils/report.h
+++ b/src/svm/utils/report.h
@@ -4,6 +4,6 @@
 
 #include <permonsvm.h>
 
-FLLOP_EXTERN PetscErrorCode ClassificationReport(SVM,Vec,Vec);
+FLLOP_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM,Vec,Vec,PetscInt *,PetscReal *);
 
 #endif //__REPORT_H

--- a/src/svm/utils/report.h
+++ b/src/svm/utils/report.h
@@ -5,5 +5,6 @@
 #include <permonsvm.h>
 
 FLLOP_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM,Vec,Vec,PetscInt *,PetscReal *);
+FLLOP_EXTERN PetscErrorCode SVMPrintBinaryClassificationReport(SVM,PetscInt *,PetscReal *,PetscViewer);
 
 #endif //__REPORT_H

--- a/src/svm/utils/report.h
+++ b/src/svm/utils/report.h
@@ -1,0 +1,9 @@
+
+#if !defined(__REPORT_H)
+#define	__REPORT_H
+
+#include <permonsvm.h>
+
+FLLOP_EXTERN PetscErrorCode ClassificationReport(SVM,Vec,Vec);
+
+#endif //__REPORT_H

--- a/src/svm/utils/report.h
+++ b/src/svm/utils/report.h
@@ -1,10 +1,10 @@
 
-#if !defined(__REPORT_H)
-#define	__REPORT_H
+#if !defined(__PERMONSVMREPORT_H)
+#define	__PERMONSVMREPORT_H
 
 #include <permonsvm.h>
 
 FLLOP_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM,Vec,Vec,PetscInt *,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMPrintBinaryClassificationReport(SVM,PetscInt *,PetscReal *,PetscViewer);
+FLLOP_EXTERN PetscErrorCode SVMViewBinaryClassificationReport(SVM,PetscInt *,PetscReal *,PetscViewer);
 
 #endif //__REPORT_H

--- a/src/tutorials/ex1.c
+++ b/src/tutorials/ex1.c
@@ -66,7 +66,7 @@ int main(int argc,char **argv)
 
   test:
     filter: grep -v MPI
-    args: -qps_view_convergence -svm_view -svm_view_score
+    args: -qps_view_convergence -svm_view -svm_view_report
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin -f_kernel $PERMON_SVM_DIR/src/tutorials/data/heart_scale.kernel.bin
     args: -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin
     output_file: output/exbinfile_1.out

--- a/src/tutorials/ex2.c
+++ b/src/tutorials/ex2.c
@@ -69,7 +69,7 @@ int main(int argc,char **argv)
   test:
     filter: grep -v MPI
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin
-    args: -cross_svm_view -cross_svm_view_score -cross_qps_view_convergence
-    args: -svm_view -svm_view_score -qps_view_convergence
+    args: -cross_svm_view -cross_svm_view_report -cross_qps_view_convergence
+    args: -svm_view -svm_view_report -qps_view_convergence
     output_file: output/ex2.out
 TEST*/

--- a/src/tutorials/ex3.c
+++ b/src/tutorials/ex3.c
@@ -73,9 +73,9 @@ int main(int argc,char **argv)
 
   test:
     filter: grep -v MPI
-    args: -qps_view_convergence -svm_view -svm_view_score
+    args: -qps_view_convergence -svm_view -svm_view_report
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
     args: -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin
-    args: -view_training_predictions -view_test_predictions
+    args: -svm_view_training_predictions -svm_view_test_predictions
     output_file: output/ex3.out
 TEST*/

--- a/src/tutorials/ex4.c
+++ b/src/tutorials/ex4.c
@@ -55,7 +55,7 @@ int main(int argc,char **argv)
   test:
     suffix: duality_gap
     filter: grep -v MPI
-    args: -qps_view_convergence -svm_view -svm_view_score -svm_binary_convergence_test duality_gap
+    args: -qps_view_convergence -svm_view -svm_view_report -svm_binary_convergence_test duality_gap
     args: -svm_loss_type L2
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
     args: -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin
@@ -64,7 +64,7 @@ int main(int argc,char **argv)
   test:
     suffix: dual_violation
     filter: grep -v MPI
-    args: -qps_view_convergence -svm_view -svm_view_score -svm_binary_convergence_test dual_violation
+    args: -qps_view_convergence -svm_view -svm_view_report -svm_binary_convergence_test dual_violation
     args: -svm_loss_type L1 -svm_binary_mod 2 -qps_atol 1e-2
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
     args: -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -53,9 +53,13 @@ int main(int argc,char **argv)
 /*TEST
 
   test:
-
-    args: -svm_loss_type L2 -svm_view_io
+    filter: grep -v MPI
+    args: -uncalibrated_svm_loss_type L1 -svm_view_io
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
     args: -f_calibration $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
-
+    args: -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin
+    args: -tao_type nls tao_view -svm_view_report
+    args: -view_test_predictions
+    args: -svm_threshold 0.47
+    output_file: output/ex5.out
 TEST*/

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -5,13 +5,33 @@ static char help[] = "";
 
 int main(int argc,char **argv)
 {
-  SVM svm;
+  SVM         svm;
+
+  // TODO change to data set containing calibration data set
+  char        training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char        calibration_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+
+  PetscViewer viewer;
 
   PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+
+  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
+  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_calibration",calibration_file,sizeof(calibration_file),NULL));
 
   /* Create SVM object */
   PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
   PetscCall(SVMSetType(svm,SVM_PROBABILITY));
+  PetscCall(SVMSetFromOptions(svm));
+
+  /* Load training data set */
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
+  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(PetscViewerDestroy(&viewer));
+
+  /* Load calibration data set */
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,calibration_file,FILE_MODE_READ,&viewer));
+  PetscCall(SVMLoadCalibrationDataset(svm,viewer));
+  PetscCall(PetscViewerDestroy(&viewer));
 
   /* Free memory */
   PetscCall(SVMDestroy(&svm));
@@ -24,6 +44,7 @@ int main(int argc,char **argv)
 
   test:
 
-    args: -svm_loss_type L2
+    args: -svm_loss_type L2 -svm_view_io
+    args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
 
 TEST*/

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -33,6 +33,8 @@ int main(int argc,char **argv)
   PetscCall(SVMLoadCalibrationDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
+  PetscCall(SVMTrain(svm));
+
   /* Free memory */
   PetscCall(SVMDestroy(&svm));
   PetscCall(PermonFinalize());
@@ -46,5 +48,6 @@ int main(int argc,char **argv)
 
     args: -svm_loss_type L2 -svm_view_io
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
+    args: -f_calibration $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
 
 TEST*/

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -3,22 +3,44 @@ static char help[] = "";
 
 #include <permonsvm.h>
 
+#define h5       "h5"
+#define bin      "bin"
+#define SVMLight "svmlight"
+
+PetscErrorCode GetFilenameExtension(const char *filename,char **extension)
+{
+  char   *extension_inner;
+
+  PetscFunctionBegin;
+  PetscCall(PetscStrrchr(filename,'.',&extension_inner));
+  *extension = extension_inner;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 int main(int argc,char **argv)
 {
-  SVM         svm;
+  SVM  svm;
 
-  // TODO change to data set containing calibration data set
-  char        training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char        calibration_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char        test_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.t.bin";
+  char training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char calibration_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char test_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.t.bin";
+  char training_result_file[PETSC_MAX_PATH_LEN] = "";
+  char test_result_file[PETSC_MAX_PATH_LEN]     = "";
+  char *extension=NULL;
+
+  PetscBool training_result_file_set=PETSC_FALSE,test_result_file_set=PETSC_FALSE;
+  PetscBool ishdf5,isbinary,issvmlight;
 
   PetscViewer viewer;
 
   PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
 
   PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_calibration",calibration_file,sizeof(calibration_file),NULL));
+  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_calib",calibration_file,sizeof(calibration_file),NULL));
   PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),NULL));
+  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training_predictions",training_result_file,sizeof(training_result_file),&training_result_file_set));
+  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test_predictions",test_result_file,sizeof(test_result_file),&test_result_file_set));
+
 
   /* Create SVM object */
   PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
@@ -26,22 +48,105 @@ int main(int argc,char **argv)
   PetscCall(SVMSetFromOptions(svm));
 
   /* Load training data set */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
+  PetscCall(GetFilenameExtension(training_file,&extension));
+  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
+  PetscCall(PetscStrcmp(extension,bin,&isbinary));
+  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+  if (ishdf5) {
+#if defined(PETSC_HAVE_HDF5)
+    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
+#else
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+#endif
+  } else if (isbinary) {
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
+  } else if (issvmlight) {
+    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,training_file,&viewer));
+  } else {
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
+  }
   PetscCall(SVMLoadTrainingDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load calibration data set */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,calibration_file,FILE_MODE_READ,&viewer));
+  PetscCall(GetFilenameExtension(calibration_file,&extension));
+  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
+  PetscCall(PetscStrcmp(extension,bin,&isbinary));
+  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+  if (ishdf5) {
+#if defined(PETSC_HAVE_HDF5)
+    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,calibration_file,FILE_MODE_READ,&viewer));
+#else
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+#endif
+  } else if (isbinary) {
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,calibration_file,FILE_MODE_READ,&viewer));
+  } else if (issvmlight) {
+    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,calibration_file,&viewer));
+  } else {
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
+  }
   PetscCall(SVMLoadCalibrationDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load test data set */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
+  PetscCall(GetFilenameExtension(test_file,&extension));
+  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
+  PetscCall(PetscStrcmp(extension,bin,&isbinary));
+  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+  if (ishdf5) {
+#if defined(PETSC_HAVE_HDF5)
+    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
+#else
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+#endif
+  } else if (isbinary) {
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
+  } else if (issvmlight) {
+    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,test_file,&viewer));
+  } else {
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
+  }
   PetscCall(SVMLoadTestDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   PetscCall(SVMTrain(svm));
   PetscCall(SVMTest(svm));
+
+  /* Save results */
+  if (training_result_file_set) {
+    PetscCall(GetFilenameExtension(training_result_file,&extension));
+    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
+    PetscCall(PetscStrcmp(extension,bin,&isbinary));
+    if (ishdf5) {
+#if defined(PETSC_HAVE_HDF5)
+      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,training_result_file,FILE_MODE_WRITE,&viewer));
+#else
+      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+#endif
+    } else {
+      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_result_file,FILE_MODE_WRITE,&viewer));
+    }
+    PetscCall(SVMViewTrainingPredictions(svm,viewer));
+    PetscCall(PetscViewerDestroy(&viewer));
+  }
+
+  if (test_result_file_set) {
+    PetscCall(GetFilenameExtension(test_result_file,&extension));
+    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
+    PetscCall(PetscStrcmp(extension,bin,&isbinary));
+    if (ishdf5) {
+#if defined(PETSC_HAVE_HDF5)
+      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,test_result_file,FILE_MODE_WRITE,&viewer));
+#else
+      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+#endif
+    } else {
+      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_result_file,FILE_MODE_WRITE,&viewer));
+    }
+    PetscCall(SVMViewTestPredictions(svm,viewer));
+    PetscCall(PetscViewerDestroy(&viewer));
+  }
 
   /* Free memory */
   PetscCall(SVMDestroy(&svm));
@@ -56,10 +161,10 @@ int main(int argc,char **argv)
     filter: grep -v MPI
     args: -uncalibrated_svm_loss_type L1 -svm_view_io
     args: -f_training $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
-    args: -f_calibration $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
+    args: -f_calib $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin
     args: -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin
-    args: -tao_type nls tao_view -svm_view_report
-    args: -view_test_predictions
+    args: -tao_type nls -tao_view -svm_view_report
+    args: -svm_view_test_predictions
     args: -svm_threshold 0.47
     output_file: output/ex5.out
 TEST*/

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -17,21 +17,52 @@ PetscErrorCode GetFilenameExtension(const char *filename,char **extension)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+PetscErrorCode ViewerOpen(const char *filename,PetscFileMode mode,PetscViewer *viewer)
+{
+  PetscViewer  inner_viewer;
+
+  char        *extension=NULL;
+  PetscBool    ishdf5,isbinary,issvmlight;
+
+  PetscFunctionBegin;
+  PetscCall(GetFilenameExtension(filename,&extension));
+  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
+  PetscCall(PetscStrcmp(extension,bin,&isbinary));
+  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+
+  if (ishdf5) {
+#if defined(PETSC_HAVE_HDF5)
+    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,filename,FILE_MODE_READ,&inner_viewer));
+#else
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+#endif
+  } else if (isbinary) {
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,filename,FILE_MODE_READ,&inner_viewer));
+  } else if (issvmlight) {
+    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,filename,&inner_viewer));
+  } else {
+    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
+  }
+
+  *viewer = inner_viewer;
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 int main(int argc,char **argv)
 {
-  SVM  svm;
+  SVM         svm;
+  PetscViewer viewer;
 
-  char training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char calibration_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char test_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.t.bin";
+  char training_file[PETSC_MAX_PATH_LEN]        = "data/heart_scale.bin";
+  char calibration_file[PETSC_MAX_PATH_LEN]     = "data/heart_scale.bin";
+  char test_file[PETSC_MAX_PATH_LEN]            = "data/heart_scale.t.bin";
   char training_result_file[PETSC_MAX_PATH_LEN] = "";
   char test_result_file[PETSC_MAX_PATH_LEN]     = "";
-  char *extension=NULL;
 
-  PetscBool training_result_file_set=PETSC_FALSE,test_result_file_set=PETSC_FALSE;
-  PetscBool ishdf5,isbinary,issvmlight;
+  PetscBool training_result_file_set = PETSC_FALSE;
+  PetscBool test_result_file_set = PETSC_FALSE;
 
-  PetscViewer viewer;
 
   PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
 
@@ -41,109 +72,34 @@ int main(int argc,char **argv)
   PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training_predictions",training_result_file,sizeof(training_result_file),&training_result_file_set));
   PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test_predictions",test_result_file,sizeof(test_result_file),&test_result_file_set));
 
-
   /* Create SVM object */
   PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
   PetscCall(SVMSetType(svm,SVM_PROBABILITY));
   PetscCall(SVMSetFromOptions(svm));
 
-  /* Load training data set */
-  PetscCall(GetFilenameExtension(training_file,&extension));
-  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-  PetscCall(PetscStrcmp(extension,bin,&isbinary));
-  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
-  if (ishdf5) {
-#if defined(PETSC_HAVE_HDF5)
-    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
-#else
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
-#endif
-  } else if (isbinary) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
-  } else if (issvmlight) {
-    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,training_file,&viewer));
-  } else {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
-  }
+  PetscCall(ViewerOpen(training_file,FILE_MODE_READ,&viewer));
   PetscCall(SVMLoadTrainingDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
-  /* Load calibration data set */
-  PetscCall(GetFilenameExtension(calibration_file,&extension));
-  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-  PetscCall(PetscStrcmp(extension,bin,&isbinary));
-  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
-  if (ishdf5) {
-#if defined(PETSC_HAVE_HDF5)
-    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,calibration_file,FILE_MODE_READ,&viewer));
-#else
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
-#endif
-  } else if (isbinary) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,calibration_file,FILE_MODE_READ,&viewer));
-  } else if (issvmlight) {
-    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,calibration_file,&viewer));
-  } else {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
-  }
+  PetscCall(ViewerOpen(calibration_file,FILE_MODE_READ,&viewer));
   PetscCall(SVMLoadCalibrationDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
-  /* Load test data set */
-  PetscCall(GetFilenameExtension(test_file,&extension));
-  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-  PetscCall(PetscStrcmp(extension,bin,&isbinary));
-  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
-  if (ishdf5) {
-#if defined(PETSC_HAVE_HDF5)
-    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
-#else
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
-#endif
-  } else if (isbinary) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
-  } else if (issvmlight) {
-    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,test_file,&viewer));
-  } else {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
-  }
+  PetscCall(ViewerOpen(test_file,FILE_MODE_READ,&viewer));
   PetscCall(SVMLoadTestDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   PetscCall(SVMTrain(svm));
   PetscCall(SVMTest(svm));
 
-  /* Save results */
   if (training_result_file_set) {
-    PetscCall(GetFilenameExtension(training_result_file,&extension));
-    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-    PetscCall(PetscStrcmp(extension,bin,&isbinary));
-    if (ishdf5) {
-#if defined(PETSC_HAVE_HDF5)
-      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,training_result_file,FILE_MODE_WRITE,&viewer));
-#else
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
-#endif
-    } else {
-      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_result_file,FILE_MODE_WRITE,&viewer));
-    }
+    PetscCall(ViewerOpen(training_result_file,FILE_MODE_WRITE,&viewer));
     PetscCall(SVMViewTrainingPredictions(svm,viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   if (test_result_file_set) {
-    PetscCall(GetFilenameExtension(test_result_file,&extension));
-    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-    PetscCall(PetscStrcmp(extension,bin,&isbinary));
-    if (ishdf5) {
-#if defined(PETSC_HAVE_HDF5)
-      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,test_result_file,FILE_MODE_WRITE,&viewer));
-#else
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
-#endif
-    } else {
-      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_result_file,FILE_MODE_WRITE,&viewer));
-    }
+    PetscCall(ViewerOpen(test_result_file,FILE_MODE_WRITE,&viewer));
     PetscCall(SVMViewTestPredictions(svm,viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -10,6 +10,7 @@ int main(int argc,char **argv)
   // TODO change to data set containing calibration data set
   char        training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
   char        calibration_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char        test_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.t.bin";
 
   PetscViewer viewer;
 
@@ -17,6 +18,7 @@ int main(int argc,char **argv)
 
   PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
   PetscCall(PetscOptionsGetString(NULL,NULL,"-f_calibration",calibration_file,sizeof(calibration_file),NULL));
+  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),NULL));
 
   /* Create SVM object */
   PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
@@ -33,7 +35,13 @@ int main(int argc,char **argv)
   PetscCall(SVMLoadCalibrationDataset(svm,viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
+  /* Load test data set */
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
+  PetscCall(SVMLoadTestDataset(svm,viewer));
+  PetscCall(PetscViewerDestroy(&viewer));
+
   PetscCall(SVMTrain(svm));
+  PetscCall(SVMTest(svm));
 
   /* Free memory */
   PetscCall(SVMDestroy(&svm));

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -1,0 +1,29 @@
+
+static char help[] = "";
+
+#include <permonsvm.h>
+
+int main(int argc,char **argv)
+{
+  SVM svm;
+
+  PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+
+  /* Create SVM object */
+  PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
+  PetscCall(SVMSetType(svm,SVM_PROBABILITY));
+
+  /* Free memory */
+  PetscCall(SVMDestroy(&svm));
+  PetscCall(PermonFinalize());
+
+  return 0;
+}
+
+/*TEST
+
+  test:
+
+    args: -svm_loss_type L2
+
+TEST*/

--- a/src/tutorials/exbinfile.c
+++ b/src/tutorials/exbinfile.c
@@ -104,7 +104,7 @@ int main(int argc,char **argv)
 /*TEST
   testset:
     suffix: 1
-    args: -qps_view_convergence -svm_view -svm_view_score
+    args: -qps_view_convergence -svm_view -svm_view_report
     filter: grep -v MPI
     test:
       args: -f $PERMON_SVM_DIR/src/tutorials/data/heart_scale.bin -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.bin
@@ -125,7 +125,7 @@ int main(int argc,char **argv)
     requires: hdf5
     filter: grep -v MPI
     nsize: 2
-    args: -qps_view_convergence -svm_view -svm_view_score
+    args: -qps_view_convergence -svm_view -svm_view_report
     args: -f $PERMON_SVM_DIR/src/tutorials/data/heart_scale.h5 -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.h5
     output_file: output/exbinfile_1.out
 TEST*/

--- a/src/tutorials/makefile
+++ b/src/tutorials/makefile
@@ -13,7 +13,7 @@ LOCDIR      = src/examples
 MANSEC      =
 DOCS        =
 DIRS        =
-CLEANFILES  = exbinfile ex1 ex2 ex3 ex4
+CLEANFILES  = exbinfile ex1 ex2 ex3 ex4 ex5
 
 include ${PERMON_SVM_DIR}/lib/permonsvm/conf/permonsvm_base
 include ${PERMON_SVM_DIR}/lib/permonsvm/conf/permonsvm_test

--- a/src/tutorials/output/ex2.out
+++ b/src/tutorials/output/ex2.out
@@ -20,8 +20,13 @@
     Confusion matrix:
       TP =   26      FP =    5
       FN =    6      TN =   23
-    accuracy=81.67%    precision=83.87%    sensitivity=81.25%
-    F1=0.83    MCC=0.63    AUC_ROC=0.82    G1=0.63
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7931		0.8214	0.8070	0.6765
+      1.0  	0.8387		0.8125	0.8254	0.7027
+      mean  	0.8159		0.8170	0.8162	0.6896
+      accuracy = 0.8167
+      auc_roc  = 0.8170
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 18 iterations
   all 2 QPSSolves from last QPSReset/QPSResetStatistics have required 31 iterations
@@ -44,8 +49,13 @@
     Confusion matrix:
       TP =   26      FP =    5
       FN =    6      TN =   23
-    accuracy=81.67%    precision=83.87%    sensitivity=81.25%
-    F1=0.83    MCC=0.63    AUC_ROC=0.82    G1=0.63
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7931		0.8214	0.8070	0.6765
+      1.0  	0.8387		0.8125	0.8254	0.7027
+      mean  	0.8159		0.8170	0.8162	0.6896
+      accuracy = 0.8167
+      auc_roc  = 0.8170
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 22 iterations
   all 3 QPSSolves from last QPSReset/QPSResetStatistics have required 53 iterations
@@ -68,8 +78,13 @@
     Confusion matrix:
       TP =   27      FP =    4
       FN =    7      TN =   22
-    accuracy=81.67%    precision=87.10%    sensitivity=79.41%
-    F1=0.83    MCC=0.63    AUC_ROC=0.82    G1=0.64
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7586		0.8462	0.8000	0.6667
+      1.0  	0.8710		0.7941	0.8308	0.7105
+      mean  	0.8148		0.8201	0.8154	0.6886
+      accuracy = 0.8167
+      auc_roc  = 0.8201
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 35 iterations
   all 4 QPSSolves from last QPSReset/QPSResetStatistics have required 88 iterations
@@ -92,8 +107,13 @@
     Confusion matrix:
       TP =   29      FP =    2
       FN =    7      TN =   22
-    accuracy=85.00%    precision=93.55%    sensitivity=80.56%
-    F1=0.87    MCC=0.71    AUC_ROC=0.86    G1=0.72
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7586		0.9167	0.8302	0.7097
+      1.0  	0.9355		0.8056	0.8657	0.7632
+      mean  	0.8471		0.8611	0.8479	0.7364
+      accuracy = 0.8500
+      auc_roc  = 0.8611
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 36 iterations
   all 5 QPSSolves from last QPSReset/QPSResetStatistics have required 124 iterations
@@ -116,8 +136,13 @@
     Confusion matrix:
       TP =   27      FP =    4
       FN =    7      TN =   22
-    accuracy=81.67%    precision=87.10%    sensitivity=79.41%
-    F1=0.83    MCC=0.63    AUC_ROC=0.82    G1=0.64
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7586		0.8462	0.8000	0.6667
+      1.0  	0.8710		0.7941	0.8308	0.7105
+      mean  	0.8148		0.8201	0.8154	0.6886
+      accuracy = 0.8167
+      auc_roc  = 0.8201
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 41 iterations
   all 6 QPSSolves from last QPSReset/QPSResetStatistics have required 165 iterations
@@ -140,8 +165,13 @@
     Confusion matrix:
       TP =   27      FP =    4
       FN =    8      TN =   21
-    accuracy=80.00%    precision=87.10%    sensitivity=77.14%
-    F1=0.82    MCC=0.60    AUC_ROC=0.81    G1=0.61
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7241		0.8400	0.7778	0.6364
+      1.0  	0.8710		0.7714	0.8182	0.6923
+      mean  	0.7976		0.8057	0.7980	0.6643
+      accuracy = 0.8000
+      auc_roc  = 0.8057
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 52 iterations
   all 7 QPSSolves from last QPSReset/QPSResetStatistics have required 217 iterations
@@ -164,8 +194,13 @@
     Confusion matrix:
       TP =   26      FP =    5
       FN =    6      TN =   23
-    accuracy=81.67%    precision=83.87%    sensitivity=81.25%
-    F1=0.83    MCC=0.63    AUC_ROC=0.82    G1=0.63
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7931		0.8214	0.8070	0.6765
+      1.0  	0.8387		0.8125	0.8254	0.7027
+      mean  	0.8159		0.8170	0.8162	0.6896
+      accuracy = 0.8167
+      auc_roc  = 0.8170
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 73 iterations
   all 8 QPSSolves from last QPSReset/QPSResetStatistics have required 290 iterations
@@ -188,8 +223,13 @@
     Confusion matrix:
       TP =   27      FP =    4
       FN =    6      TN =   23
-    accuracy=83.33%    precision=87.10%    sensitivity=81.82%
-    F1=0.84    MCC=0.67    AUC_ROC=0.84    G1=0.67
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7931		0.8519	0.8214	0.6970
+      1.0  	0.8710		0.8182	0.8438	0.7297
+      mean  	0.8320		0.8350	0.8326	0.7133
+      accuracy = 0.8333
+      auc_roc  = 0.8350
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 84 iterations
   all 9 QPSSolves from last QPSReset/QPSResetStatistics have required 374 iterations
@@ -212,8 +252,13 @@
     Confusion matrix:
       TP =   27      FP =    4
       FN =    7      TN =   22
-    accuracy=81.67%    precision=87.10%    sensitivity=79.41%
-    F1=0.83    MCC=0.63    AUC_ROC=0.82    G1=0.64
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7586		0.8462	0.8000	0.6667
+      1.0  	0.8710		0.7941	0.8308	0.7105
+      mean  	0.8148		0.8201	0.8154	0.6886
+      accuracy = 0.8167
+      auc_roc  = 0.8201
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 19 iterations
   all 1 QPSSolves from last QPSReset/QPSResetStatistics have required 19 iterations
@@ -236,8 +281,13 @@
     Confusion matrix:
       TP =   23      FP =    7
       FN =    7      TN =   23
-    accuracy=76.67%    precision=76.67%    sensitivity=76.67%
-    F1=0.77    MCC=0.53    AUC_ROC=0.77    G1=0.53
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7667		0.7667	0.7667	0.6216
+      1.0  	0.7667		0.7667	0.7667	0.6216
+      mean  	0.7667		0.7667	0.7667	0.6216
+      accuracy = 0.7667
+      auc_roc  = 0.7667
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 21 iterations
   all 2 QPSSolves from last QPSReset/QPSResetStatistics have required 40 iterations
@@ -260,8 +310,13 @@
     Confusion matrix:
       TP =   23      FP =    7
       FN =    7      TN =   23
-    accuracy=76.67%    precision=76.67%    sensitivity=76.67%
-    F1=0.77    MCC=0.53    AUC_ROC=0.77    G1=0.53
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7667		0.7667	0.7667	0.6216
+      1.0  	0.7667		0.7667	0.7667	0.6216
+      mean  	0.7667		0.7667	0.7667	0.6216
+      accuracy = 0.7667
+      auc_roc  = 0.7667
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 25 iterations
   all 3 QPSSolves from last QPSReset/QPSResetStatistics have required 65 iterations
@@ -284,8 +339,13 @@
     Confusion matrix:
       TP =   23      FP =    7
       FN =    7      TN =   23
-    accuracy=76.67%    precision=76.67%    sensitivity=76.67%
-    F1=0.77    MCC=0.53    AUC_ROC=0.77    G1=0.53
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7667		0.7667	0.7667	0.6216
+      1.0  	0.7667		0.7667	0.7667	0.6216
+      mean  	0.7667		0.7667	0.7667	0.6216
+      accuracy = 0.7667
+      auc_roc  = 0.7667
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 30 iterations
   all 4 QPSSolves from last QPSReset/QPSResetStatistics have required 95 iterations
@@ -308,8 +368,13 @@
     Confusion matrix:
       TP =   22      FP =    8
       FN =    7      TN =   23
-    accuracy=75.00%    precision=73.33%    sensitivity=75.86%
-    F1=0.75    MCC=0.50    AUC_ROC=0.75    G1=0.50
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7667		0.7419	0.7541	0.6053
+      1.0  	0.7333		0.7586	0.7458	0.5946
+      mean  	0.7500		0.7503	0.7499	0.5999
+      accuracy = 0.7500
+      auc_roc  = 0.7503
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 34 iterations
   all 5 QPSSolves from last QPSReset/QPSResetStatistics have required 129 iterations
@@ -332,8 +397,13 @@
     Confusion matrix:
       TP =   22      FP =    8
       FN =    7      TN =   23
-    accuracy=75.00%    precision=73.33%    sensitivity=75.86%
-    F1=0.75    MCC=0.50    AUC_ROC=0.75    G1=0.50
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.7667		0.7419	0.7541	0.6053
+      1.0  	0.7333		0.7586	0.7458	0.5946
+      mean  	0.7500		0.7503	0.7499	0.5999
+      accuracy = 0.7500
+      auc_roc  = 0.7503
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 39 iterations
   all 6 QPSSolves from last QPSReset/QPSResetStatistics have required 168 iterations
@@ -356,8 +426,13 @@
     Confusion matrix:
       TP =   21      FP =    9
       FN =    6      TN =   24
-    accuracy=75.00%    precision=70.00%    sensitivity=77.78%
-    F1=0.74    MCC=0.50    AUC_ROC=0.75    G1=0.51
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8000		0.7273	0.7619	0.6154
+      1.0  	0.7000		0.7778	0.7368	0.5833
+      mean  	0.7500		0.7525	0.7494	0.5994
+      accuracy = 0.7500
+      auc_roc  = 0.7525
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 50 iterations
   all 7 QPSSolves from last QPSReset/QPSResetStatistics have required 218 iterations
@@ -380,8 +455,13 @@
     Confusion matrix:
       TP =   22      FP =    8
       FN =    6      TN =   24
-    accuracy=76.67%    precision=73.33%    sensitivity=78.57%
-    F1=0.76    MCC=0.53    AUC_ROC=0.77    G1=0.54
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8000		0.7500	0.7742	0.6316
+      1.0  	0.7333		0.7857	0.7586	0.6111
+      mean  	0.7667		0.7679	0.7664	0.6213
+      accuracy = 0.7667
+      auc_roc  = 0.7679
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 82 iterations
   all 8 QPSSolves from last QPSReset/QPSResetStatistics have required 300 iterations
@@ -404,8 +484,13 @@
     Confusion matrix:
       TP =   22      FP =    8
       FN =    6      TN =   24
-    accuracy=76.67%    precision=73.33%    sensitivity=78.57%
-    F1=0.76    MCC=0.53    AUC_ROC=0.77    G1=0.54
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8000		0.7500	0.7742	0.6316
+      1.0  	0.7333		0.7857	0.7586	0.6111
+      mean  	0.7667		0.7679	0.7664	0.6213
+      accuracy = 0.7667
+      auc_roc  = 0.7679
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 108 iterations
   all 9 QPSSolves from last QPSReset/QPSResetStatistics have required 408 iterations
@@ -428,8 +513,13 @@
     Confusion matrix:
       TP =   22      FP =    8
       FN =    6      TN =   24
-    accuracy=76.67%    precision=73.33%    sensitivity=78.57%
-    F1=0.76    MCC=0.53    AUC_ROC=0.77    G1=0.54
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8000		0.7500	0.7742	0.6316
+      1.0  	0.7333		0.7857	0.7586	0.6111
+      mean  	0.7667		0.7679	0.7664	0.6213
+      accuracy = 0.7667
+      auc_roc  = 0.7679
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 14 iterations
   all 1 QPSSolves from last QPSReset/QPSResetStatistics have required 14 iterations
@@ -452,8 +542,13 @@
     Confusion matrix:
       TP =   18      FP =    5
       FN =    2      TN =   35
-    accuracy=88.33%    precision=78.26%    sensitivity=90.00%
-    F1=0.84    MCC=0.75    AUC_ROC=0.89    G1=0.77
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.9459		0.8750	0.9091	0.8333
+      1.0  	0.7826		0.9000	0.8372	0.7200
+      mean  	0.8643		0.8875	0.8732	0.7767
+      accuracy = 0.8833
+      auc_roc  = 0.8875
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 19 iterations
   all 2 QPSSolves from last QPSReset/QPSResetStatistics have required 33 iterations
@@ -476,8 +571,13 @@
     Confusion matrix:
       TP =   19      FP =    4
       FN =    2      TN =   35
-    accuracy=90.00%    precision=82.61%    sensitivity=90.48%
-    F1=0.86    MCC=0.79    AUC_ROC=0.90    G1=0.80
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.9459		0.8974	0.9211	0.8537
+      1.0  	0.8261		0.9048	0.8636	0.7600
+      mean  	0.8860		0.9011	0.8923	0.8068
+      accuracy = 0.9000
+      auc_roc  = 0.9011
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 22 iterations
   all 3 QPSSolves from last QPSReset/QPSResetStatistics have required 55 iterations
@@ -500,8 +600,13 @@
     Confusion matrix:
       TP =   20      FP =    3
       FN =    3      TN =   34
-    accuracy=90.00%    precision=86.96%    sensitivity=86.96%
-    F1=0.87    MCC=0.79    AUC_ROC=0.89    G1=0.79
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.9189		0.9189	0.9189	0.8500
+      1.0  	0.8696		0.8696	0.8696	0.7692
+      mean  	0.8942		0.8942	0.8942	0.8096
+      accuracy = 0.9000
+      auc_roc  = 0.8942
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 33 iterations
   all 4 QPSSolves from last QPSReset/QPSResetStatistics have required 88 iterations
@@ -524,8 +629,13 @@
     Confusion matrix:
       TP =   20      FP =    3
       FN =    3      TN =   34
-    accuracy=90.00%    precision=86.96%    sensitivity=86.96%
-    F1=0.87    MCC=0.79    AUC_ROC=0.89    G1=0.79
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.9189		0.9189	0.9189	0.8500
+      1.0  	0.8696		0.8696	0.8696	0.7692
+      mean  	0.8942		0.8942	0.8942	0.8096
+      accuracy = 0.9000
+      auc_roc  = 0.8942
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 45 iterations
   all 5 QPSSolves from last QPSReset/QPSResetStatistics have required 133 iterations
@@ -548,8 +658,13 @@
     Confusion matrix:
       TP =   19      FP =    4
       FN =    4      TN =   33
-    accuracy=86.67%    precision=82.61%    sensitivity=82.61%
-    F1=0.83    MCC=0.72    AUC_ROC=0.86    G1=0.72
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8919		0.8919	0.8919	0.8049
+      1.0  	0.8261		0.8261	0.8261	0.7037
+      mean  	0.8590		0.8590	0.8590	0.7543
+      accuracy = 0.8667
+      auc_roc  = 0.8590
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 55 iterations
   all 6 QPSSolves from last QPSReset/QPSResetStatistics have required 188 iterations
@@ -572,8 +687,13 @@
     Confusion matrix:
       TP =   20      FP =    3
       FN =    5      TN =   32
-    accuracy=86.67%    precision=86.96%    sensitivity=80.00%
-    F1=0.83    MCC=0.72    AUC_ROC=0.86    G1=0.71
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8649		0.9143	0.8889	0.8000
+      1.0  	0.8696		0.8000	0.8333	0.7143
+      mean  	0.8672		0.8571	0.8611	0.7571
+      accuracy = 0.8667
+      auc_roc  = 0.8571
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 72 iterations
   all 7 QPSSolves from last QPSReset/QPSResetStatistics have required 260 iterations
@@ -596,8 +716,13 @@
     Confusion matrix:
       TP =   19      FP =    4
       FN =    5      TN =   32
-    accuracy=85.00%    precision=82.61%    sensitivity=79.17%
-    F1=0.81    MCC=0.69    AUC_ROC=0.84    G1=0.68
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8649		0.8889	0.8767	0.7805
+      1.0  	0.8261		0.7917	0.8085	0.6786
+      mean  	0.8455		0.8403	0.8426	0.7295
+      accuracy = 0.8500
+      auc_roc  = 0.8403
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 89 iterations
   all 8 QPSSolves from last QPSReset/QPSResetStatistics have required 349 iterations
@@ -620,8 +745,13 @@
     Confusion matrix:
       TP =   20      FP =    3
       FN =    5      TN =   32
-    accuracy=86.67%    precision=86.96%    sensitivity=80.00%
-    F1=0.83    MCC=0.72    AUC_ROC=0.86    G1=0.71
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8649		0.9143	0.8889	0.8000
+      1.0  	0.8696		0.8000	0.8333	0.7143
+      mean  	0.8672		0.8571	0.8611	0.7571
+      accuracy = 0.8667
+      auc_roc  = 0.8571
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 116 iterations
   all 9 QPSSolves from last QPSReset/QPSResetStatistics have required 465 iterations
@@ -644,8 +774,13 @@
     Confusion matrix:
       TP =   20      FP =    3
       FN =    4      TN =   33
-    accuracy=88.33%    precision=86.96%    sensitivity=83.33%
-    F1=0.85    MCC=0.76    AUC_ROC=0.88    G1=0.75
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8919		0.9167	0.9041	0.8250
+      1.0  	0.8696		0.8333	0.8511	0.7407
+      mean  	0.8807		0.8750	0.8776	0.7829
+      accuracy = 0.8833
+      auc_roc  = 0.8750
   type: mpgp
   last QPSSolve CONVERGED due to CONVERGED_RTOL, KSPReason=2, required 46 iterations
   all 1 QPSSolves from last QPSReset/QPSResetStatistics have required 46 iterations
@@ -668,5 +803,10 @@
     Confusion matrix:
       TP =   26      FP =   10
       FN =    7      TN =   47
-    accuracy=81.11%    precision=72.22%    sensitivity=78.79%
-    F1=0.75    MCC=0.60    AUC_ROC=0.81    G1=0.61
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8704		0.8246	0.8468	0.7344
+      1.0  	0.7222		0.7879	0.7536	0.6047
+      mean  	0.7963		0.8062	0.8002	0.6695
+      accuracy = 0.8111
+      auc_roc  = 0.8062

--- a/src/tutorials/output/ex3.out
+++ b/src/tutorials/output/ex3.out
@@ -15,13 +15,6 @@
     sum(xi_i)=60.5409
   objective functions:
     primalObj=63.1920    dualObj=61.7067    gap=1.4854
-  type: binary
-  model performance score with training parameters C=1.000, mod=2, loss=L1:
-    Confusion matrix:
-      TP =   27      FP =    9
-      FN =    7      TN =   47
-    accuracy=82.22%    precision=75.00%    sensitivity=79.41%
-    F1=0.77    MCC=0.63    AUC_ROC=0.82    G1=0.63
   type: seq
 -1.
 1.
@@ -203,6 +196,18 @@
 -1.
 -1.
 -1.
+  type: binary
+  model performance score with training parameters C=1.000, mod=2, loss=L1:
+    Confusion matrix:
+      TP =   27      FP =    9
+      FN =    7      TN =   47
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8704		0.8393	0.8545	0.7460
+      1.0  	0.7500		0.7941	0.7714	0.6279
+      mean  	0.8102		0.8167	0.8130	0.6870
+      accuracy = 0.8222
+      auc_roc  = 0.8167
   type: seq
 1.
 -1.

--- a/src/tutorials/output/ex4_dual_violation.out
+++ b/src/tutorials/output/ex4_dual_violation.out
@@ -20,5 +20,10 @@
     Confusion matrix:
       TP =   27      FP =    9
       FN =    8      TN =   46
-    accuracy=81.11%    precision=75.00%    sensitivity=77.14%
-    F1=0.76    MCC=0.60    AUC_ROC=0.80    G1=0.61
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8519		0.8364	0.8440	0.7302
+      1.0  	0.7500		0.7714	0.7606	0.6136
+      mean  	0.8009		0.8039	0.8023	0.6719
+      accuracy = 0.8111
+      auc_roc  = 0.8039

--- a/src/tutorials/output/ex4_duality_gap.out
+++ b/src/tutorials/output/ex4_duality_gap.out
@@ -20,5 +20,10 @@
     Confusion matrix:
       TP =   24      FP =   12
       FN =    8      TN =   46
-    accuracy=77.78%    precision=66.67%    sensitivity=75.00%
-    F1=0.71    MCC=0.53    AUC_ROC=0.77    G1=0.54
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8519		0.7931	0.8214	0.6970
+      1.0  	0.6667		0.7500	0.7059	0.5455
+      mean  	0.7593		0.7716	0.7637	0.6212
+      accuracy = 0.7778
+      auc_roc  = 0.7716

--- a/src/tutorials/output/ex5.out
+++ b/src/tutorials/output/ex5.out
@@ -66,11 +66,11 @@
       FN =    7      TN =   47
     Classification report:
       label	precision	recall	F1	Jaccard index
-      -1.0  	0.87		0.84	0.85	0.75
-      1.0  	0.75		0.79	0.77	0.63
-      mean  	0.81		0.82	0.81	0.69
-      accuracy = 82.22%
-      auc_roc  = 81.67%
+      -1.0  	0.8393		0.8704	0.8545	0.7460
+      1.0  	0.7941		0.7500	0.7714	0.6279
+      mean  	0.8167		0.8102	0.8130	0.6870
+      accuracy = 0.8222
+      auc_roc  = 0.8548
   type: probability
   model performance scores with threshold=0.47
     Confusion matrix:
@@ -78,11 +78,11 @@
       FN =    7      TN =   47
     Classification report:
       label	precision	recall	F1	Jaccard index
-      -1.0  	0.87		0.85	0.86	0.76
-      1.0  	0.78		0.80	0.79	0.65
-      mean  	0.82		0.83	0.83	0.70
-      accuracy = 83.33%
-      auc_roc  = 82.73%
+      -1.0  	0.8545		0.8704	0.8624	0.7581
+      1.0  	0.8000		0.7778	0.7887	0.6512
+      mean  	0.8273		0.8241	0.8256	0.7046
+      accuracy = 0.8333
+      auc_roc  = 0.8625
   type: seq
 0.692152
 0.358265

--- a/src/tutorials/output/ex5.out
+++ b/src/tutorials/output/ex5.out
@@ -1,0 +1,176 @@
+  type: probability
+    type: shell
+    Samples are augmented with additional dimension by means of bias 1.00
+      type: seqaij
+      samples	  180
+      samples+	   84 (46.67%)
+      samples-	   96 (53.33%)
+      features	   13 (14)
+  type: probability
+    type: shell
+    Samples are augmented with additional dimension by means of bias 1.00
+      type: seqaij
+      samples	  180
+      samples+	   84 (46.67%)
+      samples-	   96 (53.33%)
+      features	   13 (14)
+  type: probability
+    type: shell
+    Samples are augmented with additional dimension by means of bias 1.00
+      type: seqaij
+      samples	   90
+      samples+	   36 (40.00%)
+      samples-	   54 (60.00%)
+      features	   13 (14)
+  type: nls
+    Newton steps: 4
+    BFGS steps: 0
+    Gradient steps: 0
+    nls ksp atol: 0
+    nls ksp rtol: 4
+    nls ksp ctol: 0
+    nls ksp negc: 0
+    nls ksp dtol: 0
+    nls ksp iter: 0
+    nls ksp othr: 0
+    type: more-thuente
+    maximum function evaluations=30
+    tolerances: ftol=0.0001, rtol=1e-10, gtol=0.9
+    total number of function evaluations=0
+    total number of gradient evaluations=0
+    total number of function/gradient evaluations=1
+    Termination reason: 1
+    type: stcg
+    maximum iterations=10000, initial guess is zero
+    tolerances:  relative=1e-05, absolute=1e-50, divergence=10000.
+    left preconditioning
+    using UNPRECONDITIONED norm type for convergence test
+    type: none
+    linear system matrix = precond matrix:
+      type: seqdense
+      rows=2, cols=2
+      total: nonzeros=4, allocated nonzeros=4
+      total number of mallocs used during MatSetValues calls=0
+  total KSP iterations: 8
+  convergence tolerances: gatol=1e-05,   steptol=0.,   gttol=1e-05
+  Residual in Function/Gradient:=4.68591e-05
+  Objective value=65.4017
+  total number of iterations=4,                          (max: 50)
+  total number of function/gradient evaluations=11,      (max: -1)
+  total number of Hessian evaluations=5
+  Solution converged:    ||g(X)||/|f(X)| <= grtol
+  type: binary
+  model performance score with training parameters C=1.000, mod=2, loss=L1:
+    Confusion matrix:
+      TP =   27      FP =    9
+      FN =    7      TN =   47
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.87		0.84	0.85	0.75
+      1.0  	0.75		0.79	0.77	0.63
+      mean  	0.81		0.82	0.81	0.69
+      accuracy = 82.22%
+      auc_roc  = 81.67%
+  type: probability
+  model performance scores with threshold=0.47
+    Confusion matrix:
+      TP =   28      FP =    8
+      FN =    7      TN =   47
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.87		0.85	0.86	0.76
+      1.0  	0.78		0.80	0.79	0.65
+      mean  	0.82		0.83	0.83	0.70
+      accuracy = 83.33%
+      auc_roc  = 82.73%
+  type: seq
+0.692152
+0.358265
+0.0623699
+0.0593597
+0.0847497
+0.472362
+0.77028
+0.0183972
+0.278786
+0.0661922
+0.0951332
+0.586362
+0.627691
+0.680918
+0.288899
+0.203907
+0.65593
+0.256481
+0.848288
+0.245754
+0.906959
+0.211236
+0.556919
+0.236021
+0.462092
+0.991112
+0.44014
+0.856051
+0.0359142
+0.0372889
+0.0147937
+0.232595
+0.601132
+0.0970305
+0.234534
+0.59317
+0.977234
+0.0492996
+0.837759
+0.233478
+0.0453023
+0.125797
+0.154484
+0.430019
+0.020125
+0.0233663
+0.134965
+0.858371
+0.570209
+0.555925
+0.112219
+0.0179949
+0.0885379
+0.862473
+0.0729776
+0.986202
+0.32474
+0.832726
+0.105283
+0.0394994
+0.992305
+0.992444
+0.868949
+0.693327
+0.838868
+0.253403
+0.0660132
+0.347135
+0.217783
+0.0847328
+0.15682
+0.31687
+0.0681114
+0.0663353
+0.0733602
+0.00893696
+0.0408054
+0.544612
+0.589336
+0.0807493
+0.0295832
+0.773323
+0.0383432
+0.951364
+0.806235
+0.985183
+0.643099
+0.079696
+0.974547
+0.0474249

--- a/src/tutorials/output/exbinfile_1.out
+++ b/src/tutorials/output/exbinfile_1.out
@@ -20,5 +20,10 @@
     Confusion matrix:
       TP =   27      FP =    9
       FN =    7      TN =   47
-    accuracy=82.22%    precision=75.00%    sensitivity=79.41%
-    F1=0.77    MCC=0.63    AUC_ROC=0.82    G1=0.63
+    Classification report:
+      label	precision	recall	F1	Jaccard index
+      -1.0  	0.8704		0.8393	0.8545	0.7460
+      1.0  	0.7500		0.7941	0.7714	0.6279
+      mean  	0.8102		0.8167	0.8130	0.6870
+      accuracy = 0.8222
+      auc_roc  = 0.8167


### PR DESCRIPTION
This pull request implements the Platt scaling technique for transforming raw predictions of the  SVM model, i.e. distance a sample from a separating hyperplane, to probability distribution over classes. It works by fitting a logistic regression model over the CSVM model. 