### PR TITLE
Setup right Mat and Vec types for HDF5 viewer to use PETSc GPU backend

### DIFF
--- a/src/svm/utils/io.c
+++ b/src/svm/utils/io.c
@@ -390,8 +390,11 @@ PetscErrorCode DatasetLoad_Binary(Mat Xt,Vec y,PetscViewer v)
 
   PetscCall(PetscObjectSetName((PetscObject) Xt,"X"));
   PetscCall(MatLoad(Xt,v));
+  PetscCall(MatSetFromOptions(Xt));
+
   PetscCall(PetscObjectSetName((PetscObject) y,"y"));
   PetscCall(VecLoad(y,v));
+  PetscCall(VecSetFromOptions(y));
 
   PetscCall(PetscObjectSetName((PetscObject) Xt,Xt_name));
   PetscCall(PetscObjectSetName((PetscObject) y,y_name));


### PR DESCRIPTION
This small PR adds call to `MatSetFromOptions` and `VecSetFromOptions` when loading these objects from binary file format like HDF5.

These changes are necessary to ensure that Mat and Vec objects have the correct types when targeting a computation on GPUs.