### PR TITLE
Set the default vector type of svm_binary->J to match that of H in SV…

### DIFF
--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -653,6 +653,7 @@ PetscErrorCode SVMComputeOperator_Binary(SVM svm,Mat *A)
 
   Vec         y;
   Vec         diag,diag_p,diag_n;
+  VecType     vtype;
 
   PetscInt    p;         /* penalty type */
   SVMLossType loss_type;
@@ -723,6 +724,11 @@ PetscErrorCode SVMComputeOperator_Binary(SVM svm,Mat *A)
 
       PetscCall(MatCreateDiag(diag,&svm_binary->J));
     }
+
+    /* Set the default vector type for svm_binary->J to match that of H.
+       This is needed for consistency if we want to use GPU back-ends! */
+    PetscCall(MatGetVecType(H,&vtype));
+    PetscCall(MatSetVecType(svm_binary->J,vtype));
 
     mats[0] = svm_binary->J;
     mats[1] = H;


### PR DESCRIPTION
This MR sets the default vector type of svm_binary->J to match that of H in SVMComputeOperator_Binary(). This fixes problems with inconsistent vector types when using GPU back-ends.

Note that for GPU back-ends to work correctly, one also needs the fixes in `rmills/fix-matcomposite-defaultvectype/release` that I pushed today to the PETSc Gitlab repository. (But this will hopefully be merged in soon.)

Update: The fix in `rmills/fix-matcomposite-defaultvectype/release` has been merged into petsc-release.