### PR TITLE
follow PETSc style guide

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,209 @@
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveMacros: Consecutive
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: Consecutive
+AlignEscapedNewlines: DontAlign
+AlignOperands: AlignAfterOperator
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+  - PERMON_EXTERN
+  - PERMON_INTERN
+  - PETSC_EXTERN
+  - PETSC_INTERN
+  - PETSC_UNUSED
+  - PETSC_RESTRICT
+  - PETSC_SINGLE_LIBRARY_INTERN
+  - PETSC_ATTRIBUTE_FORMAT
+  - PETSC_ATTRIBUTE_MPI_TYPE_TAG
+  - PETSC_ATTRIBUTE_MPI_POINTER_WITH_TYPE
+  - PETSC_ATTRIBUTE_MPI_TYPE_TAG_LAYOUT_COMPATIBLE
+  - PETSC_ATTRIBUTE_COLD
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+# BreakBeforeConceptDeclarations: Allowed
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: AfterColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 250
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+#  - BOOST_FOREACH
+IfMacros:
+  #- PERMON_ASSERT
+  #- PetscCheck
+  #- PetscAssert
+IncludeBlocks: Preserve
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: BeforeHash
+IndentExternBlock: NoIndent
+IndentRequires: false
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PackConstructorInitializers: NextLine
+PenaltyBreakAssignment: 1000000
+PenaltyBreakBeforeFirstCallParameter: 1000000
+PenaltyBreakComment: 300000
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 0
+PenaltyReturnTypeOnItsOwnLine: 1000000
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth: -1
+ReferenceAlignment: Pointer
+ReflowComments: false
+ShortNamespaceLines: 0
+SortIncludes: Never
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+SeparateDefinitionBlocks: Leave
+BitFieldColonSpacing: Both
+Standard: Latest
+StatementAttributeLikeMacros:
+  - PERMON_EXTERN
+  - PERMON_INTERN
+  - PETSC_EXTERN
+  - PETSC_INTERN
+  - PETSC_NODISCARD
+  - PETSC_DEPRECATED_FUNCTION
+  - PETSC_DEPRECATED_ENUM
+  - PETSC_DEPRECATED_TYPEDEF
+  - PETSC_DEPRECATED_MACRO
+StatementMacros:
+  - PetscKernel_A_gets_transpose_A_DECLARE
+  - PETSC_RETURNS
+  - PETSC_DECLTYPE_AUTO_RETURNS
+  - PETSC_NOEXCEPT_AUTO_RETURNS
+  - PETSC_DECLTYPE_NOEXCEPT_AUTO_RETURNS
+  - PETSC_UNUSED
+  - PetscPragmaOMP
+  - PetscPragmaUseOMPKernels
+  - PetscPragmaSIMD
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_BEGIN
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_BEGIN_
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_END
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_END_
+  - _Pragma
+TypeNames:
+  - PetscScalar
+  - PetscComplex
+  - PetscReal
+  - PetscInt
+  - PetscMPIInt
+  - PetscBLASInt
+  - PetscErrorCode
+  - PetscBool
+  - PetscBool3
+TabWidth: 2
+UseCRLF: false
+UseTab: Never
+WhitespaceSensitiveMacros:
+  - PetscStringize
+  - PetscStringize_
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_BEGIN
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_BEGIN_
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_END
+  - PETSC_PRAGMA_DIAGNOSTIC_IGNORED_END_
+  - _Pragma
+  - PETSC_DEPRECATED_IDENTIFIER
+  - PETSC_DEPRECATED_IDENTIFIER_
+  - PETSC_VALID_POINTER_IMPL_SPECIALIZATION
+  - _Generic
+  - PETSC_GENERIC_CV
+  - PetscMacroReturnStandard
+TypenameMacros:
+  - khash_t
+InsertNewlineAtEOF: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+Contributions are appreciated and encouraged.
+They can be sumitted via GitHub pull request to
+
+  https://github.com/permon/permonsvm
+
+If you are planning a large contribution, we
+encourage you to discuss the concept by creating an issue and interact
+with us frequently to ensure that your effort is well-directed.
+
+## Guidelines
+PERMON follows PETSc code standards.
+Please read the code standards chapter of the PETSc developer guide https://petsc.org/release/developers/style/. The code style can be checked and mostly enforced by running
+```
+make checkbadsource
+make permonclangformat
+```
+
+Before filing a pull request (PR):
+
+- If your contribution can be logically decomposed into 2 or more separate contributions, submit them in sequence with different branches instead of all at once.
+- Include tests which cover any changes to the source code.
+- Before submitting any PR, run the full test suite - i.e `make alltests TIMEOUT=600` on your machine
+
+## Certificate of Origin
+
+PERMON is distributed under a 2-clause BSD license (see LICENSE).  The
+act of submitting a pull request or patch (with or without an explicit
+Signed-off-by tag) will be understood as an affirmation of the
+following:
+
+  Developer's Certificate of Origin 1.1
+
+  By making a contribution to this project, I certify that:
+
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
+
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PermonSVM - the PERMON SVM classifier
 ====================================
 
-PERMON project homepage: <http://permon.vsb.cz>  
+PERMON project homepage: <http://permon.vsb.cz>
 PermonSVM homepage: <http://permon.vsb.cz/permonsvm.htm>
 
 Please use [GitHub](https://github.com/permon/permonsvm) for issues and pull requests.
@@ -9,30 +9,30 @@ Please use [GitHub](https://github.com/permon/permonsvm) for issues and pull req
 Feature overview
 -----------------
 
-- Scalable (parallel) solution for the linear C-SVM 
+- Scalable (parallel) solution for the linear C-SVM
 - Supported binary classifications:	
 	- standard classification (linear and bound constraints)
 	- relaxed-bias classification (bound constraints)
 - Misclassification error quantification:
 	- _l1_ hinge-loss function
 	- _l2_ hinge-loss function
-- Standard classification solvers: 
-	-  SMALXE + MPRGP (active-set method for bound constrained problems) 
+- Standard classification solvers:
+	-  SMALXE + MPRGP (active-set method for bound constrained problems)
 	-  SMALXE + [The Toolkit for Advance Optimization](https://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/Tao/index.html) (TAO) solvers for minimization with bound constraints
 - Relaxed-bias classification solvers:
 	- MPRGP
-	- TAO solvers for minimization with bound constraints 
-- Warm start  
+	- TAO solvers for minimization with bound constraints
+- Warm start
 - Grid search
 - Cross validation types:
-	- k-fold 
+	- k-fold
 	- stratified k-fold
 - Model perfomance scores:
 	- accuracy
 	- sensitivity
 	- specifity
 	- F1
-	- Matthews correlation coefficient 
+	- Matthews correlation coefficient
 	- Area Under Curve (AUC) Receiver Operating Characteristics (ROC)
 	- Gini coefficient
 - Parallel data loaders:
@@ -62,25 +62,25 @@ Tutorials
 ### Using different classification methods
 
 1. running PermonSVM on 2 MPI processes with default settings (relaxed-bias classification, _l1_ hinge loss, C = 1, B = 1)
-   
- 	```bash 
+
+ 	```bash
  	./runsvmmpi 2 -f_training $DATA_DIR/heart_scale.bin -f_test $DATA_DIR/heart_scale.t.bin
  	```
-  
-2. running PermonSVM on 2 MPI processes with penalty parameter C = 100 
+
+2. running PermonSVM on 2 MPI processes with penalty parameter C = 100
 	
 	```bash
 	./runsvmmpi 2 -f_training $DATA_DIR/heart_scale.bin -f_test $DATA_DIR/heart_scale.t.bin \
 	  -svm_C 100
 	```
-   
+
 3. running PermonSVM on 2 MPI processes with C = 0.01 and _l2_ hinge loss
 
 	```bash
 	./runsvmmpi 2 -f_training $DATA_DIR/heart_scale.bin -f_test $DATA_DIR/heart_scale.t.bin \
 	  -svm_loss_type L2 -svm_C 1e-2
 	```
-  
+
 4. running PermonSVM on 2 MPI processes solving standard classification problem (binary mod 1), missclassification error quantification by _l2_ hinge loss, and C = 0.01
 	
 	```bash
@@ -96,14 +96,14 @@ Tutorials
 	./runsvmmpi 2 -f_training $DATA_DIR/heart_scale.bin -f_test $DATA_DIR/heart_scale.t.bin \
 	  -svm_hyperopt 1
 	```
-   
+
 2. running PermonSVM on 2 MPI processes with grid-search on C = {0.1, 1, 10, 100} combined with cross validation on 3 folds that reuses a previous solution (warm start)
 
 	```bash
 	./runsvmmpi 2 -f_training $DATA_DIR/heart_scale.bin -f_test $DATA_DIR/heart_scale.t.bin \
 	  -svm_hyperopt 1 -svm_gs_logC_base 10 -svm_gs_logC_stride 1,2,1 -svm_nfolds 3 -cross_svm_warm_start 1
 	```
-  
+
 3. running PermonSVM on 2 MPI processes with grid search on C = {0.1, 1, 10, 100} and stratified k-fold cross validation on 3 folds with warm start
 
 	```bash
@@ -111,7 +111,7 @@ Tutorials
 	  -svm_hyperopt 1 -svm_gs_logC_base 10 -svm_gs_logC_stride 1,2,1 -svm_nfolds 3 -cross_svm_warm_start 1 \
 	  -svm_cv_type stratified_kfold
 	```
-   
+
 ### Using precomputed Gramian matrix
 
 PermonSVM uses an implicit representation of the Gramian matrix by default.

--- a/include/permon/private/svmimpl.h
+++ b/include/permon/private/svmimpl.h
@@ -1,6 +1,4 @@
-
-#if !defined(__SVMIMPL_H)
-#define	__SVMIMPL_H
+#pragma once
 
 #include <permon/private/qpsimpl.h>
 #include <permonsvm.h>
@@ -68,6 +66,3 @@ struct _p_SVM {
 
 FLLOP_EXTERN PetscLogEvent SVM_LoadDataset;
 FLLOP_EXTERN PetscLogEvent SVM_LoadGramian;
-
-#endif
-

--- a/include/permon/private/svmimpl.h
+++ b/include/permon/private/svmimpl.h
@@ -64,5 +64,5 @@ struct _p_SVM {
   void *data;
 };
 
-FLLOP_EXTERN PetscLogEvent SVM_LoadDataset;
-FLLOP_EXTERN PetscLogEvent SVM_LoadGramian;
+PERMON_EXTERN PetscLogEvent SVM_LoadDataset;
+PERMON_EXTERN PetscLogEvent SVM_LoadGramian;

--- a/include/permon/private/svmimpl.h
+++ b/include/permon/private/svmimpl.h
@@ -8,58 +8,58 @@ typedef struct _SVMOps *SVMOps;
 struct _SVMOps {
   PetscErrorCode (*reset)(SVM);
   PetscErrorCode (*destroy)(SVM);
-  PetscErrorCode (*setfromoptions)(PetscOptionItems *,SVM);
+  PetscErrorCode (*setfromoptions)(PetscOptionItems *, SVM);
   PetscErrorCode (*setup)(SVM);
   PetscErrorCode (*convergedsetup)(SVM);
   PetscErrorCode (*train)(SVM);
   PetscErrorCode (*posttrain)(SVM);
   PetscErrorCode (*reconstructhyperplane)(SVM);
-  PetscErrorCode (*predict)(SVM,Mat,Vec *);
+  PetscErrorCode (*predict)(SVM, Mat, Vec *);
   PetscErrorCode (*test)(SVM);
   PetscErrorCode (*gridsearch)(SVM);
-  PetscErrorCode (*crossvalidation)(SVM,PetscReal [],PetscInt,PetscReal []);
-  PetscErrorCode (*view)(SVM,PetscViewer);
-  PetscErrorCode (*viewscore)(SVM,PetscViewer);
-  PetscErrorCode (*computemodelscores)(SVM,Vec,Vec);
+  PetscErrorCode (*crossvalidation)(SVM, PetscReal[], PetscInt, PetscReal[]);
+  PetscErrorCode (*view)(SVM, PetscViewer);
+  PetscErrorCode (*viewscore)(SVM, PetscViewer);
+  PetscErrorCode (*computemodelscores)(SVM, Vec, Vec);
   PetscErrorCode (*computehingeloss)(SVM);
   PetscErrorCode (*computemodelparams)(SVM);
-  PetscErrorCode (*loadgramian)(SVM,PetscViewer);
-  PetscErrorCode (*viewgramian)(SVM,PetscViewer);
-  PetscErrorCode (*viewtrainingpredictions)(SVM,PetscViewer);
-  PetscErrorCode (*viewtestpredictions)(SVM,PetscViewer);
+  PetscErrorCode (*loadgramian)(SVM, PetscViewer);
+  PetscErrorCode (*viewgramian)(SVM, PetscViewer);
+  PetscErrorCode (*viewtrainingpredictions)(SVM, PetscViewer);
+  PetscErrorCode (*viewtestpredictions)(SVM, PetscViewer);
 };
 
 struct _p_SVM {
   PETSCHEADER(struct _SVMOps);
 
-  Mat                 Xt_test;
-  Vec                 y_test;
+  Mat Xt_test;
+  Vec y_test;
 
   ModelScore          hopt_score_types[6];
   PetscInt            hopt_nscore_types;
   CrossValidationType cv_type;
 
-  PetscInt            penalty_type;
-  PetscReal           C,C_old;
-  PetscReal           Cp,Cp_old;
-  PetscReal           Cn,Cn_old;
+  PetscInt  penalty_type;
+  PetscReal C, C_old;
+  PetscReal Cp, Cp_old;
+  PetscReal Cn, Cn_old;
 
-  PetscReal           logC_base,logC_start,logC_end,logC_step;
-  PetscReal           logCp_base,logCp_start,logCp_end,logCp_step;
-  PetscReal           logCn_base,logCn_start,logCn_end,logCn_step;
-  PetscInt            nfolds;
+  PetscReal logC_base, logC_start, logC_end, logC_step;
+  PetscReal logCp_base, logCp_start, logCp_end, logCp_step;
+  PetscReal logCn_base, logCn_start, logCn_end, logCn_step;
+  PetscInt  nfolds;
 
-  SVMLossType         loss_type;
-  PetscInt            svm_mod;
-  PetscReal           user_bias;
+  SVMLossType loss_type;
+  PetscInt    svm_mod;
+  PetscReal   user_bias;
 
-  PetscBool           warm_start;
+  PetscBool warm_start;
 
-  PetscBool           hyperoptset;
-  PetscBool           autoposttrain;
-  PetscBool           posttraincalled;
-  PetscBool           setupcalled;
-  PetscBool           setfromoptionscalled;
+  PetscBool hyperoptset;
+  PetscBool autoposttrain;
+  PetscBool posttraincalled;
+  PetscBool setupcalled;
+  PetscBool setfromoptionscalled;
 
   void *data;
 };

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -12,12 +12,12 @@
 
 .seealso:  SVMCreate(), SVMDestroy(), QP, QPS
  S*/
-typedef struct _p_SVM* SVM;
+typedef struct _p_SVM *SVM;
 
 PERMON_EXTERN PetscClassId SVM_CLASSID;
-#define SVM_CLASS_NAME  "svm"
+#define SVM_CLASS_NAME "svm"
 
-#define SVMType  char*
+#define SVMType         char *
 #define SVM_BINARY      "binary"
 #define SVM_PROBABILITY "probability"
 
@@ -28,7 +28,10 @@ PERMON_EXTERN PetscClassId SVM_CLASSID;
 
 .seealso: SVMSetLossType, SVMGetLossType()
 E*/
-typedef enum {SVM_L1, SVM_L2} SVMLossType;
+typedef enum {
+  SVM_L1,
+  SVM_L2
+} SVMLossType;
 PERMON_EXTERN const char *const SVMLossTypes[];
 
 /*MC
@@ -54,7 +57,15 @@ M*/
 
 .seealso SVMGetModelScore()
 E*/
-typedef enum {MODEL_ACCURACY, MODEL_PRECISION, MODEL_SENSITIVITY, MODEL_F1, MODEL_MCC, MODEL_AUC_ROC, MODEL_G1} ModelScore;
+typedef enum {
+  MODEL_ACCURACY,
+  MODEL_PRECISION,
+  MODEL_SENSITIVITY,
+  MODEL_F1,
+  MODEL_MCC,
+  MODEL_AUC_ROC,
+  MODEL_G1
+} ModelScore;
 PERMON_EXTERN const char *const ModelScores[];
 
 /*MC
@@ -120,7 +131,10 @@ M*/
 
 .seealso: CROSS_VALIDATION_KFOLD, CROSS_VALIDATION_STRATIFIED_KFOLD
 E*/
-typedef enum {CROSS_VALIDATION_KFOLD,CROSS_VALIDATION_STRATIFIED_KFOLD} CrossValidationType;
+typedef enum {
+  CROSS_VALIDATION_KFOLD,
+  CROSS_VALIDATION_STRATIFIED_KFOLD
+} CrossValidationType;
 PERMON_EXTERN const char *const CrossValidationTypes[];
 
 /*MC
@@ -143,143 +157,143 @@ PERMON_EXTERN PetscErrorCode SVMInitializePackage();
 PERMON_EXTERN PetscErrorCode SVMFinalizePackage();
 
 PERMON_EXTERN PetscFunctionList SVMList;
-PERMON_EXTERN PetscBool SVMRegisterAllCalled;
-PERMON_EXTERN PetscErrorCode SVMRegisterAll();
-PERMON_EXTERN PetscErrorCode SVMRegister(const char [],PetscErrorCode (*function)(SVM));
+PERMON_EXTERN PetscBool         SVMRegisterAllCalled;
+PERMON_EXTERN PetscErrorCode    SVMRegisterAll();
+PERMON_EXTERN PetscErrorCode    SVMRegister(const char[], PetscErrorCode (*function)(SVM));
 
-PERMON_EXTERN PetscErrorCode SVMCreate(MPI_Comm,SVM *);
-PERMON_EXTERN PetscErrorCode SVMSetType(SVM,const SVMType);
+PERMON_EXTERN PetscErrorCode SVMCreate(MPI_Comm, SVM *);
+PERMON_EXTERN PetscErrorCode SVMSetType(SVM, const SVMType);
 PERMON_EXTERN PetscErrorCode SVMReset(SVM);
 PERMON_EXTERN PetscErrorCode SVMDestroy(SVM *);
 PERMON_EXTERN PetscErrorCode SVMDestroyDefault(SVM);
 PERMON_EXTERN PetscErrorCode SVMSetFromOptions(SVM);
 PERMON_EXTERN PetscErrorCode SVMSetUp(SVM);
-PERMON_EXTERN PetscErrorCode SVMView(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMViewScore(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMView(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewScore(SVM, PetscViewer);
 
-PERMON_EXTERN PetscErrorCode SVMSetGramian(SVM,Mat);
-PERMON_EXTERN PetscErrorCode SVMGetGramian(SVM,Mat *);
-PERMON_EXTERN PetscErrorCode SVMSetOperator(SVM,Mat);
-PERMON_EXTERN PetscErrorCode SVMGetOperator(SVM,Mat *);
-PERMON_EXTERN PetscErrorCode SVMComputeOperator(SVM,Mat *);
+PERMON_EXTERN PetscErrorCode SVMSetGramian(SVM, Mat);
+PERMON_EXTERN PetscErrorCode SVMGetGramian(SVM, Mat *);
+PERMON_EXTERN PetscErrorCode SVMSetOperator(SVM, Mat);
+PERMON_EXTERN PetscErrorCode SVMGetOperator(SVM, Mat *);
+PERMON_EXTERN PetscErrorCode SVMComputeOperator(SVM, Mat *);
 
-PERMON_EXTERN PetscErrorCode SVMSetTrainingDataset(SVM,Mat,Vec);
-PERMON_EXTERN PetscErrorCode SVMGetTrainingDataset(SVM,Mat *,Vec *);
-PERMON_EXTERN PetscErrorCode SVMSetCalibrationDataset(SVM,Mat,Vec);
-PERMON_EXTERN PetscErrorCode SVMGetCalibrationDataset(SVM,Mat *,Vec *);
-PERMON_EXTERN PetscErrorCode SVMSetTestDataset(SVM,Mat,Vec);
-PERMON_EXTERN PetscErrorCode SVMGetTestDataset(SVM,Mat *,Vec *);
+PERMON_EXTERN PetscErrorCode SVMSetTrainingDataset(SVM, Mat, Vec);
+PERMON_EXTERN PetscErrorCode SVMGetTrainingDataset(SVM, Mat *, Vec *);
+PERMON_EXTERN PetscErrorCode SVMSetCalibrationDataset(SVM, Mat, Vec);
+PERMON_EXTERN PetscErrorCode SVMGetCalibrationDataset(SVM, Mat *, Vec *);
+PERMON_EXTERN PetscErrorCode SVMSetTestDataset(SVM, Mat, Vec);
+PERMON_EXTERN PetscErrorCode SVMGetTestDataset(SVM, Mat *, Vec *);
 
-PERMON_EXTERN PetscErrorCode SVMGetLabels(SVM,const PetscReal *[]);
+PERMON_EXTERN PetscErrorCode SVMGetLabels(SVM, const PetscReal *[]);
 
-PERMON_EXTERN PetscErrorCode SVMSetMod(SVM,PetscInt);
-PERMON_EXTERN PetscErrorCode SVMGetMod(SVM,PetscInt *);
-PERMON_EXTERN PetscErrorCode SVMSetLossType(SVM,SVMLossType);
-PERMON_EXTERN PetscErrorCode SVMGetLossType(SVM,SVMLossType *);
-PERMON_EXTERN PetscErrorCode SVMSetPenaltyType(SVM,PetscInt);
-PERMON_EXTERN PetscErrorCode SVMGetPenaltyType(SVM,PetscInt *);
-PERMON_EXTERN PetscErrorCode SVMSetPenalty(SVM,PetscInt,PetscReal []);
-PERMON_EXTERN PetscErrorCode SVMSetC(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGetC(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMSetCp(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGetCp(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMSetCn(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGetCn(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMSetNfolds(SVM,PetscInt);
-PERMON_EXTERN PetscErrorCode SVMGetNfolds(SVM,PetscInt *);
-PERMON_EXTERN PetscErrorCode SVMSetSeparatingHyperplane(SVM,Vec,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGetSeparatingHyperplane(SVM,Vec *,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMSetBias(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGetBias(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMSetUserBias(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGetUserBias(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetMod(SVM, PetscInt);
+PERMON_EXTERN PetscErrorCode SVMGetMod(SVM, PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMSetLossType(SVM, SVMLossType);
+PERMON_EXTERN PetscErrorCode SVMGetLossType(SVM, SVMLossType *);
+PERMON_EXTERN PetscErrorCode SVMSetPenaltyType(SVM, PetscInt);
+PERMON_EXTERN PetscErrorCode SVMGetPenaltyType(SVM, PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMSetPenalty(SVM, PetscInt, PetscReal[]);
+PERMON_EXTERN PetscErrorCode SVMSetC(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetC(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetCp(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetCp(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetCn(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetCn(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetNfolds(SVM, PetscInt);
+PERMON_EXTERN PetscErrorCode SVMGetNfolds(SVM, PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMSetSeparatingHyperplane(SVM, Vec, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetSeparatingHyperplane(SVM, Vec *, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetBias(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetBias(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetUserBias(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetUserBias(SVM, PetscReal *);
 
 PERMON_EXTERN PetscErrorCode SVMTrain(SVM);
 PERMON_EXTERN PetscErrorCode SVMPostTrain(SVM);
 PERMON_EXTERN PetscErrorCode SVMReconstructHyperplane(SVM);
-PERMON_EXTERN PetscErrorCode SVMSetAutoPostTrain(SVM,PetscBool);
-PERMON_EXTERN PetscErrorCode SVMGetAutoPostTrain(SVM,PetscBool *);
-PERMON_EXTERN PetscErrorCode SVMGetDistancesFromHyperplane(SVM,Mat,Vec *);
-PERMON_EXTERN PetscErrorCode SVMPredict(SVM,Mat,Vec *);
+PERMON_EXTERN PetscErrorCode SVMSetAutoPostTrain(SVM, PetscBool);
+PERMON_EXTERN PetscErrorCode SVMGetAutoPostTrain(SVM, PetscBool *);
+PERMON_EXTERN PetscErrorCode SVMGetDistancesFromHyperplane(SVM, Mat, Vec *);
+PERMON_EXTERN PetscErrorCode SVMPredict(SVM, Mat, Vec *);
 PERMON_EXTERN PetscErrorCode SVMTest(SVM);
 
 PERMON_EXTERN PetscErrorCode SVMConvergedSetUp(SVM);
 PERMON_EXTERN PetscErrorCode SVMDefaultConvergedCreate(SVM, void **);
 PERMON_EXTERN PetscErrorCode SVMDefaultConvergedDestroy(void *);
 
-PERMON_EXTERN PetscErrorCode SVMComputeModelScores(SVM,Vec,Vec);
-PERMON_EXTERN PetscErrorCode SVMGetModelScore(SVM,ModelScore,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMComputeModelScores(SVM, Vec, Vec);
+PERMON_EXTERN PetscErrorCode SVMGetModelScore(SVM, ModelScore, PetscReal *);
 PERMON_EXTERN PetscErrorCode SVMComputeHingeLoss(SVM svm);
 PERMON_EXTERN PetscErrorCode SVMComputeModelParams(SVM svm);
 
-PERMON_EXTERN PetscErrorCode SVMSetHyperOpt(SVM,PetscBool);
-PERMON_EXTERN PetscErrorCode SVMSetHyperOptScoreTypes(SVM,PetscInt,ModelScore []);
-PERMON_EXTERN PetscErrorCode SVMGetHyperOptNScoreTypes(SVM,PetscInt *);
-PERMON_EXTERN PetscErrorCode SVMGetHyperOptScoreTypes(SVM svm,const ModelScore *types[]);
+PERMON_EXTERN PetscErrorCode SVMSetHyperOpt(SVM, PetscBool);
+PERMON_EXTERN PetscErrorCode SVMSetHyperOptScoreTypes(SVM, PetscInt, ModelScore[]);
+PERMON_EXTERN PetscErrorCode SVMGetHyperOptNScoreTypes(SVM, PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMGetHyperOptScoreTypes(SVM svm, const ModelScore *types[]);
 
 PERMON_EXTERN PetscErrorCode SVMGridSearch(SVM);
 /* Penalty type 1 */
-PERMON_EXTERN PetscErrorCode SVMGridSearchSetBaseLogC(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGridSearchGetBaseLogC(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMGridSearchSetStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGridSearchGetStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetBaseLogC(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetBaseLogC(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetStrideLogC(SVM, PetscReal, PetscReal, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetStrideLogC(SVM, PetscReal *, PetscReal *, PetscReal *);
 /* Penalty type 2 */
-PERMON_EXTERN PetscErrorCode SVMGridSearchSetPositiveBaseLogC(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGridSearchGetPositiveBaseLogC(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMGridSearchSetPositiveStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGridSearchGetPositiveStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMGridSearchSetNegativeBaseLogC(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGridSearchGetNegativeBaseLogC(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMGridSearchSetNegativeStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMGridSearchGetNegativeStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetPositiveBaseLogC(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetPositiveBaseLogC(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetPositiveStrideLogC(SVM, PetscReal, PetscReal, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetPositiveStrideLogC(SVM, PetscReal *, PetscReal *, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetNegativeBaseLogC(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetNegativeBaseLogC(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetNegativeStrideLogC(SVM, PetscReal, PetscReal, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetNegativeStrideLogC(SVM, PetscReal *, PetscReal *, PetscReal *);
 
-PERMON_EXTERN PetscErrorCode SVMSetCrossValidationType(SVM,CrossValidationType);
-PERMON_EXTERN PetscErrorCode SVMGetCrossValidationType(SVM,CrossValidationType *);
-PERMON_EXTERN PetscErrorCode SVMCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
-PERMON_EXTERN PetscErrorCode SVMKFoldCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
-PERMON_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMSetCrossValidationType(SVM, CrossValidationType);
+PERMON_EXTERN PetscErrorCode SVMGetCrossValidationType(SVM, CrossValidationType *);
+PERMON_EXTERN PetscErrorCode SVMCrossValidation(SVM, PetscReal[], PetscInt, PetscReal[]);
+PERMON_EXTERN PetscErrorCode SVMKFoldCrossValidation(SVM, PetscReal[], PetscInt, PetscReal[]);
+PERMON_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation(SVM, PetscReal[], PetscInt, PetscReal[]);
 
-PERMON_EXTERN PetscErrorCode SVMSetQPS(SVM,QPS);
-PERMON_EXTERN PetscErrorCode SVMGetQPS(SVM,QPS *);
-PERMON_EXTERN PetscErrorCode SVMGetQP(SVM,QP *);
-PERMON_EXTERN PetscErrorCode SVMSetWarmStart(SVM,PetscBool);
+PERMON_EXTERN PetscErrorCode SVMSetQPS(SVM, QPS);
+PERMON_EXTERN PetscErrorCode SVMGetQPS(SVM, QPS *);
+PERMON_EXTERN PetscErrorCode SVMGetQP(SVM, QP *);
+PERMON_EXTERN PetscErrorCode SVMSetWarmStart(SVM, PetscBool);
 
-PERMON_EXTERN PetscErrorCode SVMSetOptionsPrefix(SVM svm,const char []);
-PERMON_EXTERN PetscErrorCode SVMAppendOptionsPrefix(SVM svm,const char []);
-PERMON_EXTERN PetscErrorCode SVMGetOptionsPrefix(SVM svm,const char *[]);
+PERMON_EXTERN PetscErrorCode SVMSetOptionsPrefix(SVM svm, const char[]);
+PERMON_EXTERN PetscErrorCode SVMAppendOptionsPrefix(SVM svm, const char[]);
+PERMON_EXTERN PetscErrorCode SVMGetOptionsPrefix(SVM svm, const char *[]);
 
-PERMON_EXTERN PetscErrorCode SVMGetTao(SVM,Tao *);
-PERMON_EXTERN PetscErrorCode SVMGetInnerSVM(SVM,SVM *);
+PERMON_EXTERN PetscErrorCode SVMGetTao(SVM, Tao *);
+PERMON_EXTERN PetscErrorCode SVMGetInnerSVM(SVM, SVM *);
 
 /* SVM probability */
-PERMON_EXTERN PetscErrorCode SVMProbabilitySetConvertLabelsToTargetProbability(SVM,PetscBool);
-PERMON_EXTERN PetscErrorCode SVMProbabilityGetConvertLabelsToTargetProbability(SVM,PetscBool *);
-PERMON_EXTERN PetscErrorCode SVMProbabilityGetSigmoidParams(SVM,PetscReal *,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMProbabilitySetThreshold(SVM,PetscReal);
-PERMON_EXTERN PetscErrorCode SVMProbabilityGetThreshold(SVM,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM,Vec);
+PERMON_EXTERN PetscErrorCode SVMProbabilitySetConvertLabelsToTargetProbability(SVM, PetscBool);
+PERMON_EXTERN PetscErrorCode SVMProbabilityGetConvertLabelsToTargetProbability(SVM, PetscBool *);
+PERMON_EXTERN PetscErrorCode SVMProbabilityGetSigmoidParams(SVM, PetscReal *, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMProbabilitySetThreshold(SVM, PetscReal);
+PERMON_EXTERN PetscErrorCode SVMProbabilityGetThreshold(SVM, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM, Vec);
 
 /* Input/Output functions */
-PERMON_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMViewDataset(SVM,Mat,Vec,PetscViewer);
+PERMON_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat, Vec, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewDataset(SVM, Mat, Vec, PetscViewer);
 
-PERMON_EXTERN PetscErrorCode SVMLoadGramian(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMViewGramian(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMLoadDataset(SVM,PetscViewer,Mat,Vec);
-PERMON_EXTERN PetscErrorCode SVMDatasetInfo(SVM,Mat,Vec,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMLoadTrainingDataset(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMViewTrainingDataset(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMLoadTestDataset(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMViewTestDataset(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMLoadCalibrationDataset(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMViewCalibrationDataset(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadGramian(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewGramian(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadDataset(SVM, PetscViewer, Mat, Vec);
+PERMON_EXTERN PetscErrorCode SVMDatasetInfo(SVM, Mat, Vec, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadTrainingDataset(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTrainingDataset(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadTestDataset(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTestDataset(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadCalibrationDataset(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewCalibrationDataset(SVM, PetscViewer);
 
-PERMON_EXTERN PetscErrorCode SVMViewTrainingPredictions(SVM,PetscViewer);
-PERMON_EXTERN PetscErrorCode SVMViewTestPredictions(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTrainingPredictions(SVM, PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTestPredictions(SVM, PetscViewer);
 
-PERMON_EXTERN PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm,const char [],PetscViewer *);
+PERMON_EXTERN PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm, const char[], PetscViewer *);
 
 /* Functions related to a biased matrix */
-PERMON_EXTERN PetscErrorCode MatBiasedCreate(Mat,PetscReal,Mat *);
-PERMON_EXTERN PetscErrorCode MatBiasedGetInnerMat(Mat,Mat *);
-PERMON_EXTERN PetscErrorCode MatBiasedGetBias(Mat,PetscReal *);
+PERMON_EXTERN PetscErrorCode MatBiasedCreate(Mat, PetscReal, Mat *);
+PERMON_EXTERN PetscErrorCode MatBiasedGetInnerMat(Mat, Mat *);
+PERMON_EXTERN PetscErrorCode MatBiasedGetBias(Mat, PetscReal *);

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -1,6 +1,4 @@
-
-#if !defined(__PERMONSVM_H)
-#define __PERMONSVM_H
+#pragma once
 
 #include <permonqps.h>
 #include <petscviewerhdf5.h>
@@ -285,4 +283,3 @@ FLLOP_EXTERN PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm,const char [],Petsc
 FLLOP_EXTERN PetscErrorCode MatBiasedCreate(Mat,PetscReal,Mat *);
 FLLOP_EXTERN PetscErrorCode MatBiasedGetInnerMat(Mat,Mat *);
 FLLOP_EXTERN PetscErrorCode MatBiasedGetBias(Mat,PetscReal *);
-#endif

--- a/include/permonsvm.h
+++ b/include/permonsvm.h
@@ -14,7 +14,7 @@
  S*/
 typedef struct _p_SVM* SVM;
 
-FLLOP_EXTERN PetscClassId SVM_CLASSID;
+PERMON_EXTERN PetscClassId SVM_CLASSID;
 #define SVM_CLASS_NAME  "svm"
 
 #define SVMType  char*
@@ -29,7 +29,7 @@ FLLOP_EXTERN PetscClassId SVM_CLASSID;
 .seealso: SVMSetLossType, SVMGetLossType()
 E*/
 typedef enum {SVM_L1, SVM_L2} SVMLossType;
-FLLOP_EXTERN const char *const SVMLossTypes[];
+PERMON_EXTERN const char *const SVMLossTypes[];
 
 /*MC
   SVM_L1 - L1 type of loss function, \xi = max(0, 1 - y_i * w' * x_i)
@@ -55,7 +55,7 @@ M*/
 .seealso SVMGetModelScore()
 E*/
 typedef enum {MODEL_ACCURACY, MODEL_PRECISION, MODEL_SENSITIVITY, MODEL_F1, MODEL_MCC, MODEL_AUC_ROC, MODEL_G1} ModelScore;
-FLLOP_EXTERN const char *const ModelScores[];
+PERMON_EXTERN const char *const ModelScores[];
 
 /*MC
   MODEL_ACCURACY - a ratio of correctly predicted samples to the total samples.
@@ -121,7 +121,7 @@ M*/
 .seealso: CROSS_VALIDATION_KFOLD, CROSS_VALIDATION_STRATIFIED_KFOLD
 E*/
 typedef enum {CROSS_VALIDATION_KFOLD,CROSS_VALIDATION_STRATIFIED_KFOLD} CrossValidationType;
-FLLOP_EXTERN const char *const CrossValidationTypes[];
+PERMON_EXTERN const char *const CrossValidationTypes[];
 
 /*MC
   CROSS_VALIDATION_KFOLD - k-fold cross validation.
@@ -139,147 +139,147 @@ M*/
 .seealso CrossValidationType, CROSS_VALIDATION_KFOLD
 M*/
 
-FLLOP_EXTERN PetscErrorCode SVMInitializePackage();
-FLLOP_EXTERN PetscErrorCode SVMFinalizePackage();
+PERMON_EXTERN PetscErrorCode SVMInitializePackage();
+PERMON_EXTERN PetscErrorCode SVMFinalizePackage();
 
-FLLOP_EXTERN PetscFunctionList SVMList;
-FLLOP_EXTERN PetscBool SVMRegisterAllCalled;
-FLLOP_EXTERN PetscErrorCode SVMRegisterAll();
-FLLOP_EXTERN PetscErrorCode SVMRegister(const char [],PetscErrorCode (*function)(SVM));
+PERMON_EXTERN PetscFunctionList SVMList;
+PERMON_EXTERN PetscBool SVMRegisterAllCalled;
+PERMON_EXTERN PetscErrorCode SVMRegisterAll();
+PERMON_EXTERN PetscErrorCode SVMRegister(const char [],PetscErrorCode (*function)(SVM));
 
-FLLOP_EXTERN PetscErrorCode SVMCreate(MPI_Comm,SVM *);
-FLLOP_EXTERN PetscErrorCode SVMSetType(SVM,const SVMType);
-FLLOP_EXTERN PetscErrorCode SVMReset(SVM);
-FLLOP_EXTERN PetscErrorCode SVMDestroy(SVM *);
-FLLOP_EXTERN PetscErrorCode SVMDestroyDefault(SVM);
-FLLOP_EXTERN PetscErrorCode SVMSetFromOptions(SVM);
-FLLOP_EXTERN PetscErrorCode SVMSetUp(SVM);
-FLLOP_EXTERN PetscErrorCode SVMView(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMViewScore(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMCreate(MPI_Comm,SVM *);
+PERMON_EXTERN PetscErrorCode SVMSetType(SVM,const SVMType);
+PERMON_EXTERN PetscErrorCode SVMReset(SVM);
+PERMON_EXTERN PetscErrorCode SVMDestroy(SVM *);
+PERMON_EXTERN PetscErrorCode SVMDestroyDefault(SVM);
+PERMON_EXTERN PetscErrorCode SVMSetFromOptions(SVM);
+PERMON_EXTERN PetscErrorCode SVMSetUp(SVM);
+PERMON_EXTERN PetscErrorCode SVMView(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewScore(SVM,PetscViewer);
 
-FLLOP_EXTERN PetscErrorCode SVMSetGramian(SVM,Mat);
-FLLOP_EXTERN PetscErrorCode SVMGetGramian(SVM,Mat *);
-FLLOP_EXTERN PetscErrorCode SVMSetOperator(SVM,Mat);
-FLLOP_EXTERN PetscErrorCode SVMGetOperator(SVM,Mat *);
-FLLOP_EXTERN PetscErrorCode SVMComputeOperator(SVM,Mat *);
+PERMON_EXTERN PetscErrorCode SVMSetGramian(SVM,Mat);
+PERMON_EXTERN PetscErrorCode SVMGetGramian(SVM,Mat *);
+PERMON_EXTERN PetscErrorCode SVMSetOperator(SVM,Mat);
+PERMON_EXTERN PetscErrorCode SVMGetOperator(SVM,Mat *);
+PERMON_EXTERN PetscErrorCode SVMComputeOperator(SVM,Mat *);
 
-FLLOP_EXTERN PetscErrorCode SVMSetTrainingDataset(SVM,Mat,Vec);
-FLLOP_EXTERN PetscErrorCode SVMGetTrainingDataset(SVM,Mat *,Vec *);
-FLLOP_EXTERN PetscErrorCode SVMSetCalibrationDataset(SVM,Mat,Vec);
-FLLOP_EXTERN PetscErrorCode SVMGetCalibrationDataset(SVM,Mat *,Vec *);
-FLLOP_EXTERN PetscErrorCode SVMSetTestDataset(SVM,Mat,Vec);
-FLLOP_EXTERN PetscErrorCode SVMGetTestDataset(SVM,Mat *,Vec *);
+PERMON_EXTERN PetscErrorCode SVMSetTrainingDataset(SVM,Mat,Vec);
+PERMON_EXTERN PetscErrorCode SVMGetTrainingDataset(SVM,Mat *,Vec *);
+PERMON_EXTERN PetscErrorCode SVMSetCalibrationDataset(SVM,Mat,Vec);
+PERMON_EXTERN PetscErrorCode SVMGetCalibrationDataset(SVM,Mat *,Vec *);
+PERMON_EXTERN PetscErrorCode SVMSetTestDataset(SVM,Mat,Vec);
+PERMON_EXTERN PetscErrorCode SVMGetTestDataset(SVM,Mat *,Vec *);
 
-FLLOP_EXTERN PetscErrorCode SVMGetLabels(SVM,const PetscReal *[]);
+PERMON_EXTERN PetscErrorCode SVMGetLabels(SVM,const PetscReal *[]);
 
-FLLOP_EXTERN PetscErrorCode SVMSetMod(SVM,PetscInt);
-FLLOP_EXTERN PetscErrorCode SVMGetMod(SVM,PetscInt *);
-FLLOP_EXTERN PetscErrorCode SVMSetLossType(SVM,SVMLossType);
-FLLOP_EXTERN PetscErrorCode SVMGetLossType(SVM,SVMLossType *);
-FLLOP_EXTERN PetscErrorCode SVMSetPenaltyType(SVM,PetscInt);
-FLLOP_EXTERN PetscErrorCode SVMGetPenaltyType(SVM,PetscInt *);
-FLLOP_EXTERN PetscErrorCode SVMSetPenalty(SVM,PetscInt,PetscReal []);
-FLLOP_EXTERN PetscErrorCode SVMSetC(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGetC(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMSetCp(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGetCp(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMSetCn(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGetCn(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMSetNfolds(SVM,PetscInt);
-FLLOP_EXTERN PetscErrorCode SVMGetNfolds(SVM,PetscInt *);
-FLLOP_EXTERN PetscErrorCode SVMSetSeparatingHyperplane(SVM,Vec,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGetSeparatingHyperplane(SVM,Vec *,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMSetBias(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGetBias(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMSetUserBias(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGetUserBias(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetMod(SVM,PetscInt);
+PERMON_EXTERN PetscErrorCode SVMGetMod(SVM,PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMSetLossType(SVM,SVMLossType);
+PERMON_EXTERN PetscErrorCode SVMGetLossType(SVM,SVMLossType *);
+PERMON_EXTERN PetscErrorCode SVMSetPenaltyType(SVM,PetscInt);
+PERMON_EXTERN PetscErrorCode SVMGetPenaltyType(SVM,PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMSetPenalty(SVM,PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMSetC(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetC(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetCp(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetCp(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetCn(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetCn(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetNfolds(SVM,PetscInt);
+PERMON_EXTERN PetscErrorCode SVMGetNfolds(SVM,PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMSetSeparatingHyperplane(SVM,Vec,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetSeparatingHyperplane(SVM,Vec *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetBias(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetBias(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMSetUserBias(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGetUserBias(SVM,PetscReal *);
 
-FLLOP_EXTERN PetscErrorCode SVMTrain(SVM);
-FLLOP_EXTERN PetscErrorCode SVMPostTrain(SVM);
-FLLOP_EXTERN PetscErrorCode SVMReconstructHyperplane(SVM);
-FLLOP_EXTERN PetscErrorCode SVMSetAutoPostTrain(SVM,PetscBool);
-FLLOP_EXTERN PetscErrorCode SVMGetAutoPostTrain(SVM,PetscBool *);
-FLLOP_EXTERN PetscErrorCode SVMGetDistancesFromHyperplane(SVM,Mat,Vec *);
-FLLOP_EXTERN PetscErrorCode SVMPredict(SVM,Mat,Vec *);
-FLLOP_EXTERN PetscErrorCode SVMTest(SVM);
+PERMON_EXTERN PetscErrorCode SVMTrain(SVM);
+PERMON_EXTERN PetscErrorCode SVMPostTrain(SVM);
+PERMON_EXTERN PetscErrorCode SVMReconstructHyperplane(SVM);
+PERMON_EXTERN PetscErrorCode SVMSetAutoPostTrain(SVM,PetscBool);
+PERMON_EXTERN PetscErrorCode SVMGetAutoPostTrain(SVM,PetscBool *);
+PERMON_EXTERN PetscErrorCode SVMGetDistancesFromHyperplane(SVM,Mat,Vec *);
+PERMON_EXTERN PetscErrorCode SVMPredict(SVM,Mat,Vec *);
+PERMON_EXTERN PetscErrorCode SVMTest(SVM);
 
-FLLOP_EXTERN PetscErrorCode SVMConvergedSetUp(SVM);
-FLLOP_EXTERN PetscErrorCode SVMDefaultConvergedCreate(SVM, void **);
-FLLOP_EXTERN PetscErrorCode SVMDefaultConvergedDestroy(void *);
+PERMON_EXTERN PetscErrorCode SVMConvergedSetUp(SVM);
+PERMON_EXTERN PetscErrorCode SVMDefaultConvergedCreate(SVM, void **);
+PERMON_EXTERN PetscErrorCode SVMDefaultConvergedDestroy(void *);
 
-FLLOP_EXTERN PetscErrorCode SVMComputeModelScores(SVM,Vec,Vec);
-FLLOP_EXTERN PetscErrorCode SVMGetModelScore(SVM,ModelScore,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMComputeHingeLoss(SVM svm);
-FLLOP_EXTERN PetscErrorCode SVMComputeModelParams(SVM svm);
+PERMON_EXTERN PetscErrorCode SVMComputeModelScores(SVM,Vec,Vec);
+PERMON_EXTERN PetscErrorCode SVMGetModelScore(SVM,ModelScore,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMComputeHingeLoss(SVM svm);
+PERMON_EXTERN PetscErrorCode SVMComputeModelParams(SVM svm);
 
-FLLOP_EXTERN PetscErrorCode SVMSetHyperOpt(SVM,PetscBool);
-FLLOP_EXTERN PetscErrorCode SVMSetHyperOptScoreTypes(SVM,PetscInt,ModelScore []);
-FLLOP_EXTERN PetscErrorCode SVMGetHyperOptNScoreTypes(SVM,PetscInt *);
-FLLOP_EXTERN PetscErrorCode SVMGetHyperOptScoreTypes(SVM svm,const ModelScore *types[]);
+PERMON_EXTERN PetscErrorCode SVMSetHyperOpt(SVM,PetscBool);
+PERMON_EXTERN PetscErrorCode SVMSetHyperOptScoreTypes(SVM,PetscInt,ModelScore []);
+PERMON_EXTERN PetscErrorCode SVMGetHyperOptNScoreTypes(SVM,PetscInt *);
+PERMON_EXTERN PetscErrorCode SVMGetHyperOptScoreTypes(SVM svm,const ModelScore *types[]);
 
-FLLOP_EXTERN PetscErrorCode SVMGridSearch(SVM);
+PERMON_EXTERN PetscErrorCode SVMGridSearch(SVM);
 /* Penalty type 1 */
-FLLOP_EXTERN PetscErrorCode SVMGridSearchSetBaseLogC(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchGetBaseLogC(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchSetStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchGetStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetBaseLogC(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetBaseLogC(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
 /* Penalty type 2 */
-FLLOP_EXTERN PetscErrorCode SVMGridSearchSetPositiveBaseLogC(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchGetPositiveBaseLogC(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchSetPositiveStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchGetPositiveStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchSetNegativeBaseLogC(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchGetNegativeBaseLogC(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchSetNegativeStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMGridSearchGetNegativeStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetPositiveBaseLogC(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetPositiveBaseLogC(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetPositiveStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetPositiveStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetNegativeBaseLogC(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetNegativeBaseLogC(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMGridSearchSetNegativeStrideLogC(SVM,PetscReal,PetscReal,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMGridSearchGetNegativeStrideLogC(SVM,PetscReal *,PetscReal *,PetscReal *);
 
-FLLOP_EXTERN PetscErrorCode SVMSetCrossValidationType(SVM,CrossValidationType);
-FLLOP_EXTERN PetscErrorCode SVMGetCrossValidationType(SVM,CrossValidationType *);
-FLLOP_EXTERN PetscErrorCode SVMCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
-FLLOP_EXTERN PetscErrorCode SVMKFoldCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
-FLLOP_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMSetCrossValidationType(SVM,CrossValidationType);
+PERMON_EXTERN PetscErrorCode SVMGetCrossValidationType(SVM,CrossValidationType *);
+PERMON_EXTERN PetscErrorCode SVMCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMKFoldCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation(SVM,PetscReal [],PetscInt,PetscReal []);
 
-FLLOP_EXTERN PetscErrorCode SVMSetQPS(SVM,QPS);
-FLLOP_EXTERN PetscErrorCode SVMGetQPS(SVM,QPS *);
-FLLOP_EXTERN PetscErrorCode SVMGetQP(SVM,QP *);
-FLLOP_EXTERN PetscErrorCode SVMSetWarmStart(SVM,PetscBool);
+PERMON_EXTERN PetscErrorCode SVMSetQPS(SVM,QPS);
+PERMON_EXTERN PetscErrorCode SVMGetQPS(SVM,QPS *);
+PERMON_EXTERN PetscErrorCode SVMGetQP(SVM,QP *);
+PERMON_EXTERN PetscErrorCode SVMSetWarmStart(SVM,PetscBool);
 
-FLLOP_EXTERN PetscErrorCode SVMSetOptionsPrefix(SVM svm,const char []);
-FLLOP_EXTERN PetscErrorCode SVMAppendOptionsPrefix(SVM svm,const char []);
-FLLOP_EXTERN PetscErrorCode SVMGetOptionsPrefix(SVM svm,const char *[]);
+PERMON_EXTERN PetscErrorCode SVMSetOptionsPrefix(SVM svm,const char []);
+PERMON_EXTERN PetscErrorCode SVMAppendOptionsPrefix(SVM svm,const char []);
+PERMON_EXTERN PetscErrorCode SVMGetOptionsPrefix(SVM svm,const char *[]);
 
-FLLOP_EXTERN PetscErrorCode SVMGetTao(SVM,Tao *);
-FLLOP_EXTERN PetscErrorCode SVMGetInnerSVM(SVM,SVM *);
+PERMON_EXTERN PetscErrorCode SVMGetTao(SVM,Tao *);
+PERMON_EXTERN PetscErrorCode SVMGetInnerSVM(SVM,SVM *);
 
 /* SVM probability */
-FLLOP_EXTERN PetscErrorCode SVMProbabilitySetConvertLabelsToTargetProbability(SVM,PetscBool);
-FLLOP_EXTERN PetscErrorCode SVMProbabilityGetConvertLabelsToTargetProbability(SVM,PetscBool *);
-FLLOP_EXTERN PetscErrorCode SVMProbabilityGetSigmoidParams(SVM,PetscReal *,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMProbabilitySetThreshold(SVM,PetscReal);
-FLLOP_EXTERN PetscErrorCode SVMProbabilityGetThreshold(SVM,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM,Vec);
+PERMON_EXTERN PetscErrorCode SVMProbabilitySetConvertLabelsToTargetProbability(SVM,PetscBool);
+PERMON_EXTERN PetscErrorCode SVMProbabilityGetConvertLabelsToTargetProbability(SVM,PetscBool *);
+PERMON_EXTERN PetscErrorCode SVMProbabilityGetSigmoidParams(SVM,PetscReal *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMProbabilitySetThreshold(SVM,PetscReal);
+PERMON_EXTERN PetscErrorCode SVMProbabilityGetThreshold(SVM,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM,Vec);
 
 /* Input/Output functions */
-FLLOP_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMViewDataset(SVM,Mat,Vec,PetscViewer);
+PERMON_EXTERN PetscErrorCode PetscViewerLoadSVMDataset(Mat,Vec,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewDataset(SVM,Mat,Vec,PetscViewer);
 
-FLLOP_EXTERN PetscErrorCode SVMLoadGramian(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMViewGramian(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMLoadDataset(SVM,PetscViewer,Mat,Vec);
-FLLOP_EXTERN PetscErrorCode SVMDatasetInfo(SVM,Mat,Vec,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMLoadTrainingDataset(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMViewTrainingDataset(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMLoadTestDataset(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMViewTestDataset(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMLoadCalibrationDataset(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMViewCalibrationDataset(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadGramian(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewGramian(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadDataset(SVM,PetscViewer,Mat,Vec);
+PERMON_EXTERN PetscErrorCode SVMDatasetInfo(SVM,Mat,Vec,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadTrainingDataset(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTrainingDataset(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadTestDataset(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTestDataset(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMLoadCalibrationDataset(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewCalibrationDataset(SVM,PetscViewer);
 
-FLLOP_EXTERN PetscErrorCode SVMViewTrainingPredictions(SVM,PetscViewer);
-FLLOP_EXTERN PetscErrorCode SVMViewTestPredictions(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTrainingPredictions(SVM,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMViewTestPredictions(SVM,PetscViewer);
 
-FLLOP_EXTERN PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm,const char [],PetscViewer *);
+PERMON_EXTERN PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm,const char [],PetscViewer *);
 
 /* Functions related to a biased matrix */
-FLLOP_EXTERN PetscErrorCode MatBiasedCreate(Mat,PetscReal,Mat *);
-FLLOP_EXTERN PetscErrorCode MatBiasedGetInnerMat(Mat,Mat *);
-FLLOP_EXTERN PetscErrorCode MatBiasedGetBias(Mat,PetscReal *);
+PERMON_EXTERN PetscErrorCode MatBiasedCreate(Mat,PetscReal,Mat *);
+PERMON_EXTERN PetscErrorCode MatBiasedGetInnerMat(Mat,Mat *);
+PERMON_EXTERN PetscErrorCode MatBiasedGetBias(Mat,PetscReal *);

--- a/lib/permonsvm/conf/permonsvm_rules
+++ b/lib/permonsvm/conf/permonsvm_rules
@@ -63,6 +63,11 @@ permonsvm_info:
 	-@echo "Using MAKEFLAGS: -j$(MAKE_NP) -l$(MAKE_LOAD) $(MAKEFLAGS)"
 	-@echo "=========================================="
 
+# Check that source code does not violate basic PETSc coding standards
+checkbadsource: checkbadSource
+
+checkbadSource: chk_permon_dir_private
+
 # include PERMON rules at the end only if rules and petscrules files exist
 # - this is checked by the chk_permon_petsc_dir rule
 ifneq ("$(wildcard ${PERMON_DIR}/lib/permon/conf/permon_rules)","")

--- a/lib/permonsvm/conf/permonsvm_variables
+++ b/lib/permonsvm/conf/permonsvm_variables
@@ -22,3 +22,7 @@ PERMON_SVM_LIB = ${PERMON_SVM_C_SH_LIB_PATH} -L${PERMON_SVM_LIB_DIR} ${PERMON_SV
 
 PERMON_SVM_LOG          ?= ${PERMON_PKG_LIB_DIR}/permonsvm/conf/make.log
 PERMON_SVM_ERRLOG       ?= ${PERMON_PKG_LIB_DIR}/permonsvm/conf/error.log
+
+#  Escape codes to change the text color on xterms and terminals
+PETSC_TEXT_HILIGHT ?= "\033[1;31m"
+PETSC_TEXT_NORMAL ?= "\033[0;39m\033[0;49m"

--- a/src/bin/permonsvmfile.c
+++ b/src/bin/permonsvmfile.c
@@ -8,12 +8,12 @@ static MPI_Comm comm;
 
 #undef __FUNCT__
 #define __FUNCT__ "GetFilenameExtension"
-PetscErrorCode GetFilenameExtension(const char *filename,char **extension)
+PetscErrorCode GetFilenameExtension(const char *filename, char **extension)
 {
   char *extension_inner;
 
   PetscFunctionBegin;
-  PetscCall(PetscStrrchr(filename,'.',&extension_inner));
+  PetscCall(PetscStrrchr(filename, '.', &extension_inner));
   *extension = extension_inner;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -22,136 +22,134 @@ PetscErrorCode GetFilenameExtension(const char *filename,char **extension)
 #define __FUNCT__ "SVMRunBinaryClassification"
 PetscErrorCode SVMRunBinaryClassification()
 {
-  SVM         svm;
+  SVM svm;
 
-  char        training_file[PETSC_MAX_PATH_LEN] = "examples/data/heart_scale.bin";
-  char        test_file[PETSC_MAX_PATH_LEN]     = "";
-  char        kernel_file[PETSC_MAX_PATH_LEN]   = "";
-  char        training_result_file[PETSC_MAX_PATH_LEN] = "";
-  char        test_result_file[PETSC_MAX_PATH_LEN]     = "";
-  PetscBool   test_file_set = PETSC_FALSE,kernel_file_set = PETSC_FALSE;
-  PetscBool   training_result_file_set=PETSC_FALSE,test_result_file_set=PETSC_FALSE;
+  char      training_file[PETSC_MAX_PATH_LEN]        = "examples/data/heart_scale.bin";
+  char      test_file[PETSC_MAX_PATH_LEN]            = "";
+  char      kernel_file[PETSC_MAX_PATH_LEN]          = "";
+  char      training_result_file[PETSC_MAX_PATH_LEN] = "";
+  char      test_result_file[PETSC_MAX_PATH_LEN]     = "";
+  PetscBool test_file_set = PETSC_FALSE, kernel_file_set = PETSC_FALSE;
+  PetscBool training_result_file_set = PETSC_FALSE, test_result_file_set = PETSC_FALSE;
 
-  char        *extension = NULL;
+  char *extension = NULL;
 
   PetscViewer viewer;
-  PetscBool   ishdf5,isbinary,issvmlight;
+  PetscBool   ishdf5, isbinary, issvmlight;
 
   PetscFunctionBeginI;
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),&test_file_set));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_kernel",kernel_file,sizeof(kernel_file),&kernel_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training", training_file, sizeof(training_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test", test_file, sizeof(test_file), &test_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_kernel", kernel_file, sizeof(kernel_file), &kernel_file_set));
 
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training_predictions",training_result_file,sizeof(training_result_file),&training_result_file_set));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test_predictions",test_result_file,sizeof(test_result_file),&test_result_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training_predictions", training_result_file, sizeof(training_result_file), &training_result_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test_predictions", test_result_file, sizeof(test_result_file), &test_result_file_set));
 
-  PetscCall(SVMCreate(comm,&svm));
-  PetscCall(SVMSetType(svm,SVM_BINARY));
+  PetscCall(SVMCreate(comm, &svm));
+  PetscCall(SVMSetType(svm, SVM_BINARY));
   PetscCall(SVMSetFromOptions(svm));
 
   /* Load training dataset */
-  PetscCall(GetFilenameExtension(training_file,&extension));
-  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-  PetscCall(PetscStrcmp(extension,bin,&isbinary));
-  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+  PetscCall(GetFilenameExtension(training_file, &extension));
+  PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+  PetscCall(PetscStrcmp(extension, bin, &isbinary));
+  PetscCall(PetscStrcmp(extension, SVMLight, &issvmlight));
   if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-    PetscCall(PetscViewerHDF5Open(comm,training_file,FILE_MODE_READ,&viewer));
+    PetscCall(PetscViewerHDF5Open(comm, training_file, FILE_MODE_READ, &viewer));
 #else
-    SETERRQ(comm,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+    SETERRQ(comm, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
   } else if (isbinary) {
-    PetscCall(PetscViewerBinaryOpen(comm,training_file,FILE_MODE_READ,&viewer));
+    PetscCall(PetscViewerBinaryOpen(comm, training_file, FILE_MODE_READ, &viewer));
   } else if (issvmlight) {
-    PetscCall(PetscViewerSVMLightOpen(comm,training_file,&viewer));
+    PetscCall(PetscViewerSVMLightOpen(comm, training_file, &viewer));
   } else {
-    SETERRQ(comm,PETSC_ERR_SUP,"File type %s not supported",extension);
+    SETERRQ(comm, PETSC_ERR_SUP, "File type %s not supported", extension);
   }
-  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(SVMLoadTrainingDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load precomputed Gramian (kernel matrix), i.e. phi(X^T) * phi(X) generally */
   if (kernel_file_set) {
-    PetscCall(GetFilenameExtension(kernel_file,&extension));
-    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-    PetscCall(PetscStrcmp(extension,bin,&isbinary));
+    PetscCall(GetFilenameExtension(kernel_file, &extension));
+    PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+    PetscCall(PetscStrcmp(extension, bin, &isbinary));
 
     if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-      PetscCall(PetscViewerHDF5Open(comm,kernel_file,FILE_MODE_READ,&viewer));
+      PetscCall(PetscViewerHDF5Open(comm, kernel_file, FILE_MODE_READ, &viewer));
 #else
-      SETERRQ(comm,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+      SETERRQ(comm, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
     } else if (isbinary) {
-      PetscCall(PetscViewerBinaryOpen(comm,kernel_file,FILE_MODE_READ,&viewer));
+      PetscCall(PetscViewerBinaryOpen(comm, kernel_file, FILE_MODE_READ, &viewer));
     } else {
-      SETERRQ(comm,PETSC_ERR_SUP,"File type %s not supported",extension);
+      SETERRQ(comm, PETSC_ERR_SUP, "File type %s not supported", extension);
     }
-    PetscCall(SVMLoadGramian(svm,viewer));
+    PetscCall(SVMLoadGramian(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
   /* Load test dataset */
   if (test_file_set) {
-    PetscCall(GetFilenameExtension(test_file,&extension));
-    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-    PetscCall(PetscStrcmp(extension,bin,&isbinary));
-    PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+    PetscCall(GetFilenameExtension(test_file, &extension));
+    PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+    PetscCall(PetscStrcmp(extension, bin, &isbinary));
+    PetscCall(PetscStrcmp(extension, SVMLight, &issvmlight));
     if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-      PetscCall(PetscViewerHDF5Open(comm,test_file,FILE_MODE_READ,&viewer));
+      PetscCall(PetscViewerHDF5Open(comm, test_file, FILE_MODE_READ, &viewer));
 #else
-      SETERRQ(comm,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+      SETERRQ(comm, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
     } else if (isbinary) {
-      PetscCall(PetscViewerBinaryOpen(comm,test_file,FILE_MODE_READ,&viewer));
+      PetscCall(PetscViewerBinaryOpen(comm, test_file, FILE_MODE_READ, &viewer));
     } else if (issvmlight) {
-      PetscCall(PetscViewerSVMLightOpen(comm,test_file,&viewer));
+      PetscCall(PetscViewerSVMLightOpen(comm, test_file, &viewer));
     } else {
-      SETERRQ(comm,PETSC_ERR_SUP,"File type %s not supported",extension);
+      SETERRQ(comm, PETSC_ERR_SUP, "File type %s not supported", extension);
     }
-    PetscCall(SVMLoadTestDataset(svm,viewer));
+    PetscCall(SVMLoadTestDataset(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   /* Train SVM model */
   PetscCall(SVMTrain(svm));
   /* Test performance of SVM model */
-  if (test_file_set) {
-    PetscCall(SVMTest(svm));
-  }
+  if (test_file_set) { PetscCall(SVMTest(svm)); }
 
   /* Save results */
   if (training_result_file_set) {
-    PetscCall(GetFilenameExtension(training_result_file,&extension));
-    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-    PetscCall(PetscStrcmp(extension,bin,&isbinary));
+    PetscCall(GetFilenameExtension(training_result_file, &extension));
+    PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+    PetscCall(PetscStrcmp(extension, bin, &isbinary));
     if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,training_result_file,FILE_MODE_WRITE,&viewer));
+      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD, training_result_file, FILE_MODE_WRITE, &viewer));
 #else
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+      SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
     } else {
-      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_result_file,FILE_MODE_WRITE,&viewer));
+      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, training_result_file, FILE_MODE_WRITE, &viewer));
     }
-    PetscCall(SVMViewTrainingPredictions(svm,viewer));
+    PetscCall(SVMViewTrainingPredictions(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   if (test_result_file_set) {
-    PetscCall(GetFilenameExtension(test_result_file,&extension));
-    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-    PetscCall(PetscStrcmp(extension,bin,&isbinary));
+    PetscCall(GetFilenameExtension(test_result_file, &extension));
+    PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+    PetscCall(PetscStrcmp(extension, bin, &isbinary));
     if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,test_result_file,FILE_MODE_WRITE,&viewer));
+      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD, test_result_file, FILE_MODE_WRITE, &viewer));
 #else
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+      SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
     } else {
-      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_result_file,FILE_MODE_WRITE,&viewer));
+      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, test_result_file, FILE_MODE_WRITE, &viewer));
     }
-    PetscCall(SVMViewTestPredictions(svm,viewer));
+    PetscCall(SVMViewTestPredictions(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
@@ -161,11 +159,10 @@ PetscErrorCode SVMRunBinaryClassification()
 
 #undef __FUNCT__
 #define __FUNCT__ "main"
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-
   PetscFunctionBegin;
-  PetscCall(PermonInitialize(&argc,&argv,(char *) 0,(char *) 0));
+  PetscCall(PermonInitialize(&argc, &argv, (char *)0, (char *)0));
   comm = PETSC_COMM_WORLD;
   PetscCall(SVMRunBinaryClassification());
   PetscCall(PermonFinalize());

--- a/src/docs/manualpages-sec/header_
+++ b/src/docs/manualpages-sec/header_
@@ -4,6 +4,6 @@
 </HEAD>
 <BODY BGCOLOR="FFFFFF">
 
-Empty page for makefiles that are missing a MANSEC variable (the directories 
+Empty page for makefiles that are missing a MANSEC variable (the directories
 don't have code in them).
 <P>

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -69,7 +69,6 @@ PetscErrorCode SVMReset_Binary(SVM svm)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-
 #undef __FUNCT__
 #define __FUNCT__ "SVMDestroy_Binary"
 PetscErrorCode SVMDestroy_Binary(SVM svm)
@@ -1566,7 +1565,6 @@ PetscErrorCode SVMTest_Binary(SVM svm)
   PetscCall(VecDestroy(&y_pred));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
-
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMComputePGmaxPGmin_Binary_Private"

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -1,30 +1,30 @@
 #include "binaryimpl.h"
 #include "../../utils/report.h"
 
-const char *const SVMLossTypes[]={"L1","L2","SVMLossType","SVM_",0};
+const char *const SVMLossTypes[]      = {"L1", "L2", "SVMLossType", "SVM_", 0};
 const char *const SVMConvergedTypes[] = {"default", "duality_gap", "dual_violation", "SVMConvergedType", "SVM_", 0};
 
 typedef struct {
   SVM svm_inner;
 } SVM_Binary_mctx;
 
-static PetscErrorCode SVMMonitorCreateCtx_Binary(void **,SVM);
+static PetscErrorCode SVMMonitorCreateCtx_Binary(void **, SVM);
 static PetscErrorCode SVMMonitorDestroyCtx_Binary(void **);
 
-static PetscErrorCode SVMMonitorDefault_Binary(QPS,PetscInt,PetscReal,void *);
-static PetscErrorCode SVMMonitorObjFuncs_Binary(QPS,PetscInt,PetscReal,void *);
-static PetscErrorCode SVMMonitorScores_Binary(QPS,PetscInt,PetscReal,void *);
-static PetscErrorCode SVMMonitorTrainingScores_Binary(QPS,PetscInt,PetscReal,void *);
+static PetscErrorCode SVMMonitorDefault_Binary(QPS, PetscInt, PetscReal, void *);
+static PetscErrorCode SVMMonitorObjFuncs_Binary(QPS, PetscInt, PetscReal, void *);
+static PetscErrorCode SVMMonitorScores_Binary(QPS, PetscInt, PetscReal, void *);
+static PetscErrorCode SVMMonitorTrainingScores_Binary(QPS, PetscInt, PetscReal, void *);
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMReset_Binary"
 PetscErrorCode SVMReset_Binary(SVM svm)
 {
   SVM_Binary *svm_binary;
-  PetscInt i;
+  PetscInt    i;
 
   PetscFunctionBegin;
-  svm_binary = (SVM_Binary *) svm->data;
+  svm_binary = (SVM_Binary *)svm->data;
 
   if (svm_binary->qps) {
     PetscCall(QPSDestroy(&svm_binary->qps));
@@ -43,9 +43,9 @@ PetscErrorCode SVMReset_Binary(SVM svm)
   PetscCall(ISDestroy(&svm_binary->is_p));
   PetscCall(ISDestroy(&svm_binary->is_n));
 
-  PetscCall(PetscMemzero(svm_binary->y_map,2 * sizeof(PetscScalar)));
-  PetscCall(PetscMemzero(svm_binary->confusion_matrix,4 * sizeof(PetscInt)));
-  PetscCall(PetscMemzero(svm_binary->model_scores,16 * sizeof(PetscReal)));
+  PetscCall(PetscMemzero(svm_binary->y_map, 2 * sizeof(PetscScalar)));
+  PetscCall(PetscMemzero(svm_binary->confusion_matrix, 4 * sizeof(PetscInt)));
+  PetscCall(PetscMemzero(svm_binary->model_scores, 16 * sizeof(PetscReal)));
 
   svm_binary->w           = NULL;
   svm_binary->Xt_training = NULL;
@@ -57,9 +57,9 @@ PetscErrorCode SVMReset_Binary(SVM svm)
   svm_binary->J           = NULL;
   svm_binary->diag        = NULL;
 
-  svm_binary->nsv         = 0;
+  svm_binary->nsv = 0;
   PetscCall(ISDestroy(&svm_binary->is_sv));
-  svm_binary->is_sv       = NULL;
+  svm_binary->is_sv = NULL;
 
   for (i = 0; i < 3; ++i) {
     PetscCall(VecDestroy(&svm_binary->work[i]));
@@ -72,32 +72,32 @@ PetscErrorCode SVMReset_Binary(SVM svm)
 #define __FUNCT__ "SVMDestroy_Binary"
 PetscErrorCode SVMDestroy_Binary(SVM svm)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetGramian_C"                ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetGramian_C"                ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOperator_C"               ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOperator_C"               ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C"        ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C"        ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetLabels_C"                 ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMComputeOperator_C"           ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetQPS_C"                    ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQPS_C"                    ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQP_C"                     ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetBias_C"                   ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetBias_C"                   ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetSeparatingHyperplane_C"   ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetSeparatingHyperplane_C"   ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetDistancesFromHyperplane_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetModelScore_C"             ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C"          ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C"          ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C"       ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetGramian_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetGramian_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetOperator_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetOperator_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetTrainingDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetTrainingDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetLabels_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMComputeOperator_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetQPS_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetQPS_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetQP_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetBias_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetBias_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetSeparatingHyperplane_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetSeparatingHyperplane_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetDistancesFromHyperplane_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetModelScore_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetOptionsPrefix_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetOptionsPrefix_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMAppendOptionsPrefix_C", NULL));
 
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMKFoldCrossValidation_C"          ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMStratifiedKFoldCrossValidation_C",NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMKFoldCrossValidation_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMStratifiedKFoldCrossValidation_C", NULL));
 
   PetscCall(QPSDestroy(&svm_binary->qps));
   PetscCall(SVMDestroyDefault(svm));
@@ -106,9 +106,9 @@ PetscErrorCode SVMDestroy_Binary(SVM svm)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMView_Binary"
-PetscErrorCode SVMView_Binary(SVM svm,PetscViewer v)
+PetscErrorCode SVMView_Binary(SVM svm, PetscViewer v)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   MPI_Comm    comm;
   SVMLossType loss_type;
@@ -116,132 +116,132 @@ PetscErrorCode SVMView_Binary(SVM svm,PetscViewer v)
   PetscBool   isascii;
 
   PetscFunctionBegin;
-  comm = PetscObjectComm((PetscObject) svm);
+  comm = PetscObjectComm((PetscObject)svm);
 
   if (!v) v = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
 
   if (isascii) {
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
 
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"model parameters:\n"));
+    PetscCall(PetscViewerASCIIPrintf(v, "model parameters:\n"));
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"||w||=%.4f",(double)svm_binary->norm_w));
-    PetscCall(PetscViewerASCIIPrintf(v,"bias=%.4f",(double)svm_binary->b));
-    PetscCall(PetscViewerASCIIPrintf(v,"margin=%.4f",(double)svm_binary->margin));
-    PetscCall(PetscViewerASCIIPrintf(v,"NSV=%" PetscInt_FMT "\n",svm_binary->nsv));
+    PetscCall(PetscViewerASCIIPrintf(v, "||w||=%.4f", (double)svm_binary->norm_w));
+    PetscCall(PetscViewerASCIIPrintf(v, "bias=%.4f", (double)svm_binary->b));
+    PetscCall(PetscViewerASCIIPrintf(v, "margin=%.4f", (double)svm_binary->margin));
+    PetscCall(PetscViewerASCIIPrintf(v, "NSV=%" PetscInt_FMT "\n", svm_binary->nsv));
     PetscCall(PetscViewerASCIIPopTab(v));
 
-    PetscCall(SVMGetLossType(svm,&loss_type));
-    PetscCall(SVMGetPenaltyType(svm,&p));
-    PetscCall(PetscViewerASCIIPrintf(v,"%s hinge loss:\n",SVMLossTypes[loss_type]));
+    PetscCall(SVMGetLossType(svm, &loss_type));
+    PetscCall(SVMGetPenaltyType(svm, &p));
+    PetscCall(PetscViewerASCIIPrintf(v, "%s hinge loss:\n", SVMLossTypes[loss_type]));
     PetscCall(PetscViewerASCIIPushTab(v));
     if (p == 1) {
       if (loss_type == SVM_L1) {
-        PetscCall(PetscViewerASCIIPrintf(v,"sum(xi_i)=%.4f\n",(double)svm_binary->hinge_loss));
+        PetscCall(PetscViewerASCIIPrintf(v, "sum(xi_i)=%.4f\n", (double)svm_binary->hinge_loss));
       } else {
-        PetscCall(PetscViewerASCIIPrintf(v,"sum(xi_i^2)=%.4f\n",(double)svm_binary->hinge_loss));
+        PetscCall(PetscViewerASCIIPrintf(v, "sum(xi_i^2)=%.4f\n", (double)svm_binary->hinge_loss));
       }
     } else {
       if (loss_type == SVM_L1) {
-        PetscCall(PetscViewerASCIIPrintf(v,"sum(xi_i+)=%.4f",(double)svm_binary->hinge_loss_p));
-        PetscCall(PetscViewerASCIIPrintf(v,"sum(xi_i-)=%.4f\n",(double)svm_binary->hinge_loss_n));
+        PetscCall(PetscViewerASCIIPrintf(v, "sum(xi_i+)=%.4f", (double)svm_binary->hinge_loss_p));
+        PetscCall(PetscViewerASCIIPrintf(v, "sum(xi_i-)=%.4f\n", (double)svm_binary->hinge_loss_n));
       } else {
-        PetscCall(PetscViewerASCIIPrintf(v,"sum(xi_i+^2)=%.4f",(double)svm_binary->hinge_loss_n));
-        PetscCall(PetscViewerASCIIPrintf(v,"sum(xi_i-^2)=%.4f\n",(double)svm_binary->hinge_loss_n));
+        PetscCall(PetscViewerASCIIPrintf(v, "sum(xi_i+^2)=%.4f", (double)svm_binary->hinge_loss_n));
+        PetscCall(PetscViewerASCIIPrintf(v, "sum(xi_i-^2)=%.4f\n", (double)svm_binary->hinge_loss_n));
       }
     }
     PetscCall(PetscViewerASCIIPopTab(v));
 
-    PetscCall(PetscViewerASCIIPrintf(v,"objective functions:\n"));
+    PetscCall(PetscViewerASCIIPrintf(v, "objective functions:\n"));
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"primalObj=%.4f",(double)svm_binary->primalObj));
-    PetscCall(PetscViewerASCIIPrintf(v,"dualObj=%.4f",(double)svm_binary->dualObj));
-    PetscCall(PetscViewerASCIIPrintf(v,"gap=%.4f\n",(double)(svm_binary->primalObj - svm_binary->dualObj)));
+    PetscCall(PetscViewerASCIIPrintf(v, "primalObj=%.4f", (double)svm_binary->primalObj));
+    PetscCall(PetscViewerASCIIPrintf(v, "dualObj=%.4f", (double)svm_binary->dualObj));
+    PetscCall(PetscViewerASCIIPrintf(v, "gap=%.4f\n", (double)(svm_binary->primalObj - svm_binary->dualObj)));
     PetscCall(PetscViewerASCIIPopTab(v));
 
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMView", ((PetscObject)v)->type_name);
+    SETERRQ(comm, PETSC_ERR_SUP, "Viewer type %s not supported for SVMView", ((PetscObject)v)->type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMViewScore_Binary"
-PetscErrorCode SVMViewScore_Binary(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewScore_Binary(SVM svm, PetscViewer v)
 {
-  MPI_Comm  comm;
+  MPI_Comm comm;
 
-  PetscReal   C,Cp,Cn;
+  PetscReal   C, Cp, Cn;
   PetscInt    mod;
   SVMLossType loss_type;
   PetscInt    p; /* penalty type */
 
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
-  PetscBool isascii;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
+  PetscBool   isascii;
 
   PetscFunctionBegin;
-  comm = PetscObjectComm((PetscObject) svm);
+  comm = PetscObjectComm((PetscObject)svm);
   if (!v) v = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
-    PetscCall(SVMGetPenaltyType(svm,&p));
-    PetscCall(SVMGetMod(svm,&mod));
-    PetscCall(SVMGetLossType(svm,&loss_type));
+    PetscCall(SVMGetPenaltyType(svm, &p));
+    PetscCall(SVMGetMod(svm, &mod));
+    PetscCall(SVMGetLossType(svm, &loss_type));
 
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
 
     PetscCall(PetscViewerASCIIPushTab(v));
     if (p == 1) {
-      PetscCall(SVMGetC(svm,&C));
-      PetscCall(PetscViewerASCIIPrintf(v,"model performance score with training parameters C=%.3f, mod=%" PetscInt_FMT ", loss=%s:\n",(double)C,mod,SVMLossTypes[loss_type]));
+      PetscCall(SVMGetC(svm, &C));
+      PetscCall(PetscViewerASCIIPrintf(v, "model performance score with training parameters C=%.3f, mod=%" PetscInt_FMT ", loss=%s:\n", (double)C, mod, SVMLossTypes[loss_type]));
     } else {
-      PetscCall(SVMGetCp(svm,&Cp));
-      PetscCall(SVMGetCn(svm,&Cn));
-      PetscCall(PetscViewerASCIIPrintf(v,"model performance score with training parameters C+=%.3f, C-=%.3f, mod=%" PetscInt_FMT ", loss=%s:\n",(double)Cp,(double)Cn,mod,SVMLossTypes[loss_type]));
+      PetscCall(SVMGetCp(svm, &Cp));
+      PetscCall(SVMGetCn(svm, &Cn));
+      PetscCall(PetscViewerASCIIPrintf(v, "model performance score with training parameters C+=%.3f, C-=%.3f, mod=%" PetscInt_FMT ", loss=%s:\n", (double)Cp, (double)Cn, mod, SVMLossTypes[loss_type]));
     }
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(SVMViewBinaryClassificationReport(svm,svm_binary->confusion_matrix,svm_binary->model_scores,v));
+    PetscCall(SVMViewBinaryClassificationReport(svm, svm_binary->confusion_matrix, svm_binary->model_scores, v));
     PetscCall(PetscViewerASCIIPopTab(v));
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewScore", ((PetscObject)v)->type_name);
+    SETERRQ(comm, PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewScore", ((PetscObject)v)->type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetGramian_Binary"
-PetscErrorCode SVMSetGramian_Binary(SVM svm,Mat G)
+PetscErrorCode SVMSetGramian_Binary(SVM svm, Mat G)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  Mat        Xt;
-  PetscInt   m,n;
+  Mat      Xt;
+  PetscInt m, n;
 
   PetscFunctionBegin;
-  PetscCall(MatGetSize(G,&m,&n));
-  PetscCheck(m == n,PetscObjectComm((PetscObject) G),PETSC_ERR_ARG_SIZ,"Gramian (kernel) matrix must be square, G(%" PetscInt_FMT ",%" PetscInt_FMT ")",m,n);
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,NULL));
+  PetscCall(MatGetSize(G, &m, &n));
+  PetscCheck(m == n, PetscObjectComm((PetscObject)G), PETSC_ERR_ARG_SIZ, "Gramian (kernel) matrix must be square, G(%" PetscInt_FMT ",%" PetscInt_FMT ")", m, n);
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, NULL));
   if (Xt) {
-    PetscCall(MatGetSize(Xt,&n,NULL));
-    PetscCheck(m == n,PetscObjectComm((PetscObject) G),PETSC_ERR_ARG_SIZ,"Matrix dimensions are incompatible, G(%" PetscInt_FMT ",) != X_training(%" PetscInt_FMT ",)",m,n);
+    PetscCall(MatGetSize(Xt, &n, NULL));
+    PetscCheck(m == n, PetscObjectComm((PetscObject)G), PETSC_ERR_ARG_SIZ, "Matrix dimensions are incompatible, G(%" PetscInt_FMT ",) != X_training(%" PetscInt_FMT ",)", m, n);
   }
   PetscCall(MatDestroy(&svm_binary->G));
-  PetscCall(PetscObjectReference((PetscObject) G));
+  PetscCall(PetscObjectReference((PetscObject)G));
   svm_binary->G = G;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetGramian_Binary"
-PetscErrorCode SVMGetGramian_Binary(SVM svm,Mat *G)
+PetscErrorCode SVMGetGramian_Binary(SVM svm, Mat *G)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
   *G = svm_binary->G;
@@ -250,24 +250,24 @@ PetscErrorCode SVMGetGramian_Binary(SVM svm,Mat *G)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetOperator_Binary"
-PetscErrorCode SVMSetOperator_Binary(SVM svm,Mat A)
+PetscErrorCode SVMSetOperator_Binary(SVM svm, Mat A)
 {
-  QP       qp;
+  QP qp;
 
   Mat      Xt;
-  PetscInt m,n;
+  PetscInt m, n;
 
   PetscFunctionBegin;
-  PetscCall(MatGetSize(A,&m,&n));
-  PetscCheck(m == n,PetscObjectComm((PetscObject) A),PETSC_ERR_ARG_SIZ,"Hessian matrix must be square, G(%" PetscInt_FMT ",%" PetscInt_FMT ")",m,n);
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,NULL));
+  PetscCall(MatGetSize(A, &m, &n));
+  PetscCheck(m == n, PetscObjectComm((PetscObject)A), PETSC_ERR_ARG_SIZ, "Hessian matrix must be square, G(%" PetscInt_FMT ",%" PetscInt_FMT ")", m, n);
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, NULL));
   if (Xt) {
-    PetscCall(MatGetSize(Xt,&n,NULL));
-    PetscCheck(m == n,PetscObjectComm((PetscObject) A),PETSC_ERR_ARG_SIZ,"Matrix dimensions are incompatible, A(%" PetscInt_FMT ",) != X_training(%" PetscInt_FMT ",)",m,n);
+    PetscCall(MatGetSize(Xt, &n, NULL));
+    PetscCheck(m == n, PetscObjectComm((PetscObject)A), PETSC_ERR_ARG_SIZ, "Matrix dimensions are incompatible, A(%" PetscInt_FMT ",) != X_training(%" PetscInt_FMT ",)", m, n);
   }
 
-  PetscCall(SVMGetQP(svm,&qp));
-  PetscCall(QPSetOperator(qp,A));
+  PetscCall(SVMGetQP(svm, &qp));
+  PetscCall(QPSetOperator(qp, A));
 
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -275,62 +275,62 @@ PetscErrorCode SVMSetOperator_Binary(SVM svm,Mat A)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetOperator_Binary"
-PetscErrorCode SVMGetOperator_Binary(SVM svm,Mat *A)
+PetscErrorCode SVMGetOperator_Binary(SVM svm, Mat *A)
 {
-  QP  qp;
+  QP qp;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetQP(svm,&qp));
-  PetscCall(QPGetOperator(qp,A));
+  PetscCall(SVMGetQP(svm, &qp));
+  PetscCall(QPGetOperator(qp, A));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetTrainingDataset"
-PetscErrorCode SVMSetTrainingDataset_Binary(SVM svm,Mat Xt_training,Vec y_training)
+PetscErrorCode SVMSetTrainingDataset_Binary(SVM svm, Mat Xt_training, Vec y_training)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  PetscReal  max;
-  PetscInt   lo,hi;
-  PetscInt   m,n;
+  PetscReal max;
+  PetscInt  lo, hi;
+  PetscInt  m, n;
 
-  Mat        G;
-  Vec        tmp;
+  Mat G;
+  Vec tmp;
 
   PetscFunctionBegin;
-  PetscCall(MatGetSize(Xt_training,&m,NULL));
-  PetscCall(VecGetSize(y_training,&n));
-  PetscCheck(m == n,PetscObjectComm((PetscObject) Xt_training),PETSC_ERR_ARG_SIZ,"Dimensions are incompatible, X_training(%" PetscInt_FMT ",) != y_training(%" PetscInt_FMT ")",m,n);
+  PetscCall(MatGetSize(Xt_training, &m, NULL));
+  PetscCall(VecGetSize(y_training, &n));
+  PetscCheck(m == n, PetscObjectComm((PetscObject)Xt_training), PETSC_ERR_ARG_SIZ, "Dimensions are incompatible, X_training(%" PetscInt_FMT ",) != y_training(%" PetscInt_FMT ")", m, n);
 
-  PetscCall(SVMGetGramian(svm,&G));
+  PetscCall(SVMGetGramian(svm, &G));
   if (G) {
-    PetscCall(MatGetSize(G,&n,NULL));
-    PetscCheck(m == n,PetscObjectComm((PetscObject) G),PETSC_ERR_ARG_SIZ,"Matrix dimensions are incompatible, X_training(%" PetscInt_FMT ",) != G(%" PetscInt_FMT ",)",m,n);
+    PetscCall(MatGetSize(G, &n, NULL));
+    PetscCheck(m == n, PetscObjectComm((PetscObject)G), PETSC_ERR_ARG_SIZ, "Matrix dimensions are incompatible, X_training(%" PetscInt_FMT ",) != G(%" PetscInt_FMT ",)", m, n);
   }
 
   PetscCall(MatDestroy(&svm_binary->Xt_training));
   svm_binary->Xt_training = Xt_training;
-  PetscCall(PetscObjectReference((PetscObject) Xt_training));
+  PetscCall(PetscObjectReference((PetscObject)Xt_training));
 
   PetscCall(VecDestroy(&svm_binary->y_training));
   svm_binary->y_training = y_training;
-  PetscCall(PetscObjectReference((PetscObject) y_training));
+  PetscCall(PetscObjectReference((PetscObject)y_training));
 
   /* Determine index sets of positive and negative samples */
-  PetscCall(VecGetOwnershipRange(y_training,&lo,&hi));
-  PetscCall(VecMax(y_training,NULL,&max));
+  PetscCall(VecGetOwnershipRange(y_training, &lo, &hi));
+  PetscCall(VecMax(y_training, NULL, &max));
 
-  PetscCall(VecDuplicate(y_training,&tmp));
-  PetscCall(VecSet(tmp,max));
+  PetscCall(VecDuplicate(y_training, &tmp));
+  PetscCall(VecSet(tmp, max));
 
   /* Index set for positive samples */
   PetscCall(ISDestroy(&svm_binary->is_p));
-  PetscCall(VecWhichEqual(y_training,tmp,&svm_binary->is_p));
+  PetscCall(VecWhichEqual(y_training, tmp, &svm_binary->is_p));
 
   /* Index set for negative samples */
   PetscCall(ISDestroy(&svm_binary->is_n));
-  PetscCall(ISComplement(svm_binary->is_p,lo,hi,&svm_binary->is_n));
+  PetscCall(ISComplement(svm_binary->is_p, lo, hi, &svm_binary->is_n));
 
   /* Free memory */
   PetscCall(VecDestroy(&tmp));
@@ -339,26 +339,26 @@ PetscErrorCode SVMSetTrainingDataset_Binary(SVM svm,Mat Xt_training,Vec y_traini
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetTrainingDataset_Binary"
-PetscErrorCode SVMGetTrainingDataset_Binary(SVM svm,Mat *Xt_training,Vec *y_training)
+PetscErrorCode SVMGetTrainingDataset_Binary(SVM svm, Mat *Xt_training, Vec *y_training)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   if (Xt_training) {
-    PetscAssertPointer(Xt_training,2);
+    PetscAssertPointer(Xt_training, 2);
     *Xt_training = svm_binary->Xt_training;
   }
   if (y_training) {
-    PetscAssertPointer(y_training,3);
+    PetscAssertPointer(y_training, 3);
     *y_training = svm_binary->y_training;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetLabels_Binary(SVM svm,const PetscReal *labels[])
+PetscErrorCode SVMGetLabels_Binary(SVM svm, const PetscReal *labels[])
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
   *labels = svm_binary->y_map;
@@ -369,39 +369,39 @@ PetscErrorCode SVMGetLabels_Binary(SVM svm,const PetscReal *labels[])
 #define __FUNCT__ "SVMSetUp_Remapy_Binary_Private"
 static PetscErrorCode SVMSetUp_Remapy_Binary_Private(SVM svm)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  Vec               y;
-  PetscInt          i,n;
+  Vec      y;
+  PetscInt i, n;
 
-  PetscScalar       min,max;
+  PetscScalar        min, max;
   const PetscScalar *y_arr;
   PetscScalar       *y_inner_arr;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTrainingDataset(svm,NULL,&y));
-  PetscCall(VecMin(y,NULL,&min));
-  PetscCall(VecMax(y,NULL,&max));
+  PetscCall(SVMGetTrainingDataset(svm, NULL, &y));
+  PetscCall(VecMin(y, NULL, &min));
+  PetscCall(VecMax(y, NULL, &max));
 
   if (min == -1.0 && max == 1.0) {
     PetscCall(VecDestroy(&svm_binary->y_inner));
     svm_binary->y_inner = y;
-    PetscCall(PetscObjectReference((PetscObject) y));
+    PetscCall(PetscObjectReference((PetscObject)y));
   } else {
-    PetscCall(VecGetLocalSize(y,&n));
-    PetscCall(VecDuplicate(y,&svm_binary->y_inner));
+    PetscCall(VecGetLocalSize(y, &n));
+    PetscCall(VecDuplicate(y, &svm_binary->y_inner));
 
-    PetscCall(VecGetArrayRead(y,&y_arr));
-    PetscCall(VecGetArray(svm_binary->y_inner,&y_inner_arr));
+    PetscCall(VecGetArrayRead(y, &y_arr));
+    PetscCall(VecGetArray(svm_binary->y_inner, &y_inner_arr));
     for (i = 0; i < n; ++i) {
-      if (y_arr[i]==min) {
+      if (y_arr[i] == min) {
         y_inner_arr[i] = -1.0;
       } else if (y_arr[i] == max) {
         y_inner_arr[i] = 1.0;
       }
     }
-    PetscCall(VecRestoreArrayRead(y,&y_arr));
-    PetscCall(VecRestoreArray(svm_binary->y_inner,&y_inner_arr));
+    PetscCall(VecRestoreArrayRead(y, &y_arr));
+    PetscCall(VecRestoreArray(svm_binary->y_inner, &y_inner_arr));
   }
 
   svm_binary->y_map[0] = min;
@@ -411,42 +411,42 @@ static PetscErrorCode SVMSetUp_Remapy_Binary_Private(SVM svm)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMCreateQPS_Binary_Private"
-PetscErrorCode SVMCreateQPS_Binary_Private(SVM svm,QPS *qps)
+PetscErrorCode SVMCreateQPS_Binary_Private(SVM svm, QPS *qps)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscReal rtol, divtol, max_eig_tol;
-  PetscInt max_it, max_eig_it;
+  PetscInt  max_it, max_eig_it;
 
-  QPS      qps_inner,qps_smalxe_inner;
+  QPS      qps_inner, qps_smalxe_inner;
   PetscInt svm_mod;
 
   PetscFunctionBegin;
-  rtol = 1e-1;
-  divtol = 1e100;
-  max_it = 10000;
-  max_eig_it = 100;
+  rtol        = 1e-1;
+  divtol      = 1e100;
+  max_it      = 10000;
+  max_eig_it  = 100;
   max_eig_tol = 1e-5;
 
-  PetscCall(SVMGetMod(svm,&svm_mod));
+  PetscCall(SVMGetMod(svm, &svm_mod));
 
   PetscCall(QPSDestroy(&svm_binary->qps));
-  PetscCall(QPSCreate(PetscObjectComm((PetscObject) svm),&qps_inner));
+  PetscCall(QPSCreate(PetscObjectComm((PetscObject)svm), &qps_inner));
 
   if (svm_mod == 1) {
-    PetscCall(QPSSetType(qps_inner,QPSSMALXE));
-    PetscCall(QPSSMALXEGetInnerQPS(qps_inner,&qps_smalxe_inner));
-    PetscCall(QPSSetType(qps_smalxe_inner,QPSMPGP));
-    PetscCall(QPSSMALXESetOperatorMaxEigenvalueTolerance(qps_inner,max_eig_tol));
-    PetscCall(QPSSMALXESetOperatorMaxEigenvalueIterations(qps_inner,max_eig_it));
-    PetscCall(QPSSetTolerances(qps_smalxe_inner,rtol,PETSC_DEFAULT,divtol,max_it));
-    PetscCall(QPSSMALXESetM1Initial(qps_inner,1.0,QPS_ARG_MULTIPLE));
-    PetscCall(QPSSMALXESetRhoInitial(qps_inner,1.0,QPS_ARG_MULTIPLE));
+    PetscCall(QPSSetType(qps_inner, QPSSMALXE));
+    PetscCall(QPSSMALXEGetInnerQPS(qps_inner, &qps_smalxe_inner));
+    PetscCall(QPSSetType(qps_smalxe_inner, QPSMPGP));
+    PetscCall(QPSSMALXESetOperatorMaxEigenvalueTolerance(qps_inner, max_eig_tol));
+    PetscCall(QPSSMALXESetOperatorMaxEigenvalueIterations(qps_inner, max_eig_it));
+    PetscCall(QPSSetTolerances(qps_smalxe_inner, rtol, PETSC_DEFAULT, divtol, max_it));
+    PetscCall(QPSSMALXESetM1Initial(qps_inner, 1.0, QPS_ARG_MULTIPLE));
+    PetscCall(QPSSMALXESetRhoInitial(qps_inner, 1.0, QPS_ARG_MULTIPLE));
   } else {
-    PetscCall(QPSSetType(qps_inner,QPSMPGP));
-    PetscCall(QPSSetTolerances(qps_inner,rtol,PETSC_DEFAULT,divtol,max_it));
-    PetscCall(QPSMPGPSetOperatorMaxEigenvalueTolerance(qps_inner,max_eig_tol));
-    PetscCall(QPSMPGPSetOperatorMaxEigenvalueIterations(qps_inner,max_eig_it));
+    PetscCall(QPSSetType(qps_inner, QPSMPGP));
+    PetscCall(QPSSetTolerances(qps_inner, rtol, PETSC_DEFAULT, divtol, max_it));
+    PetscCall(QPSMPGPSetOperatorMaxEigenvalueTolerance(qps_inner, max_eig_tol));
+    PetscCall(QPSMPGPSetOperatorMaxEigenvalueIterations(qps_inner, max_eig_it));
   }
   *qps = qps_inner;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -454,14 +454,14 @@ PetscErrorCode SVMCreateQPS_Binary_Private(SVM svm,QPS *qps)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetQPS_Binary"
-PetscErrorCode SVMGetQPS_Binary(SVM svm,QPS *qps)
+PetscErrorCode SVMGetQPS_Binary(SVM svm, QPS *qps)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
-  QPS        qps_inner;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
+  QPS         qps_inner;
 
   PetscFunctionBegin;
   if (!svm_binary->qps) {
-    PetscCall(SVMCreateQPS_Binary_Private(svm,&qps_inner));
+    PetscCall(SVMCreateQPS_Binary_Private(svm, &qps_inner));
     svm_binary->qps = qps_inner;
   }
   *qps = svm_binary->qps;
@@ -470,16 +470,16 @@ PetscErrorCode SVMGetQPS_Binary(SVM svm,QPS *qps)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetQPS_Binary"
-PetscErrorCode SVMSetQPS_Binary(SVM svm,QPS qps)
+PetscErrorCode SVMSetQPS_Binary(SVM svm, QPS qps)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
-  PetscCheckSameComm(svm,1,qps,2);
+  PetscCheckSameComm(svm, 1, qps, 2);
 
   PetscCall(QPSDestroy(&svm_binary->qps));
   svm_binary->qps = qps;
-  PetscCall(PetscObjectReference((PetscObject) qps));
+  PetscCall(PetscObjectReference((PetscObject)qps));
 
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -487,13 +487,13 @@ PetscErrorCode SVMSetQPS_Binary(SVM svm,QPS qps)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetQP_Binary"
-PetscErrorCode SVMGetQP_Binary(SVM svm,QP *qp)
+PetscErrorCode SVMGetQP_Binary(SVM svm, QP *qp)
 {
   QPS qps;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetQPS(svm,&qps));
-  PetscCall(QPSGetQP(qps,qp));
+  PetscCall(SVMGetQPS(svm, &qps));
+  PetscCall(QPSGetQP(qps, qp));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -501,37 +501,37 @@ PetscErrorCode SVMGetQP_Binary(SVM svm,QP *qp)
 #define __FUNCT__ "SVMUpdateOperator_Binary_Private"
 PetscErrorCode SVMUpdateOperator_Binary_Private(SVM svm)
 {
-  SVM_Binary  *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  Vec         diag_p,diag_n;
+  Vec diag_p, diag_n;
 
   PetscInt    p;
   SVMLossType loss_type;
 
-  PetscReal   C,Cn,Cp;
+  PetscReal C, Cn, Cp;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetLossType(svm,&loss_type));
+  PetscCall(SVMGetLossType(svm, &loss_type));
   if (loss_type == SVM_L1) PetscFunctionReturn(PETSC_SUCCESS);
 
   /* Update regularization of Hessian */
-  PetscCall(SVMGetPenaltyType(svm,&p));
+  PetscCall(SVMGetPenaltyType(svm, &p));
   if (p == 1) {
-    PetscCall(SVMGetC(svm,&C));
+    PetscCall(SVMGetC(svm, &C));
 
-    PetscCall(MatScale(svm_binary->J,0.));
-    PetscCall(MatShift(svm_binary->J,1. / C));
+    PetscCall(MatScale(svm_binary->J, 0.));
+    PetscCall(MatShift(svm_binary->J, 1. / C));
   } else {
-    PetscCall(SVMGetCp(svm,&Cp));
-    PetscCall(SVMGetCn(svm,&Cn));
+    PetscCall(SVMGetCp(svm, &Cp));
+    PetscCall(SVMGetCn(svm, &Cn));
 
-    PetscCall(VecGetSubVector(svm_binary->diag,svm_binary->is_p,&diag_p));
-    PetscCall(VecSet(diag_p,1. / Cp));
-    PetscCall(VecRestoreSubVector(svm_binary->diag,svm_binary->is_p,&diag_p));
+    PetscCall(VecGetSubVector(svm_binary->diag, svm_binary->is_p, &diag_p));
+    PetscCall(VecSet(diag_p, 1. / Cp));
+    PetscCall(VecRestoreSubVector(svm_binary->diag, svm_binary->is_p, &diag_p));
 
-    PetscCall(VecGetSubVector(svm_binary->diag,svm_binary->is_n,&diag_n));
-    PetscCall(VecSet(diag_n,1. / Cn));
-    PetscCall(VecRestoreSubVector(svm_binary->diag,svm_binary->is_n,&diag_n));
+    PetscCall(VecGetSubVector(svm_binary->diag, svm_binary->is_n, &diag_n));
+    PetscCall(VecSet(diag_n, 1. / Cn));
+    PetscCall(VecRestoreSubVector(svm_binary->diag, svm_binary->is_n, &diag_n));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -542,78 +542,78 @@ PetscErrorCode SVMUpdateOperator_Binary_Private(SVM svm)
 #define __FUNCT__ "SVMUpdate_Binary_Private"
 PetscErrorCode SVMUpdate_Binary_Private(SVM svm)
 {
-  SVM_Binary  *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  QP          qp;
+  QP qp;
 
-  Vec         x_init,x_init_p,x_init_n;
-  Vec         ub = NULL,ub_p,ub_n;
+  Vec x_init, x_init_p, x_init_n;
+  Vec ub = NULL, ub_p, ub_n;
 
   PetscInt    p;
   SVMLossType loss_type;
 
-  PetscReal   C,Cn,Cp;
+  PetscReal C, Cn, Cp;
 
   PetscFunctionBegin;
   PetscCall(SVMUpdateOperator_Binary_Private(svm));
 
-  PetscCall(SVMGetPenaltyType(svm,&p));
+  PetscCall(SVMGetPenaltyType(svm, &p));
   if (p == 1) {
-    PetscCall(SVMGetC(svm,&C));
+    PetscCall(SVMGetC(svm, &C));
   } else {
-    PetscCall(SVMGetCp(svm,&Cp));
-    PetscCall(SVMGetCn(svm,&Cn));
+    PetscCall(SVMGetCp(svm, &Cp));
+    PetscCall(SVMGetCn(svm, &Cn));
   }
 
   /* Update initial guess */
-  PetscCall(SVMGetQP(svm,&qp));
-  PetscCall(QPGetSolutionVector(qp,&x_init));
+  PetscCall(SVMGetQP(svm, &qp));
+  PetscCall(QPGetSolutionVector(qp, &x_init));
 
   /* TODO SVMUpdateInitialVector_Binary_Private */
   if (svm->warm_start) {
     if (p == 1) {
-      PetscCall(VecScale(x_init,1. / svm->C_old));
-      PetscCall(VecScale(x_init,C));
+      PetscCall(VecScale(x_init, 1. / svm->C_old));
+      PetscCall(VecScale(x_init, C));
     } else {
-      PetscCall(VecGetSubVector(x_init,svm_binary->is_p,&x_init_p));
-      PetscCall(VecScale(x_init_p,1. / svm->Cp_old));
-      PetscCall(VecScale(x_init_p,Cp));
-      PetscCall(VecRestoreSubVector(x_init,svm_binary->is_p,&x_init_p));
+      PetscCall(VecGetSubVector(x_init, svm_binary->is_p, &x_init_p));
+      PetscCall(VecScale(x_init_p, 1. / svm->Cp_old));
+      PetscCall(VecScale(x_init_p, Cp));
+      PetscCall(VecRestoreSubVector(x_init, svm_binary->is_p, &x_init_p));
 
-      PetscCall(VecGetSubVector(x_init,svm_binary->is_n,&x_init_n));
-      PetscCall(VecScale(x_init_n,1. / svm->Cn_old));
-      PetscCall(VecScale(x_init_n,Cn));
-      PetscCall(VecRestoreSubVector(x_init,svm_binary->is_n,&x_init_n));
+      PetscCall(VecGetSubVector(x_init, svm_binary->is_n, &x_init_n));
+      PetscCall(VecScale(x_init_n, 1. / svm->Cn_old));
+      PetscCall(VecScale(x_init_n, Cn));
+      PetscCall(VecRestoreSubVector(x_init, svm_binary->is_n, &x_init_n));
     }
   } else {
     if (p == 1) {
-      PetscCall(VecSet(x_init,C - 100 * PETSC_MACHINE_EPSILON));
+      PetscCall(VecSet(x_init, C - 100 * PETSC_MACHINE_EPSILON));
     } else {
-      PetscCall(VecGetSubVector(x_init,svm_binary->is_p,&x_init_p));
-      PetscCall(VecSet(x_init_p,Cp - 100 * PETSC_MACHINE_EPSILON));
-      PetscCall(VecRestoreSubVector(x_init,svm_binary->is_p,&x_init_p));
+      PetscCall(VecGetSubVector(x_init, svm_binary->is_p, &x_init_p));
+      PetscCall(VecSet(x_init_p, Cp - 100 * PETSC_MACHINE_EPSILON));
+      PetscCall(VecRestoreSubVector(x_init, svm_binary->is_p, &x_init_p));
 
-      PetscCall(VecGetSubVector(x_init,svm_binary->is_n,&x_init_n));
-      PetscCall(VecSet(x_init_n,Cn - 100 * PETSC_MACHINE_EPSILON));
-      PetscCall(VecRestoreSubVector(x_init,svm_binary->is_n,&x_init_n));
+      PetscCall(VecGetSubVector(x_init, svm_binary->is_n, &x_init_n));
+      PetscCall(VecSet(x_init_n, Cn - 100 * PETSC_MACHINE_EPSILON));
+      PetscCall(VecRestoreSubVector(x_init, svm_binary->is_n, &x_init_n));
     }
   }
 
   /* Update upper bound vector */
-  PetscCall(SVMGetLossType(svm,&loss_type));
+  PetscCall(SVMGetLossType(svm, &loss_type));
   if (loss_type == SVM_L2) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCall(QPGetBox(qp,NULL,NULL,&ub));
+  PetscCall(QPGetBox(qp, NULL, NULL, &ub));
   if (p == 1) {
-    PetscCall(VecSet(ub,C));
+    PetscCall(VecSet(ub, C));
   } else {
-    PetscCall(VecGetSubVector(ub,svm_binary->is_p,&ub_p));
-    PetscCall(VecSet(ub_p,Cp));
-    PetscCall(VecRestoreSubVector(ub,svm_binary->is_p,&ub_p));
+    PetscCall(VecGetSubVector(ub, svm_binary->is_p, &ub_p));
+    PetscCall(VecSet(ub_p, Cp));
+    PetscCall(VecRestoreSubVector(ub, svm_binary->is_p, &ub_p));
 
-    PetscCall(VecGetSubVector(ub,svm_binary->is_n,&ub_n));
-    PetscCall(VecSet(ub_n,Cn));
-    PetscCall(VecRestoreSubVector(ub,svm_binary->is_n,&ub_n));
+    PetscCall(VecGetSubVector(ub, svm_binary->is_n, &ub_n));
+    PetscCall(VecSet(ub_n, Cn));
+    PetscCall(VecRestoreSubVector(ub, svm_binary->is_n, &ub_n));
   }
 
   svm->setupcalled     = PETSC_TRUE;
@@ -623,42 +623,42 @@ PetscErrorCode SVMUpdate_Binary_Private(SVM svm)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMComputeOperator_Binary"
-PetscErrorCode SVMComputeOperator_Binary(SVM svm,Mat *A)
+PetscErrorCode SVMComputeOperator_Binary(SVM svm, Mat *A)
 {
   MPI_Comm    comm;
-  SVM_Binary  *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  Mat         G,H,HpJ;
-  Mat         mats[2];
-  Mat         Xt,X = NULL;
-  PetscInt    m,n,M,N;
+  Mat      G, H, HpJ;
+  Mat      mats[2];
+  Mat      Xt, X = NULL;
+  PetscInt m, n, M, N;
 
-  Vec         y;
-  Vec         diag,diag_p,diag_n;
-  VecType     vtype;
+  Vec     y;
+  Vec     diag, diag_p, diag_n;
+  VecType vtype;
 
-  PetscInt    p;         /* penalty type */
+  PetscInt    p; /* penalty type */
   SVMLossType loss_type;
 
-  PetscReal   C,Cp,Cn;
+  PetscReal C, Cp, Cn;
 
   PetscFunctionBegin;
   /* Check if operator is set */
-  PetscCall(SVMGetOperator(svm,&H));
+  PetscCall(SVMGetOperator(svm, &H));
   if (H) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCall(SVMGetPenaltyType(svm,&p));
-  PetscCall(SVMGetLossType(svm,&loss_type));
+  PetscCall(SVMGetPenaltyType(svm, &p));
+  PetscCall(SVMGetLossType(svm, &loss_type));
 
-  PetscCall(SVMGetGramian(svm,&G));
+  PetscCall(SVMGetGramian(svm, &G));
   /* Create Gramian matrix (X^t * X) implicitly if it is not set by user, i.e. G == NULL */
   if (!G) {
     /* TODO add option for computing Gramian explicitly */
-    PetscCall(SVMGetTrainingDataset(svm,&Xt,NULL));
-    PetscCall(PermonMatTranspose(Xt,MAT_TRANSPOSE_CHEAPEST,&X));
-    PetscCall(MatCreateNormal(X,&G));  /* G = X^t * X */
+    PetscCall(SVMGetTrainingDataset(svm, &Xt, NULL));
+    PetscCall(PermonMatTranspose(Xt, MAT_TRANSPOSE_CHEAPEST, &X));
+    PetscCall(MatCreateNormal(X, &G)); /* G = X^t * X */
   } else {
-    PetscCall(PetscObjectReference((PetscObject) G));
+    PetscCall(PetscObjectReference((PetscObject)G));
   }
 
   /* Remap y to -1,1 values if needed */
@@ -667,7 +667,7 @@ PetscErrorCode SVMComputeOperator_Binary(SVM svm,Mat *A)
 
   /* Create Hessian matrix */
   H = G;
-  PetscCall(MatDiagonalScale(H,y,y)); /* H = diag(y) * G * diag(y) */
+  PetscCall(MatDiagonalScale(H, y, y)); /* H = diag(y) * G * diag(y) */
 
   /* Regularize Hessian in case of l2-loss SVM */
   if (loss_type == SVM_L2) {
@@ -675,49 +675,49 @@ PetscErrorCode SVMComputeOperator_Binary(SVM svm,Mat *A)
     /* H = H + t * I */
     /* https://link.springer.com/article/10.1134/S1054661812010129 */
     /* http://www.lib.kobe-u.ac.jp/repository/90000225.pdf */
-    PetscCall(PetscObjectGetComm((PetscObject) H,&comm));
+    PetscCall(PetscObjectGetComm((PetscObject)H, &comm));
     PetscCall(MatDestroy(&svm_binary->J));
 
     if (p == 1) { /* Penalty type 1 */
-      PetscCall(SVMGetC(svm,&C));
+      PetscCall(SVMGetC(svm, &C));
 
-      PetscCall(MatGetLocalSize(H,&m,&n));
-      PetscCall(MatGetSize(H,&M,&N));
+      PetscCall(MatGetLocalSize(H, &m, &n));
+      PetscCall(MatGetSize(H, &M, &N));
 
-      PetscCall(MatCreateConstantDiagonal(comm,m,n,M,N,1. / C,&svm_binary->J));
-      PetscCall(MatAssemblyBegin(svm_binary->J,MAT_FINAL_ASSEMBLY));
-      PetscCall(MatAssemblyEnd(svm_binary->J,MAT_FINAL_ASSEMBLY));
+      PetscCall(MatCreateConstantDiagonal(comm, m, n, M, N, 1. / C, &svm_binary->J));
+      PetscCall(MatAssemblyBegin(svm_binary->J, MAT_FINAL_ASSEMBLY));
+      PetscCall(MatAssemblyEnd(svm_binary->J, MAT_FINAL_ASSEMBLY));
     } else { /* Penalty type 2 */
-      PetscCall(SVMGetCp(svm,&Cp));
-      PetscCall(SVMGetCn(svm,&Cn));
+      PetscCall(SVMGetCp(svm, &Cp));
+      PetscCall(SVMGetCn(svm, &Cn));
 
       PetscCall(VecDestroy(&svm_binary->diag));
-      PetscCall(VecDuplicate(y,&svm_binary->diag));
+      PetscCall(VecDuplicate(y, &svm_binary->diag));
 
       diag = svm_binary->diag;
 
-      PetscCall(VecGetSubVector(diag,svm_binary->is_p,&diag_p));
-      PetscCall(VecSet(diag_p,1. / Cp));
-      PetscCall(VecRestoreSubVector(diag,svm_binary->is_p,&diag_p));
+      PetscCall(VecGetSubVector(diag, svm_binary->is_p, &diag_p));
+      PetscCall(VecSet(diag_p, 1. / Cp));
+      PetscCall(VecRestoreSubVector(diag, svm_binary->is_p, &diag_p));
 
-      PetscCall(VecGetSubVector(diag,svm_binary->is_n,&diag_n));
-      PetscCall(VecSet(diag_n,1. / Cn));
-      PetscCall(VecRestoreSubVector(diag,svm_binary->is_n,&diag_n));
+      PetscCall(VecGetSubVector(diag, svm_binary->is_n, &diag_n));
+      PetscCall(VecSet(diag_n, 1. / Cn));
+      PetscCall(VecRestoreSubVector(diag, svm_binary->is_n, &diag_n));
 
-      PetscCall(MatCreateDiag(diag,&svm_binary->J));
+      PetscCall(MatCreateDiag(diag, &svm_binary->J));
     }
 
     /* Set the default vector type for svm_binary->J to match that of H.
        This is needed for consistency if we want to use GPU back-ends! */
-    PetscCall(MatGetVecType(H,&vtype));
-    PetscCall(MatSetVecType(svm_binary->J,vtype));
+    PetscCall(MatGetVecType(H, &vtype));
+    PetscCall(MatSetVecType(svm_binary->J, vtype));
 
     mats[0] = svm_binary->J;
     mats[1] = H;
-    PetscCall(MatCreateComposite(comm,2,mats,&HpJ)); /* H = H + J */
+    PetscCall(MatCreateComposite(comm, 2, mats, &HpJ)); /* H = H + J */
     PetscCall(MatDestroy(&H));
 
-    H  = HpJ;
+    H = HpJ;
   }
 
   *A = H;
@@ -730,33 +730,33 @@ PetscErrorCode SVMComputeOperator_Binary(SVM svm,Mat *A)
 #define __FUNCT__ "SVMSetUp_Binary"
 PetscErrorCode SVMSetUp_Binary(SVM svm)
 {
-  SVM_Binary  *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  QPS         qps;
-  QP          qp;
+  QPS qps;
+  QP  qp;
 
-  Mat         Xt;
-  Vec         y;
+  Mat Xt;
+  Vec y;
 
-  Mat         H;
-  Vec         e;
-  Vec         x_init,x_init_p,x_init_n;
-  Mat         Be = NULL;
-  PetscReal   norm;
-  Vec         lb;
-  Vec         ub = NULL,ub_p,ub_n;
+  Mat       H;
+  Vec       e;
+  Vec       x_init, x_init_p, x_init_n;
+  Mat       Be = NULL;
+  PetscReal norm;
+  Vec       lb;
+  Vec       ub = NULL, ub_p, ub_n;
 
-  PetscInt    p;        /* penalty type */
+  PetscInt    p; /* penalty type */
   PetscInt    svm_mod;
   SVMLossType loss_type;
 
-  PetscReal   C,Cp,Cn;
+  PetscReal C, Cp, Cn;
 
-  PetscInt    i;
+  PetscInt i;
 
   /* monitors */
-  PetscBool   svm_monitor_set;
-  void        *mctx;  /* monitor context */
+  PetscBool svm_monitor_set;
+  void     *mctx; /* monitor context */
 
   PetscFunctionBegin;
   if (svm->setupcalled) PetscFunctionReturn(PETSC_SUCCESS);
@@ -767,132 +767,130 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
   }
 
   /* TODO generalize implementation of hyper parameter optimization */
-  if (svm->hyperoptset) {
-    PetscCall(SVMGridSearch(svm));
-  }
+  if (svm->hyperoptset) { PetscCall(SVMGridSearch(svm)); }
 
-  PetscCall(SVMComputeOperator(svm,&H)); /* compute Hessian of QP problem */
-  PetscCall(SVMSetOperator(svm,H));
+  PetscCall(SVMComputeOperator(svm, &H)); /* compute Hessian of QP problem */
+  PetscCall(SVMSetOperator(svm, H));
 
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,&y)); /* get samples and label vector for latter computing */
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, &y)); /* get samples and label vector for latter computing */
 
-  PetscCall(SVMGetQPS(svm,&qps));
-  PetscCall(QPSGetQP(qps,&qp));
+  PetscCall(SVMGetQPS(svm, &qps));
+  PetscCall(QPSGetQP(qps, &qp));
 
   /* Set RHS */
-  PetscCall(VecDuplicate(y,&e));  /* creating vector e same size and type as y_training */
-  PetscCall(VecSet(e,1.));
-  PetscCall(QPSetRhs(qp,e));      /* set linear term of QP problem */
+  PetscCall(VecDuplicate(y, &e)); /* creating vector e same size and type as y_training */
+  PetscCall(VecSet(e, 1.));
+  PetscCall(QPSetRhs(qp, e)); /* set linear term of QP problem */
 
   /* Set equality constraint for SVM mod 1 */
-  PetscCall(SVMGetMod(svm,&svm_mod));
+  PetscCall(SVMGetMod(svm, &svm_mod));
   if (svm_mod == 1) {
-    PetscCall(MatCreateOneRow(y,&Be));   /* Be = y^t */
-    PetscCall(VecNorm(y,NORM_2,&norm));
-    PetscCall(MatScale(Be,1. / norm));    /* ||Be|| = 1 */
-    PetscCall(QPSetEq(qp,Be,NULL));
+    PetscCall(MatCreateOneRow(y, &Be)); /* Be = y^t */
+    PetscCall(VecNorm(y, NORM_2, &norm));
+    PetscCall(MatScale(Be, 1. / norm)); /* ||Be|| = 1 */
+    PetscCall(QPSetEq(qp, Be, NULL));
   }
 
   /* Create box constraint */
-  PetscCall(VecDuplicate(y,&lb));  /* create lower bound constraint */
-  PetscCall(VecSet(lb,0.));
+  PetscCall(VecDuplicate(y, &lb)); /* create lower bound constraint */
+  PetscCall(VecSet(lb, 0.));
 
-  PetscCall(SVMGetPenaltyType(svm,&p));
+  PetscCall(SVMGetPenaltyType(svm, &p));
   if (p == 1) {
-    PetscCall(SVMGetC(svm,&C));
+    PetscCall(SVMGetC(svm, &C));
   } else {
-    PetscCall(SVMGetCp(svm,&Cp));
-    PetscCall(SVMGetCn(svm,&Cn));
+    PetscCall(SVMGetCp(svm, &Cp));
+    PetscCall(SVMGetCn(svm, &Cn));
   }
 
-  PetscCall(SVMGetLossType(svm,&loss_type));
+  PetscCall(SVMGetLossType(svm, &loss_type));
   if (loss_type == SVM_L1) {
-    PetscCall(VecDuplicate(lb,&ub));
+    PetscCall(VecDuplicate(lb, &ub));
 
     if (p == 1) {
-      PetscCall(VecSet(ub,C));
+      PetscCall(VecSet(ub, C));
     } else {
       /* Set upper bound constrain related to positive samples */
-      PetscCall(VecGetSubVector(ub,svm_binary->is_p,&ub_p));
-      PetscCall(VecSet(ub_p,Cp));
-      PetscCall(VecRestoreSubVector(ub,svm_binary->is_p,&ub_p));
+      PetscCall(VecGetSubVector(ub, svm_binary->is_p, &ub_p));
+      PetscCall(VecSet(ub_p, Cp));
+      PetscCall(VecRestoreSubVector(ub, svm_binary->is_p, &ub_p));
 
       /* Set upper bound constrain related to negative samples */
-      PetscCall(VecGetSubVector(ub,svm_binary->is_n,&ub_n));
-      PetscCall(VecSet(ub_n,Cn));
-      PetscCall(VecRestoreSubVector(ub,svm_binary->is_n,&ub_n));
+      PetscCall(VecGetSubVector(ub, svm_binary->is_n, &ub_n));
+      PetscCall(VecSet(ub_n, Cn));
+      PetscCall(VecRestoreSubVector(ub, svm_binary->is_n, &ub_n));
     }
   }
 
-  PetscCall(QPSetBox(qp,NULL,lb,ub));
+  PetscCall(QPSetBox(qp, NULL, lb, ub));
 
   /* TODO create public method for setting initial vector */
   /* Set initial guess */
-  PetscCall(VecDuplicate(lb,&x_init));
+  PetscCall(VecDuplicate(lb, &x_init));
 
   if (p == 1) {
-    PetscCall(VecSet(x_init,C - 100 * PETSC_MACHINE_EPSILON));
+    PetscCall(VecSet(x_init, C - 100 * PETSC_MACHINE_EPSILON));
   } else {
-    PetscCall(VecGetSubVector(x_init,svm_binary->is_p,&x_init_p));
-    PetscCall(VecSet(x_init_p,Cp - 100 * PETSC_MACHINE_EPSILON));
-    PetscCall(VecRestoreSubVector(x_init,svm_binary->is_p,&x_init_p));
+    PetscCall(VecGetSubVector(x_init, svm_binary->is_p, &x_init_p));
+    PetscCall(VecSet(x_init_p, Cp - 100 * PETSC_MACHINE_EPSILON));
+    PetscCall(VecRestoreSubVector(x_init, svm_binary->is_p, &x_init_p));
 
-    PetscCall(VecGetSubVector(x_init,svm_binary->is_n,&x_init_n));
-    PetscCall(VecSet(x_init_n,Cn - 100 * PETSC_MACHINE_EPSILON));
-    PetscCall(VecRestoreSubVector(x_init,svm_binary->is_n,&x_init_n));
+    PetscCall(VecGetSubVector(x_init, svm_binary->is_n, &x_init_n));
+    PetscCall(VecSet(x_init_n, Cn - 100 * PETSC_MACHINE_EPSILON));
+    PetscCall(VecRestoreSubVector(x_init, svm_binary->is_n, &x_init_n));
   }
-  PetscCall(QPSetInitialVector(qp,x_init));
+  PetscCall(QPSetInitialVector(qp, x_init));
   PetscCall(VecDestroy(&x_init));
 
   /* TODO create public method for setting monitors */
   /* Set monitors */
-  PetscCall(PetscOptionsHasName(NULL,((PetscObject) svm)->prefix,"-svm_monitor",&svm_monitor_set));
+  PetscCall(PetscOptionsHasName(NULL, ((PetscObject)svm)->prefix, "-svm_monitor", &svm_monitor_set));
   if (svm_monitor_set) {
-    PetscCall(SVMMonitorCreateCtx_Binary(&mctx,svm));
+    PetscCall(SVMMonitorCreateCtx_Binary(&mctx, svm));
     if (svm_mod == 1) {
       QPS qps_inner;
-      PetscCall(QPSSMALXEGetInnerQPS(qps,&qps_inner));
-      PetscCall(QPSMonitorSet(qps_inner,SVMMonitorDefault_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSSMALXEGetInnerQPS(qps, &qps_inner));
+      PetscCall(QPSMonitorSet(qps_inner, SVMMonitorDefault_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     } else {
-      PetscCall(QPSMonitorSet(qps,SVMMonitorDefault_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSMonitorSet(qps, SVMMonitorDefault_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     }
   }
-  PetscCall(PetscOptionsHasName(NULL,((PetscObject) svm)->prefix,"-svm_monitor_obj_funcs",&svm_monitor_set));
+  PetscCall(PetscOptionsHasName(NULL, ((PetscObject)svm)->prefix, "-svm_monitor_obj_funcs", &svm_monitor_set));
   if (svm_monitor_set) {
-    PetscCall(SVMMonitorCreateCtx_Binary(&mctx,svm));
+    PetscCall(SVMMonitorCreateCtx_Binary(&mctx, svm));
     if (svm_mod == 1) {
       QPS qps_inner;
-      PetscCall(QPSSMALXEGetInnerQPS(qps,&qps_inner));
-      PetscCall(QPSMonitorSet(qps_inner,SVMMonitorObjFuncs_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSSMALXEGetInnerQPS(qps, &qps_inner));
+      PetscCall(QPSMonitorSet(qps_inner, SVMMonitorObjFuncs_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     } else {
-      PetscCall(QPSMonitorSet(qps,SVMMonitorObjFuncs_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSMonitorSet(qps, SVMMonitorObjFuncs_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     }
   }
-  PetscCall(PetscOptionsHasName(NULL,((PetscObject) svm)->prefix,"-svm_monitor_training_scores",&svm_monitor_set));
+  PetscCall(PetscOptionsHasName(NULL, ((PetscObject)svm)->prefix, "-svm_monitor_training_scores", &svm_monitor_set));
   if (svm_monitor_set) {
-    PetscCall(SVMMonitorCreateCtx_Binary(&mctx,svm));
+    PetscCall(SVMMonitorCreateCtx_Binary(&mctx, svm));
     if (svm_mod == 1) {
       QPS qps_inner;
-      PetscCall(QPSSMALXEGetInnerQPS(qps,&qps_inner));
-      PetscCall(QPSMonitorSet(qps_inner,SVMMonitorTrainingScores_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSSMALXEGetInnerQPS(qps, &qps_inner));
+      PetscCall(QPSMonitorSet(qps_inner, SVMMonitorTrainingScores_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     } else {
-      PetscCall(QPSMonitorSet(qps,SVMMonitorTrainingScores_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSMonitorSet(qps, SVMMonitorTrainingScores_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     }
   }
-  PetscCall(PetscOptionsHasName(NULL,((PetscObject) svm)->prefix,"-svm_monitor_scores",&svm_monitor_set));
+  PetscCall(PetscOptionsHasName(NULL, ((PetscObject)svm)->prefix, "-svm_monitor_scores", &svm_monitor_set));
   if (svm_monitor_set) {
     Mat Xt_test;
     Vec y_test;
 
-    PetscCall(SVMGetTestDataset(svm,&Xt_test,&y_test));
-    PetscCheck(Xt_test || y_test,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_NULL,"Test dataset must be set for using -svm_monitor_scores.");
-    PetscCall(SVMMonitorCreateCtx_Binary(&mctx,svm));
+    PetscCall(SVMGetTestDataset(svm, &Xt_test, &y_test));
+    PetscCheck(Xt_test || y_test, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_NULL, "Test dataset must be set for using -svm_monitor_scores.");
+    PetscCall(SVMMonitorCreateCtx_Binary(&mctx, svm));
     if (svm_mod == 1) {
       QPS qps_inner;
-      PetscCall(QPSSMALXEGetInnerQPS(qps,&qps_inner));
-      PetscCall(QPSMonitorSet(qps_inner,SVMMonitorScores_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSSMALXEGetInnerQPS(qps, &qps_inner));
+      PetscCall(QPSMonitorSet(qps_inner, SVMMonitorScores_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     } else {
-      PetscCall(QPSMonitorSet(qps,SVMMonitorScores_Binary,mctx,SVMMonitorDestroyCtx_Binary));
+      PetscCall(QPSMonitorSet(qps, SVMMonitorScores_Binary, mctx, SVMMonitorDestroyCtx_Binary));
     }
   }
 
@@ -908,13 +906,11 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
   PetscCall(QPSSetUp(qps));
 
   /* Create work vectors */
-  for (i = 0; i < 3; ++i) {
-    PetscCall(VecDestroy(&svm_binary->work[i]));
-  }
+  for (i = 0; i < 3; ++i) { PetscCall(VecDestroy(&svm_binary->work[i])); }
 
-  PetscCall(MatCreateVecs(Xt,NULL,&svm_binary->work[0])); /* TODO use duplicated vector y instead of creating vec? */
-  PetscCall(VecDuplicate(svm_binary->work[0],&svm_binary->work[1]));
-  PetscCall(VecDuplicate(svm_binary->work[0],&svm_binary->work[2]));
+  PetscCall(MatCreateVecs(Xt, NULL, &svm_binary->work[0])); /* TODO use duplicated vector y instead of creating vec? */
+  PetscCall(VecDuplicate(svm_binary->work[0], &svm_binary->work[1]));
+  PetscCall(VecDuplicate(svm_binary->work[0], &svm_binary->work[2]));
 
   /* Decreasing reference counts using destroy methods */
   PetscCall(MatDestroy(&H));
@@ -929,37 +925,36 @@ PetscErrorCode SVMSetUp_Binary(SVM svm)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetOptionsPrefix_Binary"
-PetscErrorCode SVMSetOptionsPrefix_Binary(SVM svm,const char prefix[])
+PetscErrorCode SVMSetOptionsPrefix_Binary(SVM svm, const char prefix[])
 {
   QPS qps;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) svm,prefix));
-  PetscCall(SVMGetQPS(svm,&qps));
-  PetscCall(QPSSetOptionsPrefix(qps,prefix));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)svm, prefix));
+  PetscCall(SVMGetQPS(svm, &qps));
+  PetscCall(QPSSetOptionsPrefix(qps, prefix));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMAppendOptionsPrefix_Binary"
-PetscErrorCode SVMAppendOptionsPrefix_Binary(SVM svm,const char prefix[])
+PetscErrorCode SVMAppendOptionsPrefix_Binary(SVM svm, const char prefix[])
 {
   QPS qps;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject) svm,prefix));
-  PetscCall(SVMGetQPS(svm,&qps));
-  PetscCall(QPSAppendOptionsPrefix(qps,prefix));
+  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject)svm, prefix));
+  PetscCall(SVMGetQPS(svm, &qps));
+  PetscCall(QPSAppendOptionsPrefix(qps, prefix));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetOptionsPrefix_Binary"
-PetscErrorCode SVMGetOptionsPrefix_Binary(SVM svm,const char *prefix[])
+PetscErrorCode SVMGetOptionsPrefix_Binary(SVM svm, const char *prefix[])
 {
-
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetOptionsPrefix((PetscObject) svm,prefix));
+  PetscCall(PetscObjectGetOptionsPrefix((PetscObject)svm, prefix));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -967,15 +962,13 @@ PetscErrorCode SVMGetOptionsPrefix_Binary(SVM svm,const char *prefix[])
 #define __FUNCT__ "SVMTrain_Binary"
 PetscErrorCode SVMTrain_Binary(SVM svm)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
   PetscCall(SVMSetUp(svm));
-  PetscCall(QPSSetAutoPostSolve(svm_binary->qps,PETSC_FALSE));
+  PetscCall(QPSSetAutoPostSolve(svm_binary->qps, PETSC_FALSE));
   PetscCall(QPSSolve(svm_binary->qps));
-  if (svm->autoposttrain) {
-    PetscCall(SVMPostTrain(svm));
-  }
+  if (svm->autoposttrain) { PetscCall(SVMPostTrain(svm)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -983,57 +976,57 @@ PetscErrorCode SVMTrain_Binary(SVM svm)
 #define __FUNCT__ "SVMReconstructHyperplane_Binary"
 PetscErrorCode SVMReconstructHyperplane_Binary(SVM svm)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  QP        qp;
-  Vec       lb,ub;
+  QP  qp;
+  Vec lb, ub;
 
-  Mat       Xt;
-  Vec       x,y,yx,y_sv,t;
-  Vec       Xtw_sv;
+  Mat Xt;
+  Vec x, y, yx, y_sv, t;
+  Vec Xtw_sv;
 
   Vec       w_inner;
   PetscReal b_inner;
 
-  PetscInt  svm_mod;
+  PetscInt svm_mod;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,NULL));
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, NULL));
   y = svm_binary->y_inner;
 
   /* Reconstruction of hyperplane normal */
-  PetscCall(SVMGetQP(svm,&qp));
-  PetscCall(QPGetSolutionVector(qp,&x));
-  PetscCall(VecDuplicate(x,&yx));
+  PetscCall(SVMGetQP(svm, &qp));
+  PetscCall(QPGetSolutionVector(qp, &x));
+  PetscCall(VecDuplicate(x, &yx));
 
-  PetscCall(VecPointwiseMult(yx,y,x)); /* yx = y.*x */
-  PetscCall(MatCreateVecs(Xt,&w_inner,NULL));
-  PetscCall(MatMultTranspose(Xt,yx,w_inner)); /* w = (X^t)^t * yx = X * yx */
+  PetscCall(VecPointwiseMult(yx, y, x)); /* yx = y.*x */
+  PetscCall(MatCreateVecs(Xt, &w_inner, NULL));
+  PetscCall(MatMultTranspose(Xt, yx, w_inner)); /* w = (X^t)^t * yx = X * yx */
 
   /* Reconstruction of the hyperplane bias */
-  PetscCall(SVMGetMod(svm,&svm_mod));
+  PetscCall(SVMGetMod(svm, &svm_mod));
   if (svm_mod == 1) {
-    PetscCall(QPGetBox(qp,NULL,&lb,&ub));
+    PetscCall(QPGetBox(qp, NULL, &lb, &ub));
 
     PetscCall(ISDestroy(&svm_binary->is_sv));
     if (svm->loss_type == SVM_L1) {
-      PetscCall(VecWhichBetween(lb,x,ub,&svm_binary->is_sv));
+      PetscCall(VecWhichBetween(lb, x, ub, &svm_binary->is_sv));
     } else {
-      PetscCall(VecWhichGreaterThan(x,lb,&svm_binary->is_sv));
+      PetscCall(VecWhichGreaterThan(x, lb, &svm_binary->is_sv));
     }
-    PetscCall(ISGetSize(svm_binary->is_sv,&svm_binary->nsv));
+    PetscCall(ISGetSize(svm_binary->is_sv, &svm_binary->nsv));
 
-    PetscCall(MatMult(Xt,w_inner,svm_binary->work[2]));
+    PetscCall(MatMult(Xt, w_inner, svm_binary->work[2]));
 
-    PetscCall(VecGetSubVector(y,svm_binary->is_sv,&y_sv));     /* y_sv = y(is_sv) */
-    PetscCall(VecGetSubVector(svm_binary->work[2],svm_binary->is_sv,&Xtw_sv)); /* Xtw_sv = Xt(is_sv) */
+    PetscCall(VecGetSubVector(y, svm_binary->is_sv, &y_sv));                     /* y_sv = y(is_sv) */
+    PetscCall(VecGetSubVector(svm_binary->work[2], svm_binary->is_sv, &Xtw_sv)); /* Xtw_sv = Xt(is_sv) */
 
-    PetscCall(VecDuplicate(y_sv,&t));
-    PetscCall(VecWAXPY(t,-1.,Xtw_sv,y_sv));
+    PetscCall(VecDuplicate(y_sv, &t));
+    PetscCall(VecWAXPY(t, -1., Xtw_sv, y_sv));
 
-    PetscCall(VecRestoreSubVector(y,svm_binary->is_sv,&y_sv));
-    PetscCall(VecRestoreSubVector(svm_binary->work[2],svm_binary->is_sv,&Xtw_sv));
-    PetscCall(VecSum(t,&b_inner));
+    PetscCall(VecRestoreSubVector(y, svm_binary->is_sv, &y_sv));
+    PetscCall(VecRestoreSubVector(svm_binary->work[2], svm_binary->is_sv, &Xtw_sv));
+    PetscCall(VecSum(t, &b_inner));
 
     b_inner /= svm_binary->nsv;
 
@@ -1042,7 +1035,7 @@ PetscErrorCode SVMReconstructHyperplane_Binary(SVM svm)
     b_inner = 0.;
   }
 
-  PetscCall(SVMSetSeparatingHyperplane(svm,w_inner,b_inner));
+  PetscCall(SVMSetSeparatingHyperplane(svm, w_inner, b_inner));
 
   PetscCall(VecDestroy(&w_inner));
   PetscCall(VecDestroy(&yx));
@@ -1051,33 +1044,33 @@ PetscErrorCode SVMReconstructHyperplane_Binary(SVM svm)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetSeparatingHyperplane_Binary"
-PetscErrorCode SVMSetSeparatingHyperplane_Binary(SVM svm,Vec w,PetscReal b)
+PetscErrorCode SVMSetSeparatingHyperplane_Binary(SVM svm, Vec w, PetscReal b)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
-  PetscCheckSameComm(svm,1,w,2);
+  PetscCheckSameComm(svm, 1, w, 2);
 
   PetscCall(VecDestroy(&svm_binary->w));
   svm_binary->w = w;
   svm_binary->b = b;
-  PetscCall(PetscObjectReference((PetscObject) w));
+  PetscCall(PetscObjectReference((PetscObject)w));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetSeparatingHyperplane_Binary"
-PetscErrorCode SVMGetSeparatingHyperplane_Binary(SVM svm,Vec *w,PetscReal *b)
+PetscErrorCode SVMGetSeparatingHyperplane_Binary(SVM svm, Vec *w, PetscReal *b)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
   if (w) {
-    PetscAssertPointer(w,2);
+    PetscAssertPointer(w, 2);
     *w = svm_binary->w;
   }
   if (b) {
-    PetscAssertPointer(b,3);
+    PetscAssertPointer(b, 3);
     *b = svm_binary->b;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1085,15 +1078,15 @@ PetscErrorCode SVMGetSeparatingHyperplane_Binary(SVM svm,Vec *w,PetscReal *b)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetBias_Binary"
-PetscErrorCode SVMSetBias_Binary(SVM svm,PetscReal b)
+PetscErrorCode SVMSetBias_Binary(SVM svm, PetscReal b)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
-  PetscValidLogicalCollectiveReal(svm,b,2);
+  PetscValidLogicalCollectiveReal(svm, b, 2);
 
   if (svm_binary->b != b) {
-    svm_binary->b = b;
+    svm_binary->b    = b;
     svm->setupcalled = PETSC_FALSE;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1101,9 +1094,9 @@ PetscErrorCode SVMSetBias_Binary(SVM svm,PetscReal b)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetBias_Binary"
-PetscErrorCode SVMGetBias_Binary(SVM svm,PetscReal *b)
+PetscErrorCode SVMGetBias_Binary(SVM svm, PetscReal *b)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
   *b = svm_binary->b;
@@ -1114,34 +1107,32 @@ PetscErrorCode SVMGetBias_Binary(SVM svm,PetscReal *b)
 #define __FUNCT__ "SVMComputeModelParams_Binary"
 PetscErrorCode SVMComputeModelParams_Binary(SVM svm)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  QP          qp;
-  Vec         x,lb,ub;
-  Vec         w;
-  PetscReal   max;
+  QP        qp;
+  Vec       x, lb, ub;
+  Vec       w;
+  PetscReal max;
 
   SVMLossType loss_type;
   PetscInt    svm_mod;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetQP(svm,&qp));
-  PetscCall(SVMGetLossType(svm,&loss_type));
-  PetscCall(SVMGetMod(svm,&svm_mod));
+  PetscCall(SVMGetQP(svm, &qp));
+  PetscCall(SVMGetLossType(svm, &loss_type));
+  PetscCall(SVMGetMod(svm, &svm_mod));
 
-  PetscCall(SVMGetSeparatingHyperplane(svm,&w,NULL));
-  if (!w) {
-    PetscCall(SVMReconstructHyperplane(svm));
-  }
+  PetscCall(SVMGetSeparatingHyperplane(svm, &w, NULL));
+  if (!w) { PetscCall(SVMReconstructHyperplane(svm)); }
 
-  PetscCall(VecNorm(w,NORM_2,&svm_binary->norm_w));
+  PetscCall(VecNorm(w, NORM_2, &svm_binary->norm_w));
   svm_binary->margin = 2. / svm_binary->norm_w;
 
-  PetscCall(QPGetSolutionVector(qp,&x));
-  PetscCall(QPGetBox(qp,NULL,&lb,&ub));
+  PetscCall(QPGetSolutionVector(qp, &x));
+  PetscCall(QPGetBox(qp, NULL, &lb, &ub));
 
-  PetscCall(VecMax(x,NULL,&max));
-  PetscCall(VecFilter(x,svm_binary->chop_tol*max));
+  PetscCall(VecMax(x, NULL, &max));
+  PetscCall(VecFilter(x, svm_binary->chop_tol * max));
 
   if (svm_mod == 2) {
     PetscCall(ISDestroy(&svm_binary->is_sv));
@@ -1159,70 +1150,70 @@ PetscErrorCode SVMComputeModelParams_Binary(SVM svm)
 #define __FUNCT__ "SVMComputeHingeLoss_Binary"
 PetscErrorCode SVMComputeHingeLoss_Binary(SVM svm)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  Mat         Xt;
-  Vec         y;
+  Mat Xt;
+  Vec y;
 
   Vec         w;
   PetscScalar b;
 
-  PetscInt    p;        /* penalty type */
+  PetscInt    p; /* penalty type */
   PetscInt    svm_mod;
-  Vec         work_p,work_n;
+  Vec         work_p, work_n;
   SVMLossType loss_type;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetMod(svm,&svm_mod));
-  PetscCall(SVMGetLossType(svm,&loss_type));
-  PetscCall(SVMGetPenaltyType(svm,&p));
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,&y));
+  PetscCall(SVMGetMod(svm, &svm_mod));
+  PetscCall(SVMGetLossType(svm, &loss_type));
+  PetscCall(SVMGetPenaltyType(svm, &p));
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, &y));
 
-  PetscCall(SVMGetSeparatingHyperplane(svm,&w,NULL));
+  PetscCall(SVMGetSeparatingHyperplane(svm, &w, NULL));
   if (!w) {
     PetscCall(SVMReconstructHyperplane(svm));
-    PetscCall(SVMGetSeparatingHyperplane(svm,&w,NULL));
+    PetscCall(SVMGetSeparatingHyperplane(svm, &w, NULL));
   }
 
   if (svm_mod == 1) {
-    PetscCall(SVMGetSeparatingHyperplane(svm,NULL,&b));
-    PetscCall(VecSet(svm_binary->work[1],-b));
-    PetscCall(VecCopy(svm_binary->work[2],svm_binary->work[0]));
-    PetscCall(VecAYPX(svm_binary->work[0],1.,svm_binary->work[1])); /* xi = Xtw - b */
+    PetscCall(SVMGetSeparatingHyperplane(svm, NULL, &b));
+    PetscCall(VecSet(svm_binary->work[1], -b));
+    PetscCall(VecCopy(svm_binary->work[2], svm_binary->work[0]));
+    PetscCall(VecAYPX(svm_binary->work[0], 1., svm_binary->work[1])); /* xi = Xtw - b */
   } else {
-    PetscCall(MatMult(Xt,w,svm_binary->work[0])); /* xi = Xtw */
+    PetscCall(MatMult(Xt, w, svm_binary->work[0])); /* xi = Xtw */
   }
 
-  PetscCall(VecPointwiseMult(svm_binary->work[0],y,svm_binary->work[0])); /* xi = y .* xi */
+  PetscCall(VecPointwiseMult(svm_binary->work[0], y, svm_binary->work[0])); /* xi = y .* xi */
 
-  PetscCall(VecSet(svm_binary->work[1],1.));
-  PetscCall(VecAYPX(svm_binary->work[0],-1.,svm_binary->work[1]));       /* xi = 1 - xi */
-  PetscCall(VecSet(svm_binary->work[1],0.));
-  PetscCall(VecPointwiseMax(svm_binary->work[0],svm_binary->work[1],svm_binary->work[0])); /* max(0,xi) */
+  PetscCall(VecSet(svm_binary->work[1], 1.));
+  PetscCall(VecAYPX(svm_binary->work[0], -1., svm_binary->work[1])); /* xi = 1 - xi */
+  PetscCall(VecSet(svm_binary->work[1], 0.));
+  PetscCall(VecPointwiseMax(svm_binary->work[0], svm_binary->work[1], svm_binary->work[0])); /* max(0,xi) */
 
   if (loss_type == SVM_L1) {
     if (p == 1) {
-      PetscCall(VecSum(svm_binary->work[0],&svm_binary->hinge_loss)); /* hinge_loss = sum(xi) */
+      PetscCall(VecSum(svm_binary->work[0], &svm_binary->hinge_loss)); /* hinge_loss = sum(xi) */
     } else {
-      PetscCall(VecGetSubVector(svm_binary->work[0],svm_binary->is_p,&work_p));
-      PetscCall(VecSum(work_p,&svm_binary->hinge_loss_p)); /* hinge_loss_p = sum(xi_p) */
-      PetscCall(VecRestoreSubVector(svm_binary->work[0],svm_binary->is_p,&work_p));
+      PetscCall(VecGetSubVector(svm_binary->work[0], svm_binary->is_p, &work_p));
+      PetscCall(VecSum(work_p, &svm_binary->hinge_loss_p)); /* hinge_loss_p = sum(xi_p) */
+      PetscCall(VecRestoreSubVector(svm_binary->work[0], svm_binary->is_p, &work_p));
 
-      PetscCall(VecGetSubVector(svm_binary->work[0],svm_binary->is_n,&work_n));
-      PetscCall(VecSum(work_n,&svm_binary->hinge_loss_n)); /* hinge_loss_n = sum(xi_n) */
-      PetscCall(VecRestoreSubVector(svm_binary->work[0],svm_binary->is_n,&work_n));
+      PetscCall(VecGetSubVector(svm_binary->work[0], svm_binary->is_n, &work_n));
+      PetscCall(VecSum(work_n, &svm_binary->hinge_loss_n)); /* hinge_loss_n = sum(xi_n) */
+      PetscCall(VecRestoreSubVector(svm_binary->work[0], svm_binary->is_n, &work_n));
     }
   } else {
     if (p == 1) {
-      PetscCall(VecDot(svm_binary->work[0],svm_binary->work[0],&svm_binary->hinge_loss)); /* hinge_loss = sum(xi^2) */
+      PetscCall(VecDot(svm_binary->work[0], svm_binary->work[0], &svm_binary->hinge_loss)); /* hinge_loss = sum(xi^2) */
     } else {
-      PetscCall(VecGetSubVector(svm_binary->work[0],svm_binary->is_p,&work_p));
-      PetscCall(VecDot(work_p,work_p,&svm_binary->hinge_loss_p)); /* hinge_loss_p = sum(xi_p^2) */
-      PetscCall(VecRestoreSubVector(svm_binary->work[0],svm_binary->is_p,&work_p));
+      PetscCall(VecGetSubVector(svm_binary->work[0], svm_binary->is_p, &work_p));
+      PetscCall(VecDot(work_p, work_p, &svm_binary->hinge_loss_p)); /* hinge_loss_p = sum(xi_p^2) */
+      PetscCall(VecRestoreSubVector(svm_binary->work[0], svm_binary->is_p, &work_p));
 
-      PetscCall(VecGetSubVector(svm_binary->work[0],svm_binary->is_n,&work_n));
-      PetscCall(VecDot(work_n,work_n,&svm_binary->hinge_loss_n)); /* hinge_loss_n = sum(xi_n^2) */
-      PetscCall(VecRestoreSubVector(svm_binary->work[0],svm_binary->is_n,&work_n));
+      PetscCall(VecGetSubVector(svm_binary->work[0], svm_binary->is_n, &work_n));
+      PetscCall(VecDot(work_n, work_n, &svm_binary->hinge_loss_n)); /* hinge_loss_n = sum(xi_n^2) */
+      PetscCall(VecRestoreSubVector(svm_binary->work[0], svm_binary->is_n, &work_n));
     }
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1232,37 +1223,37 @@ PetscErrorCode SVMComputeHingeLoss_Binary(SVM svm)
 #define __FUNCT__ "SVMComputeObjFuncValues_Binary_Private"
 PetscErrorCode SVMComputeObjFuncValues_Binary_Private(SVM svm)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  PetscInt    p;        /* penalty type */
-  PetscReal   C,Cp,Cn;
+  PetscInt  p; /* penalty type */
+  PetscReal C, Cp, Cn;
 
   Vec         w;
   SVMLossType loss_type;
 
-  PetscReal   tmp;
+  PetscReal tmp;
 
-  QP          qp;
-  Vec         x;
+  QP  qp;
+  Vec x;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetLossType(svm,&loss_type));
-  PetscCall(SVMGetPenaltyType(svm,&p));
+  PetscCall(SVMGetLossType(svm, &loss_type));
+  PetscCall(SVMGetPenaltyType(svm, &p));
 
   PetscCall(SVMComputeHingeLoss(svm));
 
   /* Compute value of primal objective function */
-  PetscCall(SVMGetSeparatingHyperplane(svm,&w,NULL));
+  PetscCall(SVMGetSeparatingHyperplane(svm, &w, NULL));
 
-  PetscCall(VecDot(w,w,&svm_binary->primalObj));
+  PetscCall(VecDot(w, w, &svm_binary->primalObj));
   svm_binary->primalObj *= 0.5;
   if (p == 1) {
-    PetscCall(SVMGetC(svm,&C));
+    PetscCall(SVMGetC(svm, &C));
 
     tmp = C * svm_binary->hinge_loss;
   } else {
-    PetscCall(SVMGetCp(svm,&Cp));
-    PetscCall(SVMGetCn(svm,&Cn));
+    PetscCall(SVMGetCp(svm, &Cp));
+    PetscCall(SVMGetCn(svm, &Cn));
 
     tmp = Cp * svm_binary->hinge_loss_p;
     tmp += Cn * svm_binary->hinge_loss_n;
@@ -1275,9 +1266,9 @@ PetscErrorCode SVMComputeObjFuncValues_Binary_Private(SVM svm)
   }
 
   /* Compute value of dual objective function */
-  PetscCall(SVMGetQP(svm,&qp));
-  PetscCall(QPGetSolutionVector(qp,&x));
-  PetscCall(QPComputeObjective(qp,x,&svm_binary->dualObj));
+  PetscCall(SVMGetQP(svm, &qp));
+  PetscCall(QPGetSolutionVector(qp, &x));
+  PetscCall(QPComputeObjective(qp, x, &svm_binary->dualObj));
   svm_binary->dualObj *= -1.;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1286,13 +1277,13 @@ PetscErrorCode SVMComputeObjFuncValues_Binary_Private(SVM svm)
 #define __FUNCT__ "SVMPostTrain_Binary"
 PetscErrorCode SVMPostTrain_Binary(SVM svm)
 {
-  QPS       qps;
+  QPS qps;
 
   PetscFunctionBegin;
   if (svm->posttraincalled) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCall(SVMGetQPS(svm,&qps));
-  PetscCall(QPSPostSolve(qps) );
+  PetscCall(SVMGetQPS(svm, &qps));
+  PetscCall(QPSPostSolve(qps));
 
   PetscCall(SVMReconstructHyperplane(svm));
   PetscCall(SVMComputeObjFuncValues_Binary_Private(svm));
@@ -1304,7 +1295,7 @@ PetscErrorCode SVMPostTrain_Binary(SVM svm)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetFromOptions_Binary"
-PetscErrorCode SVMSetFromOptions_Binary(PetscOptionItems *PetscOptionsObject,SVM svm)
+PetscErrorCode SVMSetFromOptions_Binary(PetscOptionItems *PetscOptionsObject, SVM svm)
 {
   /* SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
 
@@ -1312,37 +1303,37 @@ PetscErrorCode SVMSetFromOptions_Binary(PetscOptionItems *PetscOptionsObject,SVM
   PetscBool flg; */
 
   PetscFunctionBegin;
-  PetscObjectOptionsBegin((PetscObject) svm);
-//  PetscCall(PetscOptionsReal("-svm_bias","","SVMSetBias",svm_binary->b,&b,&flg));
-//  if (flg) {
-//    PetscCall(SVMSetBias(svm,b));
-//  }
+  PetscObjectOptionsBegin((PetscObject)svm);
+  //  PetscCall(PetscOptionsReal("-svm_bias","","SVMSetBias",svm_binary->b,&b,&flg));
+  //  if (flg) {
+  //    PetscCall(SVMSetBias(svm,b));
+  //  }
   PetscOptionsEnd();
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetHyperplaneSubNormal_Binary_Private"
-PetscErrorCode SVMGetHyperplaneSubNormal_Binary_Private(SVM svm,Mat Xt_predict,IS *is_sub,Vec *w_sub)
+PetscErrorCode SVMGetHyperplaneSubNormal_Binary_Private(SVM svm, Mat Xt_predict, IS *is_sub, Vec *w_sub)
 {
-  MPI_Comm  comm;
+  MPI_Comm comm;
 
-  Vec       w,w_sub_inner;
-  IS        is,is_last,is_tmp;
+  Vec w, w_sub_inner;
+  IS  is, is_last, is_tmp;
 
-  PetscInt  mod;
+  PetscInt mod;
 
-  PetscInt  n,lo,hi;
-  PetscInt  N,N_predict;
+  PetscInt n, lo, hi;
+  PetscInt N, N_predict;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetMod(svm,&mod));
+  PetscCall(SVMGetMod(svm, &mod));
 
-  PetscCall(MatGetSize(Xt_predict,NULL,&N_predict));
-  PetscCall(MatGetOwnershipRangeColumn(Xt_predict,&lo,&hi));
+  PetscCall(MatGetSize(Xt_predict, NULL, &N_predict));
+  PetscCall(MatGetOwnershipRangeColumn(Xt_predict, &lo, &hi));
 
-  PetscCall(SVMGetSeparatingHyperplane(svm,&w,NULL));
-  PetscCall(PetscObjectGetComm((PetscObject) w,&comm));
+  PetscCall(SVMGetSeparatingHyperplane(svm, &w, NULL));
+  PetscCall(PetscObjectGetComm((PetscObject)w, &comm));
 
   n = 0;
   N_predict += (1 - mod);
@@ -1351,15 +1342,15 @@ PetscErrorCode SVMGetHyperplaneSubNormal_Binary_Private(SVM svm,Mat Xt_predict,I
   } else if (lo < N_predict) {
     n = N_predict - lo;
   }
-  PetscCall(ISCreateStride(comm,n,lo,1,&is));
+  PetscCall(ISCreateStride(comm, n, lo, 1, &is));
 
   if (mod == 2) {
-    PetscCall(VecGetSize(w,&N));
-    PetscCall(VecGetOwnershipRange(w,NULL,&hi));
+    PetscCall(VecGetSize(w, &N));
+    PetscCall(VecGetOwnershipRange(w, NULL, &hi));
 
-    PetscCall(ISCreateStride(comm,(hi == N) ? 1 : 0,hi - 1,1,&is_last));
+    PetscCall(ISCreateStride(comm, (hi == N) ? 1 : 0, hi - 1, 1, &is_last));
     /* Concatenate is and is_last */
-    PetscCall(ISExpand(is,is_last,&is_tmp));
+    PetscCall(ISExpand(is, is_last, &is_tmp));
     /* Free memory */
     PetscCall(ISDestroy(&is));
     PetscCall(ISDestroy(&is_last));
@@ -1367,46 +1358,46 @@ PetscErrorCode SVMGetHyperplaneSubNormal_Binary_Private(SVM svm,Mat Xt_predict,I
     is = is_tmp;
   }
 
-  PetscCall(VecGetSubVector(w,is,&w_sub_inner));
+  PetscCall(VecGetSubVector(w, is, &w_sub_inner));
 
-  *w_sub = w_sub_inner;
+  *w_sub  = w_sub_inner;
   *is_sub = is;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMCreateSubPredictDataset_Binary_Private"
-PetscErrorCode SVMCreateSubPredictDataset_Binary_Private(SVM svm,Mat Xt_predict,Mat *Xt_out)
+PetscErrorCode SVMCreateSubPredictDataset_Binary_Private(SVM svm, Mat Xt_predict, Mat *Xt_out)
 {
-  MPI_Comm  comm;
+  MPI_Comm comm;
 
-  Vec       w;
-  PetscInt  lo,hi;
-  PetscInt  N,tmp;
+  Vec      w;
+  PetscInt lo, hi;
+  PetscInt N, tmp;
 
-  PetscInt  mod;
+  PetscInt mod;
 
-  Mat       Xt_sub;
-  IS        is_cols,is_rows;
+  Mat Xt_sub;
+  IS  is_cols, is_rows;
 
   PetscFunctionBegin;
   tmp = 0;
 
-  PetscCall(SVMGetMod(svm,&mod));
+  PetscCall(SVMGetMod(svm, &mod));
 
-  PetscCall(SVMGetSeparatingHyperplane(svm,&w,NULL));
+  PetscCall(SVMGetSeparatingHyperplane(svm, &w, NULL));
 
-  PetscCall(VecGetOwnershipRange(w,&lo,&hi));
-  PetscCall(PetscObjectGetComm((PetscObject) Xt_predict,&comm));
+  PetscCall(VecGetOwnershipRange(w, &lo, &hi));
+  PetscCall(PetscObjectGetComm((PetscObject)Xt_predict, &comm));
 
-  PetscCall(MatGetOwnershipIS(Xt_predict,&is_rows,NULL));
+  PetscCall(MatGetOwnershipIS(Xt_predict, &is_rows, NULL));
   if (mod == 2) {
-    PetscCall(VecGetSize(w,&N));
+    PetscCall(VecGetSize(w, &N));
     tmp = (hi == N) ? 1 : 0;
   }
-  PetscCall(ISCreateStride(comm,hi - lo - tmp,lo,1,&is_cols));
+  PetscCall(ISCreateStride(comm, hi - lo - tmp, lo, 1, &is_cols));
 
-  PetscCall(MatCreateSubMatrix(Xt_predict,is_rows,is_cols,MAT_INITIAL_MATRIX,&Xt_sub));
+  PetscCall(MatCreateSubMatrix(Xt_predict, is_rows, is_cols, MAT_INITIAL_MATRIX, &Xt_sub));
 
   *Xt_out = Xt_sub;
 
@@ -1418,52 +1409,50 @@ PetscErrorCode SVMCreateSubPredictDataset_Binary_Private(SVM svm,Mat Xt_predict,
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetDistancesFromHyperplane_Binary"
-PetscErrorCode SVMGetDistancesFromHyperplane_Binary(SVM svm,Mat Xt_pred,Vec *dist_out)
+PetscErrorCode SVMGetDistancesFromHyperplane_Binary(SVM svm, Mat Xt_pred, Vec *dist_out)
 {
   /* Hyperplane */
-  Vec       w,w_tmp;
+  Vec       w, w_tmp;
   PetscReal b;
 
-  IS        is_w;
+  IS is_w;
 
-  Mat       Xt_training,Xt_sub;
-  PetscInt  N_training,N_predict;
+  Mat      Xt_training, Xt_sub;
+  PetscInt N_training, N_predict;
 
-  Vec       dist;
+  Vec dist;
 
   PetscFunctionBegin;
-  if (!svm->posttraincalled) {
-    PetscCall(SVMPostTrain(svm));
-  }
-  PetscCall(SVMGetSeparatingHyperplane(svm,NULL,&b));
-  PetscCall(SVMGetTrainingDataset(svm,&Xt_training,NULL));
+  if (!svm->posttraincalled) { PetscCall(SVMPostTrain(svm)); }
+  PetscCall(SVMGetSeparatingHyperplane(svm, NULL, &b));
+  PetscCall(SVMGetTrainingDataset(svm, &Xt_training, NULL));
 
-  PetscCall(MatGetSize(Xt_training,NULL,&N_training));
-  PetscCall(MatGetSize(Xt_pred,NULL,&N_predict));
+  PetscCall(MatGetSize(Xt_training, NULL, &N_training));
+  PetscCall(MatGetSize(Xt_pred, NULL, &N_predict));
   /* Check number of features */
   if (N_training > N_predict) {
-    PetscCall(SVMGetHyperplaneSubNormal_Binary_Private(svm,Xt_pred,&is_w,&w));
+    PetscCall(SVMGetHyperplaneSubNormal_Binary_Private(svm, Xt_pred, &is_w, &w));
   } else {
-    PetscCall(SVMGetSeparatingHyperplane(svm,&w,NULL));
+    PetscCall(SVMGetSeparatingHyperplane(svm, &w, NULL));
     if (N_training < N_predict) {
-      PetscCall(SVMCreateSubPredictDataset_Binary_Private(svm,Xt_pred,&Xt_sub));
+      PetscCall(SVMCreateSubPredictDataset_Binary_Private(svm, Xt_pred, &Xt_sub));
       Xt_pred = Xt_sub;
     }
   }
 
   /* Predict labels of unseen samples */
-  PetscCall(MatCreateVecs(Xt_pred,NULL,&dist));
+  PetscCall(MatCreateVecs(Xt_pred, NULL, &dist));
   PetscCall(VecSetFromOptions(dist));
 
-  PetscCall(MatMult(Xt_pred,w,dist));
-  PetscCall(VecShift(dist,b)); /* shifting is not performed in case of b = 0 (inner implementation) */
+  PetscCall(MatMult(Xt_pred, w, dist));
+  PetscCall(VecShift(dist, b)); /* shifting is not performed in case of b = 0 (inner implementation) */
 
   *dist_out = dist;
 
   /* Clean up */
   if (N_training > N_predict) {
-    PetscCall(SVMGetSeparatingHyperplane(svm,&w_tmp,NULL));
-    PetscCall(VecRestoreSubVector(w_tmp,is_w,&w));
+    PetscCall(SVMGetSeparatingHyperplane(svm, &w_tmp, NULL));
+    PetscCall(VecRestoreSubVector(w_tmp, is_w, &w));
     PetscCall(ISDestroy(&is_w));
   } else if (N_training < N_predict) {
     PetscCall(MatDestroy(&Xt_pred));
@@ -1473,40 +1462,38 @@ PetscErrorCode SVMGetDistancesFromHyperplane_Binary(SVM svm,Mat Xt_pred,Vec *dis
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMPredict_Binary"
-PetscErrorCode SVMPredict_Binary(SVM svm,Mat Xt_pred,Vec *y_out)
+PetscErrorCode SVMPredict_Binary(SVM svm, Mat Xt_pred, Vec *y_out)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  Vec       dist;
-  Vec       o;
-  Vec       y,sub_y;
+  Vec dist;
+  Vec o;
+  Vec y, sub_y;
 
-  IS        is_p,is_n;
-  PetscInt  lo,hi;
+  IS       is_p, is_n;
+  PetscInt lo, hi;
 
   PetscFunctionBegin;
-  if (!svm->posttraincalled) {
-    PetscCall(SVMPostTrain(svm));
-  }
+  if (!svm->posttraincalled) { PetscCall(SVMPostTrain(svm)); }
 
-  PetscCall(SVMGetDistancesFromHyperplane(svm,Xt_pred,&dist));
-  PetscCall(VecGetOwnershipRange(dist,&lo,&hi));
+  PetscCall(SVMGetDistancesFromHyperplane(svm, Xt_pred, &dist));
+  PetscCall(VecGetOwnershipRange(dist, &lo, &hi));
 
-  PetscCall(VecDuplicate(dist,&y));
-  PetscCall(VecDuplicate(dist,&o));
+  PetscCall(VecDuplicate(dist, &y));
+  PetscCall(VecDuplicate(dist, &o));
 
-  PetscCall(VecSet(o,0.));
+  PetscCall(VecSet(o, 0.));
 
-  PetscCall(VecWhichGreaterThan(dist,o,&is_p));
-  PetscCall(ISComplement(is_p,lo,hi,&is_n));
+  PetscCall(VecWhichGreaterThan(dist, o, &is_p));
+  PetscCall(ISComplement(is_p, lo, hi, &is_n));
 
-  PetscCall(VecGetSubVector(y,is_n,&sub_y));
-  PetscCall(VecSet(sub_y,svm_binary->y_map[0]));
-  PetscCall(VecRestoreSubVector(y,is_n,&sub_y));
+  PetscCall(VecGetSubVector(y, is_n, &sub_y));
+  PetscCall(VecSet(sub_y, svm_binary->y_map[0]));
+  PetscCall(VecRestoreSubVector(y, is_n, &sub_y));
 
-  PetscCall(VecGetSubVector(y,is_p,&sub_y));
-  PetscCall(VecSet(sub_y,svm_binary->y_map[1]));
-  PetscCall(VecRestoreSubVector(y,is_p,&sub_y));
+  PetscCall(VecGetSubVector(y, is_p, &sub_y));
+  PetscCall(VecSet(sub_y, svm_binary->y_map[1]));
+  PetscCall(VecRestoreSubVector(y, is_p, &sub_y));
 
   *y_out = y;
 
@@ -1520,12 +1507,12 @@ PetscErrorCode SVMPredict_Binary(SVM svm,Mat Xt_pred,Vec *y_out)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMComputeModelScores_Binary"
-PetscErrorCode SVMComputeModelScores_Binary(SVM svm,Vec y,Vec y_known)
+PetscErrorCode SVMComputeModelScores_Binary(SVM svm, Vec y, Vec y_known)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetBinaryClassificationReport(svm,y,y_known,svm_binary->confusion_matrix,svm_binary->model_scores));
+  PetscCall(SVMGetBinaryClassificationReport(svm, y, y_known, svm_binary->confusion_matrix, svm_binary->model_scores));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1538,86 +1525,86 @@ PetscErrorCode SVMTest_Binary(SVM svm)
   Vec y_pred;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTestDataset(svm,&Xt_test,&y_known));
-  PetscCall(SVMPredict(svm,Xt_test,&y_pred));
+  PetscCall(SVMGetTestDataset(svm, &Xt_test, &y_known));
+  PetscCall(SVMPredict(svm, Xt_test, &y_pred));
 
   /* Evaluation of model performance scores */
-  PetscCall(SVMComputeModelScores(svm,y_pred,y_known));
+  PetscCall(SVMComputeModelScores(svm, y_pred, y_known));
   PetscCall(VecDestroy(&y_pred));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMComputePGmaxPGmin_Binary_Private"
-PetscErrorCode SVMComputePGminPGmax_Binary_Private(SVM svm,PetscReal *PG_min,PetscReal *PG_max)
+PetscErrorCode SVMComputePGminPGmax_Binary_Private(SVM svm, PetscReal *PG_min, PetscReal *PG_max)
 {
   // https://www.jmlr.org/papers/volume8/loosli07a/loosli07a.pdf
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  Vec         x,g,sg;
-  Vec         y;
+  Vec x, g, sg;
+  Vec y;
 
-  Vec         lb,ub;
+  Vec lb, ub;
 
-  IS          is_yp,is_ym;
-  IS          is_xgl,is_xlu,is_int;
+  IS is_yp, is_ym;
+  IS is_xgl, is_xlu, is_int;
 
-  PetscReal   min_1,min_2,max_1,max_2;
-  PetscInt    rstart,rend;
+  PetscReal min_1, min_2, max_1, max_2;
+  PetscInt  rstart, rend;
 
-  QPS         qps;
-  QP          qp;
+  QPS qps;
+  QP  qp;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscCall(SVMGetQPS(svm,&qps));
-  PetscCall(QPSGetQP(qps,&qp));
+  PetscCall(SVMGetQPS(svm, &qps));
+  PetscCall(QPSGetQP(qps, &qp));
 
-  PetscCall(QPGetSolutionVector(qp,&x)); // this function returns borrowed reference
-  PetscCall(QPGetBox(qp,NULL,&lb,&ub)); // this function returns borrowed reference
+  PetscCall(QPGetSolutionVector(qp, &x));  // this function returns borrowed reference
+  PetscCall(QPGetBox(qp, NULL, &lb, &ub)); // this function returns borrowed reference
 
   y = svm_binary->y_inner; // labels remapped to +1 and -1
   g = qps->work[0];        // get gradient
 
-  PetscCall(VecWhichGreaterThan(y,lb,&is_yp));       // lb = zeros, then is_yp contains indices of samples related to class +1
-  PetscCall(VecGetOwnershipRange(y,&rstart,&rend));
-  PetscCall(ISComplement(is_yp,rstart,rend,&is_ym)); // is_y, contains indices of samples related to class -1
+  PetscCall(VecWhichGreaterThan(y, lb, &is_yp)); // lb = zeros, then is_yp contains indices of samples related to class +1
+  PetscCall(VecGetOwnershipRange(y, &rstart, &rend));
+  PetscCall(ISComplement(is_yp, rstart, rend, &is_ym)); // is_y, contains indices of samples related to class -1
 
-  PetscCall(VecWhichGreaterThan(x,lb,&is_xgl));     // get index set for x < C or x < Cp, x < Cm
-  PetscCall(VecWhichLessThan(x,ub,&is_xlu));        // get index set for x > 0
+  PetscCall(VecWhichGreaterThan(x, lb, &is_xgl)); // get index set for x < C or x < Cp, x < Cm
+  PetscCall(VecWhichLessThan(x, ub, &is_xlu));    // get index set for x > 0
 
   /* Compute PG_max */
-  PetscCall(ISIntersect(is_yp,is_xlu,&is_int));     // get index set for x < C & y = +1
-  PetscCall(VecGetSubVector(g,is_int,&sg));         // get sub gradient sg = g(x < C & y = +1)
-  PetscCall(VecMin(sg,NULL,&max_1));
-  max_1 *= -1.0;                                    // max_1 = max(-sg) = -min(sg) = -min(g(x < C & y = 1))
-  PetscCall(VecRestoreSubVector(g,is_int,&sg));
+  PetscCall(ISIntersect(is_yp, is_xlu, &is_int)); // get index set for x < C & y = +1
+  PetscCall(VecGetSubVector(g, is_int, &sg));     // get sub gradient sg = g(x < C & y = +1)
+  PetscCall(VecMin(sg, NULL, &max_1));
+  max_1 *= -1.0; // max_1 = max(-sg) = -min(sg) = -min(g(x < C & y = 1))
+  PetscCall(VecRestoreSubVector(g, is_int, &sg));
   PetscCall(ISDestroy(&is_int));
 
-  PetscCall(ISIntersect(is_ym,is_xgl,&is_int));    // get index set for x > 0 & y == -1
-  PetscCall(VecGetSubVector(g,is_int,&sg));        // get sub gradient sg = g(x > 0 & y == -1)
-  PetscCall(VecMax(sg,NULL,&max_2));               // max_2 = max(sg) = max(g(x > 0 & y = -1))
-  PetscCall(VecRestoreSubVector(g,is_int,&sg));
+  PetscCall(ISIntersect(is_ym, is_xgl, &is_int)); // get index set for x > 0 & y == -1
+  PetscCall(VecGetSubVector(g, is_int, &sg));     // get sub gradient sg = g(x > 0 & y == -1)
+  PetscCall(VecMax(sg, NULL, &max_2));            // max_2 = max(sg) = max(g(x > 0 & y = -1))
+  PetscCall(VecRestoreSubVector(g, is_int, &sg));
   PetscCall(ISDestroy(&is_int));
 
-  *PG_max = PetscMax(max_1,max_2);
+  *PG_max = PetscMax(max_1, max_2);
 
   /* Compute PG_min */
-  PetscCall(ISIntersect(is_ym,is_xlu,&is_int));   // get index set x < C & y = -1
-  PetscCall(VecGetSubVector(g,is_int,&sg));       // min_1 = min(sg) = min(g(x < C & y = -1))
-  PetscCall(VecMin(sg,NULL,&min_1));
-  PetscCall(VecRestoreSubVector(g,is_int,&sg));
+  PetscCall(ISIntersect(is_ym, is_xlu, &is_int)); // get index set x < C & y = -1
+  PetscCall(VecGetSubVector(g, is_int, &sg));     // min_1 = min(sg) = min(g(x < C & y = -1))
+  PetscCall(VecMin(sg, NULL, &min_1));
+  PetscCall(VecRestoreSubVector(g, is_int, &sg));
   PetscCall(ISDestroy(&is_int));
 
-  PetscCall(ISIntersect(is_yp,is_xgl,&is_int));  // get index set x > 0 & y = +1
-  PetscCall(VecGetSubVector(g,is_int,&sg));
-  PetscCall(VecMax(sg,NULL,&min_2));
+  PetscCall(ISIntersect(is_yp, is_xgl, &is_int)); // get index set x > 0 & y = +1
+  PetscCall(VecGetSubVector(g, is_int, &sg));
+  PetscCall(VecMax(sg, NULL, &min_2));
   min_2 *= -1.0;
-  PetscCall(VecRestoreSubVector(g,is_int,&sg));
+  PetscCall(VecRestoreSubVector(g, is_int, &sg));
   PetscCall(ISDestroy(&is_int));
 
-  *PG_min = PetscMin(min_1,min_2);
+  *PG_min = PetscMin(min_1, min_2);
 
   PetscCall(ISDestroy(&is_yp));
   PetscCall(ISDestroy(&is_ym));
@@ -1628,65 +1615,65 @@ PetscErrorCode SVMComputePGminPGmax_Binary_Private(SVM svm,PetscReal *PG_min,Pet
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMConvergedMaximalDualViolation_Binary"
-PetscErrorCode SVMConvergedMaximalDualViolation_Binary(QPS qps,KSPConvergedReason *reason)
+PetscErrorCode SVMConvergedMaximalDualViolation_Binary(QPS qps, KSPConvergedReason *reason)
 {
-  SVM              svm;
+  SVM svm;
 
-  PetscInt         max_it;
-  PetscReal        atol;
+  PetscInt  max_it;
+  PetscReal atol;
 
-  PetscReal        PGmin,PGmax,v=0.;
-  PetscInt         it;
+  PetscReal PGmin, PGmax, v = 0.;
+  PetscInt  it;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(qps,QPS_CLASSID,1);
+  PetscValidHeaderSpecific(qps, QPS_CLASSID, 1);
 
-  PetscCall(QPSGetConvergenceContext(qps,(void*)&svm));
-  PetscCall(QPSGetIterationNumber(qps,&it));
-  PetscCall(QPSGetTolerances(qps,NULL,&atol,NULL,&max_it));
+  PetscCall(QPSGetConvergenceContext(qps, (void *)&svm));
+  PetscCall(QPSGetIterationNumber(qps, &it));
+  PetscCall(QPSGetTolerances(qps, NULL, &atol, NULL, &max_it));
 
   *reason = KSP_CONVERGED_ITERATING;
   if (it == 0) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCall(SVMComputePGminPGmax_Binary_Private(svm,&PGmin,&PGmax));
+  PetscCall(SVMComputePGminPGmax_Binary_Private(svm, &PGmin, &PGmax));
   v = PGmax - PGmin;
 
   if (it > max_it) {
     *reason = KSP_DIVERGED_ITS;
-    PetscCall(PetscInfo(qps,"QP solver is diverging (iteration count reached the maximum). Current dual violation %14.12e at iteration %" PetscInt_FMT "\n",(double) v,it));
+    PetscCall(PetscInfo(qps, "QP solver is diverging (iteration count reached the maximum). Current dual violation %14.12e at iteration %" PetscInt_FMT "\n", (double)v, it));
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
   if ((v <= atol) && PetscAbsReal(PGmax) <= atol && PetscAbsReal(PGmin) <= atol) {
     *reason = KSP_CONVERGED_ATOL;
-    PetscCall(PetscInfo(qps,"QP solver has converged. Dual violation %14.12e at iteration %" PetscInt_FMT "\n",(double) v,it));
+    PetscCall(PetscInfo(qps, "QP solver has converged. Dual violation %14.12e at iteration %" PetscInt_FMT "\n", (double)v, it));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMConvergedDualityGap_Binary"
-PetscErrorCode SVMConvergedDualityGap_Binary(QPS qps,KSPConvergedReason *reason)
+PetscErrorCode SVMConvergedDualityGap_Binary(QPS qps, KSPConvergedReason *reason)
 {
   SVM_Binary *svm_binary;
   SVM         svm;
 
-  PetscInt    max_it;
-  PetscReal   rtol;
+  PetscInt  max_it;
+  PetscReal rtol;
 
-  PetscReal   D,P;
+  PetscReal D, P;
 
-  PetscReal   gap;
-  PetscInt    it;
+  PetscReal gap;
+  PetscInt  it;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(qps,QPS_CLASSID,1);
+  PetscValidHeaderSpecific(qps, QPS_CLASSID, 1);
 
-  PetscCall(QPSGetConvergenceContext(qps,(void*)&svm));
-  PetscCall(QPSGetIterationNumber(qps,&it));
-  PetscCall(QPSGetTolerances(qps,&rtol,NULL,NULL,&max_it));
+  PetscCall(QPSGetConvergenceContext(qps, (void *)&svm));
+  PetscCall(QPSGetIterationNumber(qps, &it));
+  PetscCall(QPSGetTolerances(qps, &rtol, NULL, NULL, &max_it));
 
-  svm_binary = (SVM_Binary *) svm->data;
+  svm_binary = (SVM_Binary *)svm->data;
 
   *reason = KSP_CONVERGED_ITERATING;
   if (it == 0) PetscFunctionReturn(PETSC_SUCCESS);
@@ -1702,13 +1689,13 @@ PetscErrorCode SVMConvergedDualityGap_Binary(QPS qps,KSPConvergedReason *reason)
 
   if (it > max_it) {
     *reason = KSP_DIVERGED_ITS;
-    PetscCall(PetscInfo(qps,"QP solver is diverging (iteration count reached the maximum). Current duality gap %14.12e at iteration %" PetscInt_FMT "\n",(double) gap,it));
+    PetscCall(PetscInfo(qps, "QP solver is diverging (iteration count reached the maximum). Current duality gap %14.12e at iteration %" PetscInt_FMT "\n", (double)gap, it));
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
   if (gap <= rtol * PetscAbs(P)) {
     *reason = KSP_CONVERGED_RTOL;
-    PetscCall(PetscInfo(qps,"QP solver has converged. Duality gap %14.12e at iteration %" PetscInt_FMT "\n",(double) gap,it));
+    PetscCall(PetscInfo(qps, "QP solver has converged. Duality gap %14.12e at iteration %" PetscInt_FMT "\n", (double)gap, it));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1717,48 +1704,48 @@ PetscErrorCode SVMConvergedDualityGap_Binary(QPS qps,KSPConvergedReason *reason)
 #define __FUNCT__ "SVMConvergedSetUp_Binary"
 PetscErrorCode SVMConvergedSetUp_Binary(SVM svm)
 {
-  SVMConvergedType  type_stop_criteria;
-  void             *ctx;
+  SVMConvergedType type_stop_criteria;
+  void            *ctx;
 
-  QPS               qps;
-  PetscInt          svm_mod;
+  QPS      qps;
+  PetscInt svm_mod;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
   type_stop_criteria = SVM_CONVERGED_DEFAULT;
 
-  PetscCall(PetscOptionsGetEnum(NULL,((PetscObject) svm)->prefix,"-svm_binary_convergence_test",SVMConvergedTypes,(PetscEnum*)&type_stop_criteria,NULL));
+  PetscCall(PetscOptionsGetEnum(NULL, ((PetscObject)svm)->prefix, "-svm_binary_convergence_test", SVMConvergedTypes, (PetscEnum *)&type_stop_criteria, NULL));
   if (type_stop_criteria == SVM_CONVERGED_DEFAULT) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCall(SVMGetMod(svm,&svm_mod));
-  PetscCall(SVMGetQPS(svm,&qps));
+  PetscCall(SVMGetMod(svm, &svm_mod));
+  PetscCall(SVMGetQPS(svm, &qps));
 
   switch (type_stop_criteria) {
-    // convergence test based on maximal dual violation
-    case SVM_CONVERGED_MAXIMAL_DUAL_VIOLATION:
-      PetscCall(SVMDefaultConvergedCreate(svm,&ctx));
-      PetscCall(QPSSetConvergenceTest(qps,SVMConvergedMaximalDualViolation_Binary,ctx,SVMDefaultConvergedDestroy));
-      break;
-    // convergence test based on duality gap
-    case SVM_CONVERGED_DUALITY_GAP:
-      PetscCall(SVMDefaultConvergedCreate(svm,&ctx));
-      PetscCall(QPSSetConvergenceTest(qps,SVMConvergedDualityGap_Binary,ctx,SVMDefaultConvergedDestroy));
-      break;
-    default:
-      break;
+  // convergence test based on maximal dual violation
+  case SVM_CONVERGED_MAXIMAL_DUAL_VIOLATION:
+    PetscCall(SVMDefaultConvergedCreate(svm, &ctx));
+    PetscCall(QPSSetConvergenceTest(qps, SVMConvergedMaximalDualViolation_Binary, ctx, SVMDefaultConvergedDestroy));
+    break;
+  // convergence test based on duality gap
+  case SVM_CONVERGED_DUALITY_GAP:
+    PetscCall(SVMDefaultConvergedCreate(svm, &ctx));
+    PetscCall(QPSSetConvergenceTest(qps, SVMConvergedDualityGap_Binary, ctx, SVMDefaultConvergedDestroy));
+    break;
+  default:
+    break;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMGetModelScore_Binary"
-PetscErrorCode SVMGetModelScore_Binary(SVM svm,ModelScore score_type,PetscReal *s)
+PetscErrorCode SVMGetModelScore_Binary(SVM svm, ModelScore score_type, PetscReal *s)
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
   PetscFunctionBegin;
-  PetscAssertPointer(s,3);
+  PetscAssertPointer(s, 3);
 
   *s = svm_binary->model_scores[3 * score_type];
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1766,53 +1753,53 @@ PetscErrorCode SVMGetModelScore_Binary(SVM svm,ModelScore score_type,PetscReal *
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMInitGridSearch_Binary_Private"
-PetscErrorCode SVMInitGridSearch_Binary_Private(SVM svm,PetscInt *n_out,PetscReal *grid_out[])
+PetscErrorCode SVMInitGridSearch_Binary_Private(SVM svm, PetscInt *n_out, PetscReal *grid_out[])
 {
-  PetscInt  penalty_type;
+  PetscInt penalty_type;
 
-  PetscReal base_1,start_1,end_1,step_1;
-  PetscReal base_2,start_2,end_2,step_2;
+  PetscReal base_1, start_1, end_1, step_1;
+  PetscReal base_2, start_2, end_2, step_2;
   PetscReal tmp;
 
   PetscReal *grid;
-  PetscInt  n,n_1,n_2;
+  PetscInt   n, n_1, n_2;
 
-  PetscInt  i,j,p;
+  PetscInt i, j, p;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetPenaltyType(svm,&penalty_type));
+  PetscCall(SVMGetPenaltyType(svm, &penalty_type));
   if (penalty_type == 1) {
-    PetscCall(SVMGridSearchGetBaseLogC(svm,&base_1));
-    PetscCall(SVMGridSearchGetStrideLogC(svm,&start_1,&end_1,&step_1));
+    PetscCall(SVMGridSearchGetBaseLogC(svm, &base_1));
+    PetscCall(SVMGridSearchGetStrideLogC(svm, &start_1, &end_1, &step_1));
 
     n = PetscAbs(end_1 - start_1) / PetscAbs(step_1) + 1;
-    PetscCall(PetscMalloc1(n,&grid));
+    PetscCall(PetscMalloc1(n, &grid));
 
-    for (i = 0; i < n; ++i) grid[i] = PetscPowReal(base_1,start_1 + i * step_1);
+    for (i = 0; i < n; ++i) grid[i] = PetscPowReal(base_1, start_1 + i * step_1);
   } else {
-    PetscCall(SVMGridSearchGetPositiveBaseLogC(svm,&base_1));
-    PetscCall(SVMGridSearchGetPositiveStrideLogC(svm,&start_1,&end_1,&step_1));
-    PetscCall(SVMGridSearchGetNegativeBaseLogC(svm,&base_2));
-    PetscCall(SVMGridSearchGetNegativeStrideLogC(svm,&start_2,&end_2,&step_2));
+    PetscCall(SVMGridSearchGetPositiveBaseLogC(svm, &base_1));
+    PetscCall(SVMGridSearchGetPositiveStrideLogC(svm, &start_1, &end_1, &step_1));
+    PetscCall(SVMGridSearchGetNegativeBaseLogC(svm, &base_2));
+    PetscCall(SVMGridSearchGetNegativeStrideLogC(svm, &start_2, &end_2, &step_2));
 
     n_1 = PetscAbs(end_1 - start_1) / PetscAbs(step_1) + 1;
     n_2 = PetscAbs(end_2 - start_2) / PetscAbs(step_2) + 1;
-    n = 2 * n_1 * n_2;
-    PetscCall(PetscMalloc1(n,&grid));
+    n   = 2 * n_1 * n_2;
+    PetscCall(PetscMalloc1(n, &grid));
 
     p = -1;
     for (i = 0; i < n_1; ++i) {
-      grid[++p] = PetscPowReal(base_1,start_1 + i * step_1);
-      tmp = grid[p];
-      grid[++p] = PetscPowReal(base_2,start_2);
+      grid[++p] = PetscPowReal(base_1, start_1 + i * step_1);
+      tmp       = grid[p];
+      grid[++p] = PetscPowReal(base_2, start_2);
       for (j = 1; j < n_2; ++j) {
         grid[++p] = tmp;
-        grid[++p] = PetscPowReal(base_2,start_2 + j * step_2);
+        grid[++p] = PetscPowReal(base_2, start_2 + j * step_2);
       }
     }
   }
 
-  *n_out = n;
+  *n_out    = n;
   *grid_out = grid;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1822,35 +1809,35 @@ PetscErrorCode SVMInitGridSearch_Binary_Private(SVM svm,PetscInt *n_out,PetscRea
 PetscErrorCode SVMGridSearch_Binary(SVM svm)
 {
   PetscReal *grid;
-  PetscReal *scores,score_best;
-  PetscInt  i,n,m,p,s;
+  PetscReal *scores, score_best;
+  PetscInt   i, n, m, p, s;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetPenaltyType(svm,&m));
+  PetscCall(SVMGetPenaltyType(svm, &m));
 
   /* Initialize grid */
-  PetscCall(SVMInitGridSearch_Binary_Private(svm,&n,&grid));
+  PetscCall(SVMInitGridSearch_Binary_Private(svm, &n, &grid));
   /* Perform cross-validation */
   s = n / m;
-  PetscCall(PetscCalloc1(s,&scores));
-  PetscCall(SVMCrossValidation(svm,grid,n,scores));
+  PetscCall(PetscCalloc1(s, &scores));
+  PetscCall(SVMCrossValidation(svm, grid, n, scores));
 
   /* Find best score */
   score_best = -1.;
   for (i = 0; i < s; ++i) {
     if (scores[i] > score_best) {
-      p = i;
+      p          = i;
       score_best = scores[i];
     }
   }
 
   if (m == 1) {
-    PetscCall(PetscInfo(svm,"selected best C=%.4f (score=%f)\n",grid[p],score_best));
+    PetscCall(PetscInfo(svm, "selected best C=%.4f (score=%f)\n", grid[p], score_best));
   } else {
-    PetscCall(PetscInfo(svm,"selected best C+=%.4f, C-=%.4f (score=%f)\n",grid[p * m],grid[p * m + 1],score_best));
+    PetscCall(PetscInfo(svm, "selected best C+=%.4f, C-=%.4f (score=%f)\n", grid[p * m], grid[p * m + 1], score_best));
   }
 
-  PetscCall(SVMSetPenalty(svm,m,&grid[p * m]));
+  PetscCall(SVMSetPenalty(svm, m, &grid[p * m]));
 
   PetscCall(PetscFree(grid));
   PetscCall(PetscFree(scores));
@@ -1859,20 +1846,20 @@ PetscErrorCode SVMGridSearch_Binary(SVM svm)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMLoadGramian_Binary"
-PetscErrorCode SVMLoadGramian_Binary(SVM svm,PetscViewer v)
+PetscErrorCode SVMLoadGramian_Binary(SVM svm, PetscViewer v)
 {
   Mat G;
 
   PetscFunctionBegin;
   /* Create matrix */
-  PetscCall(MatCreate(PetscObjectComm((PetscObject) svm),&G));
-  PetscCall(MatSetType(G,MATDENSE));
-  PetscCall(PetscObjectSetName((PetscObject) G,"G"));
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) G,"G_"));
+  PetscCall(MatCreate(PetscObjectComm((PetscObject)svm), &G));
+  PetscCall(MatSetType(G, MATDENSE));
+  PetscCall(PetscObjectSetName((PetscObject)G, "G"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)G, "G_"));
   PetscCall(MatSetFromOptions(G));
 
-  PetscCall(MatLoad(G,v));
-  PetscCall(SVMSetGramian(svm,G));
+  PetscCall(MatLoad(G, v));
+  PetscCall(SVMSetGramian(svm, G));
 
   /* Free memory */
   PetscCall(MatDestroy(&G));
@@ -1881,101 +1868,101 @@ PetscErrorCode SVMLoadGramian_Binary(SVM svm,PetscViewer v)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMViewGramian_Binary"
-PetscErrorCode SVMViewGramian_Binary(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewGramian_Binary(SVM svm, PetscViewer v)
 {
   const char *type_name = NULL;
 
-  Mat        G;
-  PetscInt   M,N;
+  Mat      G;
+  PetscInt M, N;
 
-  PetscBool  isascii;
+  PetscBool isascii;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetGramian(svm,&G));
-  PetscCheck(G,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Gramian (kernel) matrix is not set");
+  PetscCall(SVMGetGramian(svm, &G));
+  PetscCheck(G, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Gramian (kernel) matrix is not set");
 
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
 
     PetscCall(PetscViewerASCIIPushTab(v));
 
-    PetscCall(MatGetSize(G,&M,&N));
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) G,v));
+    PetscCall(MatGetSize(G, &M, &N));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)G, v));
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"dimensions: %" PetscInt_FMT ",%" PetscInt_FMT "\n",M,N));
+    PetscCall(PetscViewerASCIIPrintf(v, "dimensions: %" PetscInt_FMT ",%" PetscInt_FMT "\n", M, N));
     /* TODO information related to kernel type, parameters, mod etc. */
     PetscCall(PetscViewerASCIIPopTab(v));
 
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
-    SETERRQ(PetscObjectComm((PetscObject) v),PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewGramian",type_name);
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
+    SETERRQ(PetscObjectComm((PetscObject)v), PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewGramian", type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMViewTrainingDataset_Binary"
-PetscErrorCode SVMViewTrainingDataset_Binary(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTrainingDataset_Binary(SVM svm, PetscViewer v)
 {
-  Mat        Xt;
-  Vec        y;
+  Mat Xt;
+  Vec y;
 
-  PetscBool  isascii;
+  PetscBool   isascii;
   const char *type_name = NULL;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,&y));
-  PetscCheck(Xt && y,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Training dataset is not set");
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, &y));
+  PetscCheck(Xt && y, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Training dataset is not set");
 
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
     /* Print info related to svm type */
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
 
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(SVMViewDataset(svm,Xt,y,v));
+    PetscCall(SVMViewDataset(svm, Xt, y, v));
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
-    SETERRQ(PetscObjectComm((PetscObject) v),PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewTrainingDataset",type_name);
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
+    SETERRQ(PetscObjectComm((PetscObject)v), PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewTrainingDataset", type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMViewTrainingPredictions_Binary(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTrainingPredictions_Binary(SVM svm, PetscViewer v)
 {
-  Mat        Xt_training;
-  Vec        y_pred;
+  Mat Xt_training;
+  Vec y_pred;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTrainingDataset(svm,&Xt_training,NULL));
-  PetscCheck(Xt_training,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Training dataset is not set");
+  PetscCall(SVMGetTrainingDataset(svm, &Xt_training, NULL));
+  PetscCheck(Xt_training, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Training dataset is not set");
 
   /* View predictions on training samples */
-  PetscCall(SVMPredict(svm,Xt_training,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
-  PetscCall(VecView(y_pred,v));
+  PetscCall(SVMPredict(svm, Xt_training, &y_pred));
+  PetscCall(PetscObjectSetName((PetscObject)y_pred, "y_predictions"));
+  PetscCall(VecView(y_pred, v));
 
   /* Free memory */
   PetscCall(VecDestroy(&y_pred));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMViewTestPredictions_Binary(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTestPredictions_Binary(SVM svm, PetscViewer v)
 {
-  Mat        Xt_test;
-  Vec        y_pred;
+  Mat Xt_test;
+  Vec y_pred;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTestDataset(svm,&Xt_test,NULL));
-  PetscCheck(Xt_test,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Test dataset is not set");
+  PetscCall(SVMGetTestDataset(svm, &Xt_test, NULL));
+  PetscCheck(Xt_test, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Test dataset is not set");
 
   /* View predictions on test samples */
-  PetscCall(SVMPredict(svm,Xt_test,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
-  PetscCall(VecView(y_pred,v));
+  PetscCall(SVMPredict(svm, Xt_test, &y_pred));
+  PetscCall(PetscObjectSetName((PetscObject)y_pred, "y_predictions"));
+  PetscCall(VecView(y_pred, v));
 
   /* Free memory */
   PetscCall(VecDestroy(&y_pred));
@@ -1988,41 +1975,39 @@ PetscErrorCode SVMCreate_Binary(SVM svm)
 {
   SVM_Binary *svm_binary;
 
-  PetscInt   i;
+  PetscInt i;
 
   PetscFunctionBegin;
   PetscCall(PetscNew(&svm_binary));
-  svm->data = (void *) svm_binary;
+  svm->data = (void *)svm_binary;
 
-  svm_binary->w           = NULL;
-  svm_binary->b           = 1.;
+  svm_binary->w = NULL;
+  svm_binary->b = 1.;
 
-  svm_binary->qps         = NULL;
+  svm_binary->qps = NULL;
 
   svm_binary->Xt_training = NULL;
 
-  svm_binary->G           = NULL;
-  svm_binary->J           = NULL;
-  svm_binary->diag        = NULL;
+  svm_binary->G    = NULL;
+  svm_binary->J    = NULL;
+  svm_binary->diag = NULL;
 
-  svm_binary->y_training  = NULL;
-  svm_binary->y_inner     = NULL;
+  svm_binary->y_training = NULL;
+  svm_binary->y_inner    = NULL;
 
-  svm_binary->is_p        = NULL;
-  svm_binary->is_n        = NULL;
+  svm_binary->is_p = NULL;
+  svm_binary->is_n = NULL;
 
-  svm_binary->nsv         = 0;
-  svm_binary->is_sv       = NULL;
+  svm_binary->nsv   = 0;
+  svm_binary->is_sv = NULL;
 
-  svm_binary->chop_tol    = PETSC_MACHINE_EPSILON;
+  svm_binary->chop_tol = PETSC_MACHINE_EPSILON;
 
-  PetscCall(PetscMemzero(svm_binary->y_map,2 * sizeof(PetscScalar)));
-  PetscCall(PetscMemzero(svm_binary->confusion_matrix,4 * sizeof(PetscInt)));
-  PetscCall(PetscMemzero(svm_binary->model_scores,16 * sizeof(PetscReal)));
+  PetscCall(PetscMemzero(svm_binary->y_map, 2 * sizeof(PetscScalar)));
+  PetscCall(PetscMemzero(svm_binary->confusion_matrix, 4 * sizeof(PetscInt)));
+  PetscCall(PetscMemzero(svm_binary->model_scores, 16 * sizeof(PetscReal)));
 
-  for (i = 0; i < 3; ++i) {
-    svm_binary->work[i] = NULL;
-  }
+  for (i = 0; i < 3; ++i) { svm_binary->work[i] = NULL; }
 
   svm->ops->setup                   = SVMSetUp_Binary;
   svm->ops->reset                   = SVMReset_Binary;
@@ -2046,45 +2031,45 @@ PetscErrorCode SVMCreate_Binary(SVM svm)
   svm->ops->viewtrainingpredictions = SVMViewTrainingPredictions_Binary;
   svm->ops->viewtestpredictions     = SVMViewTestPredictions_Binary;
 
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetGramian_C"                ,SVMSetGramian_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetGramian_C"                ,SVMGetGramian_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOperator_C"               ,SVMSetOperator_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOperator_C"               ,SVMGetOperator_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C"        ,SVMSetTrainingDataset_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C"        ,SVMGetTrainingDataset_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetLabels_C"                 ,SVMGetLabels_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMComputeOperator_C"           ,SVMComputeOperator_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetQPS_C"                    ,SVMSetQPS_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQPS_C"                    ,SVMGetQPS_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetQP_C"                     ,SVMGetQP_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetBias_C"                   ,SVMSetBias_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetBias_C"                   ,SVMGetBias_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetSeparatingHyperplane_C"   ,SVMSetSeparatingHyperplane_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetSeparatingHyperplane_C"   ,SVMGetSeparatingHyperplane_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetDistancesFromHyperplane_C",SVMGetDistancesFromHyperplane_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetModelScore_C"             ,SVMGetModelScore_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C"          ,SVMSetOptionsPrefix_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C"          ,SVMGetOptionsPrefix_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C"       ,SVMAppendOptionsPrefix_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetGramian_C", SVMSetGramian_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetGramian_C", SVMGetGramian_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetOperator_C", SVMSetOperator_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetOperator_C", SVMGetOperator_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetTrainingDataset_C", SVMSetTrainingDataset_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetTrainingDataset_C", SVMGetTrainingDataset_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetLabels_C", SVMGetLabels_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMComputeOperator_C", SVMComputeOperator_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetQPS_C", SVMSetQPS_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetQPS_C", SVMGetQPS_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetQP_C", SVMGetQP_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetBias_C", SVMSetBias_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetBias_C", SVMGetBias_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetSeparatingHyperplane_C", SVMSetSeparatingHyperplane_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetSeparatingHyperplane_C", SVMGetSeparatingHyperplane_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetDistancesFromHyperplane_C", SVMGetDistancesFromHyperplane_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetModelScore_C", SVMGetModelScore_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetOptionsPrefix_C", SVMSetOptionsPrefix_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetOptionsPrefix_C", SVMGetOptionsPrefix_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMAppendOptionsPrefix_C", SVMAppendOptionsPrefix_Binary));
 
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMKFoldCrossValidation_C"          ,SVMKFoldCrossValidation_Binary));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMStratifiedKFoldCrossValidation_C",SVMStratifiedKFoldCrossValidation_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMKFoldCrossValidation_C", SVMKFoldCrossValidation_Binary));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMStratifiedKFoldCrossValidation_C", SVMStratifiedKFoldCrossValidation_Binary));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMMonitorCreateMCtx_Binary"
-PetscErrorCode SVMMonitorCreateCtx_Binary(void **mctx,SVM svm)
+PetscErrorCode SVMMonitorCreateCtx_Binary(void **mctx, SVM svm)
 {
   SVM_Binary_mctx *mctx_inner;
 
   PetscFunctionBegin;
-  PetscAssertPointer(mctx,1);
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,2);
+  PetscAssertPointer(mctx, 1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 2);
 
   PetscCall(PetscNew(&mctx_inner));
   mctx_inner->svm_inner = svm;
-  *mctx = mctx_inner;
+  *mctx                 = mctx_inner;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2092,7 +2077,7 @@ PetscErrorCode SVMMonitorCreateCtx_Binary(void **mctx,SVM svm)
 #define __FUNCT__ "SVMMonitorDestroyMCtx_Binary"
 PetscErrorCode SVMMonitorDestroyCtx_Binary(void **mctx)
 {
-  SVM_Binary_mctx *mctx_inner = (SVM_Binary_mctx *) *mctx;
+  SVM_Binary_mctx *mctx_inner = (SVM_Binary_mctx *)*mctx;
 
   PetscFunctionBegin;
   mctx_inner->svm_inner = NULL;
@@ -2102,7 +2087,7 @@ PetscErrorCode SVMMonitorDestroyCtx_Binary(void **mctx)
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMMonitorDefault_Binary"
-PetscErrorCode SVMMonitorDefault_Binary(QPS qps,PetscInt it,PetscReal rnorm,void *mctx)
+PetscErrorCode SVMMonitorDefault_Binary(QPS qps, PetscInt it, PetscReal rnorm, void *mctx)
 {
   MPI_Comm comm;
 
@@ -2112,25 +2097,25 @@ PetscErrorCode SVMMonitorDefault_Binary(QPS qps,PetscInt it,PetscReal rnorm,void
   PetscViewer v;
 
   PetscFunctionBegin;
-  svm_inner = ((SVM_Binary_mctx *) mctx)->svm_inner;
-  svm_binary = (SVM_Binary *) svm_inner->data;
+  svm_inner  = ((SVM_Binary_mctx *)mctx)->svm_inner;
+  svm_binary = (SVM_Binary *)svm_inner->data;
 
   PetscCall(SVMReconstructHyperplane(svm_inner));
   PetscCall(SVMComputeModelParams(svm_inner));
 
-  comm = PetscObjectComm((PetscObject) svm_inner);
-  v = PETSC_VIEWER_STDOUT_(comm);
+  comm = PetscObjectComm((PetscObject)svm_inner);
+  v    = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM ||w||=%.10e",it,(double)svm_binary->norm_w));
-  PetscCall(PetscViewerASCIIPrintf(v,",\tmargin=%.10e",(double)svm_binary->margin));
-  PetscCall(PetscViewerASCIIPrintf(v,",\tbias=%.10e",(double)svm_binary->b));
-  PetscCall(PetscViewerASCIIPrintf(v,",\tNSV=%3" PetscInt_FMT "\n",svm_binary->nsv));
+  PetscCall(PetscViewerASCIIPrintf(v, "%3" PetscInt_FMT " SVM ||w||=%.10e", it, (double)svm_binary->norm_w));
+  PetscCall(PetscViewerASCIIPrintf(v, ",\tmargin=%.10e", (double)svm_binary->margin));
+  PetscCall(PetscViewerASCIIPrintf(v, ",\tbias=%.10e", (double)svm_binary->b));
+  PetscCall(PetscViewerASCIIPrintf(v, ",\tNSV=%3" PetscInt_FMT "\n", svm_binary->nsv));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__
-PetscErrorCode SVMMonitorObjFuncs_Binary(QPS qps,PetscInt it,PetscReal rnorm,void *mctx)
+PetscErrorCode SVMMonitorObjFuncs_Binary(QPS qps, PetscInt it, PetscReal rnorm, void *mctx)
 {
   MPI_Comm comm;
 
@@ -2139,30 +2124,30 @@ PetscErrorCode SVMMonitorObjFuncs_Binary(QPS qps,PetscInt it,PetscReal rnorm,voi
 
   PetscViewer v;
 
-  PetscInt    p;        /* penalty type */
+  PetscInt    p; /* penalty type */
   SVMLossType loss_type;
 
   PetscFunctionBegin;
-  svm_inner  = ((SVM_Binary_mctx *) mctx)->svm_inner;
-  svm_binary = (SVM_Binary *) svm_inner->data;
+  svm_inner  = ((SVM_Binary_mctx *)mctx)->svm_inner;
+  svm_binary = (SVM_Binary *)svm_inner->data;
 
-  PetscCall(SVMGetLossType(svm_inner,&loss_type));
-  PetscCall(SVMGetPenaltyType(svm_inner,&p));
+  PetscCall(SVMGetLossType(svm_inner, &loss_type));
+  PetscCall(SVMGetPenaltyType(svm_inner, &p));
 
   PetscCall(SVMReconstructHyperplane(svm_inner));
   PetscCall(SVMComputeObjFuncValues_Binary_Private(svm_inner));
 
-  comm = PetscObjectComm((PetscObject) svm_inner);
-  v = PETSC_VIEWER_STDOUT_(comm);
+  comm = PetscObjectComm((PetscObject)svm_inner);
+  v    = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM primalObj=%.10e,",it,(double)svm_binary->primalObj));
+  PetscCall(PetscViewerASCIIPrintf(v, "%3" PetscInt_FMT " SVM primalObj=%.10e,", it, (double)svm_binary->primalObj));
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v,"dualObj=%.10e,",(double)svm_binary->dualObj));
-  PetscCall(PetscViewerASCIIPrintf(v,"gap=%.10e,",(double)(svm_binary->primalObj - svm_binary->dualObj)));
+  PetscCall(PetscViewerASCIIPrintf(v, "dualObj=%.10e,", (double)svm_binary->dualObj));
+  PetscCall(PetscViewerASCIIPrintf(v, "gap=%.10e,", (double)(svm_binary->primalObj - svm_binary->dualObj)));
   if (p == 1) {
-    PetscCall(PetscViewerASCIIPrintf(v,"%s-HingeLoss=%.10e\n",SVMLossTypes[loss_type],(double)svm_binary->hinge_loss));
+    PetscCall(PetscViewerASCIIPrintf(v, "%s-HingeLoss=%.10e\n", SVMLossTypes[loss_type], (double)svm_binary->hinge_loss));
   } else {
-    PetscCall(PetscViewerASCIIPrintf(v,"%s-HingeLoss+=%.10e %s-HingeLoss-=%.10e\n",SVMLossTypes[loss_type],(double)svm_binary->hinge_loss_p, SVMLossTypes[loss_type],(double)svm_binary->hinge_loss_n));
+    PetscCall(PetscViewerASCIIPrintf(v, "%s-HingeLoss+=%.10e %s-HingeLoss-=%.10e\n", SVMLossTypes[loss_type], (double)svm_binary->hinge_loss_p, SVMLossTypes[loss_type], (double)svm_binary->hinge_loss_n));
   }
   PetscCall(PetscViewerASCIIPopTab(v));
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -2170,42 +2155,42 @@ PetscErrorCode SVMMonitorObjFuncs_Binary(QPS qps,PetscInt it,PetscReal rnorm,voi
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMMonitorScores_Binary"
-PetscErrorCode SVMMonitorScores_Binary(QPS qps,PetscInt it,PetscReal rnorm,void *mctx)
+PetscErrorCode SVMMonitorScores_Binary(QPS qps, PetscInt it, PetscReal rnorm, void *mctx)
 {
   MPI_Comm    comm;
   SVM         svm_inner;
   SVM_Binary *svm_binary;
 
-  Mat         Xt_test;
-  Vec         y_known;
-  Vec         y_pred;
+  Mat Xt_test;
+  Vec y_known;
+  Vec y_pred;
 
   PetscViewer v;
 
   PetscFunctionBegin;
-  svm_inner  = ((SVM_Binary_mctx *) mctx)->svm_inner;
-  svm_binary = (SVM_Binary *) svm_inner->data;
+  svm_inner  = ((SVM_Binary_mctx *)mctx)->svm_inner;
+  svm_binary = (SVM_Binary *)svm_inner->data;
 
-  PetscCall(SVMGetTestDataset(svm_inner,&Xt_test,&y_known));
+  PetscCall(SVMGetTestDataset(svm_inner, &Xt_test, &y_known));
 
   svm_inner->posttraincalled = PETSC_TRUE;
   PetscCall(SVMReconstructHyperplane(svm_inner));
-  PetscCall(SVMPredict(svm_inner,Xt_test,&y_pred));
+  PetscCall(SVMPredict(svm_inner, Xt_test, &y_pred));
   svm_inner->posttraincalled = PETSC_FALSE;
 
   /* Evaluation of model performance scores */
-  PetscCall(SVMComputeModelScores(svm_inner,y_pred,y_known));
+  PetscCall(SVMComputeModelScores(svm_inner, y_pred, y_known));
 
-  comm = PetscObjectComm((PetscObject) svm_inner);
-  v = PETSC_VIEWER_STDOUT_(comm);
+  comm = PetscObjectComm((PetscObject)svm_inner);
+  v    = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_test=%.2f",it,(double)svm_binary->model_scores[0]));
+  PetscCall(PetscViewerASCIIPrintf(v, "%3" PetscInt_FMT " SVM accuracy_test=%.2f", it, (double)svm_binary->model_scores[0]));
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_test=%.2f",(double)svm_binary->model_scores[3]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_test=%.2f"   ,(double)svm_binary->model_scores[6]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_test=%.2f,"      ,(double)svm_binary->model_scores[9]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_test=%.2f," ,(double)svm_binary->model_scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_test=%.2f\n"     ,(double)svm_binary->model_scores[15]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_precision_test=%.2f", (double)svm_binary->model_scores[3]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_recall_test=%.2f", (double)svm_binary->model_scores[6]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_F1_test=%.2f,", (double)svm_binary->model_scores[9]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_Jaccard_test=%.2f,", (double)svm_binary->model_scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v, "auc_roc_test=%.2f\n", (double)svm_binary->model_scores[15]));
   PetscCall(PetscViewerASCIIPopTab(v));
 
   PetscCall(VecDestroy(&y_pred));
@@ -2214,43 +2199,43 @@ PetscErrorCode SVMMonitorScores_Binary(QPS qps,PetscInt it,PetscReal rnorm,void 
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMMonitorTrainingScores_Binary"
-PetscErrorCode SVMMonitorTrainingScores_Binary(QPS qps,PetscInt it,PetscReal rnorm,void *mctx)
+PetscErrorCode SVMMonitorTrainingScores_Binary(QPS qps, PetscInt it, PetscReal rnorm, void *mctx)
 {
-  MPI_Comm    comm;
+  MPI_Comm comm;
 
   SVM         svm_inner;
-  SVM_Binary  *svm_binary;
+  SVM_Binary *svm_binary;
 
-  Mat         Xt_training;
-  Vec         y_known;
-  Vec         y_pred;
+  Mat Xt_training;
+  Vec y_known;
+  Vec y_pred;
 
   PetscViewer v;
 
   PetscFunctionBegin;
-  svm_inner  = ((SVM_Binary_mctx *) mctx)->svm_inner;
-  svm_binary = (SVM_Binary *) svm_inner->data;
+  svm_inner  = ((SVM_Binary_mctx *)mctx)->svm_inner;
+  svm_binary = (SVM_Binary *)svm_inner->data;
 
-  PetscCall(SVMGetTrainingDataset(svm_inner,&Xt_training,&y_known));
+  PetscCall(SVMGetTrainingDataset(svm_inner, &Xt_training, &y_known));
 
   svm_inner->posttraincalled = PETSC_TRUE;
   PetscCall(SVMReconstructHyperplane(svm_inner));
-  PetscCall(SVMPredict(svm_inner,Xt_training,&y_pred));
+  PetscCall(SVMPredict(svm_inner, Xt_training, &y_pred));
   svm_inner->posttraincalled = PETSC_FALSE;
 
   /* Evaluation of model performance scores */
-  PetscCall(SVMComputeModelScores(svm_inner,y_pred,y_known));
+  PetscCall(SVMComputeModelScores(svm_inner, y_pred, y_known));
 
-  comm = PetscObjectComm((PetscObject) svm_inner);
-  v = PETSC_VIEWER_STDOUT_(comm);
+  comm = PetscObjectComm((PetscObject)svm_inner);
+  v    = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_training=%.2f",it,(double)svm_binary->model_scores[0]));
+  PetscCall(PetscViewerASCIIPrintf(v, "%3" PetscInt_FMT " SVM accuracy_training=%.2f", it, (double)svm_binary->model_scores[0]));
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_training=%.2f",(double)svm_binary->model_scores[3]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_training=%.2f"   ,(double)svm_binary->model_scores[6]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_F1_training=%.2f"       ,(double)svm_binary->model_scores[9]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean_Jaccard_training=%.2f"  ,(double)svm_binary->model_scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc_training=%.2f\n"     ,(double)svm_binary->model_scores[15]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_precision_training=%.2f", (double)svm_binary->model_scores[3]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_recall_training=%.2f", (double)svm_binary->model_scores[6]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_F1_training=%.2f", (double)svm_binary->model_scores[9]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean_Jaccard_training=%.2f", (double)svm_binary->model_scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v, "auc_roc_training=%.2f\n", (double)svm_binary->model_scores[15]));
   PetscCall(PetscViewerASCIIPopTab(v));
 
   PetscCall(VecDestroy(&y_pred));

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -2240,7 +2240,7 @@ PetscErrorCode SVMMonitorScores_Binary(QPS qps,PetscInt it,PetscReal rnorm,void 
   comm = PetscObjectComm((PetscObject) svm_inner);
   v = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_test=%.2f",it,(double)(svm_binary->model_scores[0])));
+  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_test=%.2f",it,(double)svm_binary->model_scores[0]));
   PetscCall(PetscViewerASCIIPushTab(v));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_test=%.2f",(double)svm_binary->model_scores[3]));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_test=%.2f"   ,(double)svm_binary->model_scores[6]));
@@ -2285,7 +2285,7 @@ PetscErrorCode SVMMonitorTrainingScores_Binary(QPS qps,PetscInt it,PetscReal rno
   comm = PetscObjectComm((PetscObject) svm_inner);
   v = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_training=%.2f",it,(double)(svm_binary->model_scores[0])));
+  PetscCall(PetscViewerASCIIPrintf(v,"%3" PetscInt_FMT " SVM accuracy_training=%.2f",it,(double)svm_binary->model_scores[0]));
   PetscCall(PetscViewerASCIIPushTab(v));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_precision_training=%.2f",(double)svm_binary->model_scores[3]));
   PetscCall(PetscViewerASCIIPrintf(v,"mean_recall_training=%.2f"   ,(double)svm_binary->model_scores[6]));

--- a/src/svm/impls/binary/binary.c
+++ b/src/svm/impls/binary/binary.c
@@ -1,4 +1,3 @@
-
 #include "binaryimpl.h"
 #include "../../utils/report.h"
 
@@ -22,8 +21,8 @@ static PetscErrorCode SVMMonitorTrainingScores_Binary(QPS,PetscInt,PetscReal,voi
 PetscErrorCode SVMReset_Binary(SVM svm)
 {
   SVM_Binary *svm_binary;
-
   PetscInt i;
+
   PetscFunctionBegin;
   svm_binary = (SVM_Binary *) svm->data;
 
@@ -1680,7 +1679,6 @@ PetscErrorCode SVMConvergedMaximalDualViolation_Binary(QPS qps,KSPConvergedReaso
     *reason = KSP_CONVERGED_ATOL;
     PetscCall(PetscInfo(qps,"QP solver has converged. Dual violation %14.12e at iteration %" PetscInt_FMT "\n",(double) v,it));
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1730,7 +1728,6 @@ PetscErrorCode SVMConvergedDualityGap_Binary(QPS qps,KSPConvergedReason *reason)
     *reason = KSP_CONVERGED_RTOL;
     PetscCall(PetscInfo(qps,"QP solver has converged. Duality gap %14.12e at iteration %" PetscInt_FMT "\n",(double) gap,it));
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1769,7 +1766,6 @@ PetscErrorCode SVMConvergedSetUp_Binary(SVM svm)
     default:
       break;
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/svm/impls/binary/binaryimpl.h
+++ b/src/svm/impls/binary/binaryimpl.h
@@ -1,6 +1,4 @@
-
-#if !defined(__BINARYIMPL_H)
-#define	__BINARYIMPL_H
+#pragma once
 
 #include <permon/private/svmimpl.h>
 
@@ -46,4 +44,3 @@ FLLOP_EXTERN const char *const SVMConvergedTypes[];
 FLLOP_EXTERN PetscErrorCode SVMCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
 FLLOP_EXTERN PetscErrorCode SVMKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
 FLLOP_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
-#endif

--- a/src/svm/impls/binary/binaryimpl.h
+++ b/src/svm/impls/binary/binaryimpl.h
@@ -3,44 +3,48 @@
 #include <permon/private/svmimpl.h>
 
 typedef struct {
-    Mat         Xt_training;
-    Vec         y_training;
-    Vec         y_inner;
-    IS          is_p,is_n;
+  Mat Xt_training;
+  Vec y_training;
+  Vec y_inner;
+  IS  is_p, is_n;
 
-    PetscScalar y_map[2];
-    Vec         diag;
-    Mat         J;
+  PetscScalar y_map[2];
+  Vec         diag;
+  Mat         J;
 
-    Mat         G;
+  Mat G;
 
-    Vec         w;
-    PetscScalar b;
+  Vec         w;
+  PetscScalar b;
 
-    PetscScalar hinge_loss,hinge_loss_p,hinge_loss_n;
+  PetscScalar hinge_loss, hinge_loss_p, hinge_loss_n;
 
-    PetscReal   norm_w;
-    PetscReal   margin;
+  PetscReal norm_w;
+  PetscReal margin;
 
-    IS          is_sv;
-    PetscInt    nsv;
-    PetscReal   chop_tol;
+  IS        is_sv;
+  PetscInt  nsv;
+  PetscReal chop_tol;
 
-    QPS         qps;
+  QPS qps;
 
-    PetscInt    confusion_matrix[4];
-    PetscReal   model_scores[16];
+  PetscInt  confusion_matrix[4];
+  PetscReal model_scores[16];
 
-    /* Work vecs */
-    Vec         work[3]; /* xi, c, Xtw */
+  /* Work vecs */
+  Vec work[3]; /* xi, c, Xtw */
 
-    /* Valuess of primal and dual objective functions */
-    PetscReal   primalObj,dualObj;
+  /* Valuess of primal and dual objective functions */
+  PetscReal primalObj, dualObj;
 } SVM_Binary;
 
-typedef enum {SVM_CONVERGED_DEFAULT,SVM_CONVERGED_DUALITY_GAP,SVM_CONVERGED_MAXIMAL_DUAL_VIOLATION} SVMConvergedType;
+typedef enum {
+  SVM_CONVERGED_DEFAULT,
+  SVM_CONVERGED_DUALITY_GAP,
+  SVM_CONVERGED_MAXIMAL_DUAL_VIOLATION
+} SVMConvergedType;
 PERMON_EXTERN const char *const SVMConvergedTypes[];
 
-PERMON_EXTERN PetscErrorCode SVMCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
-PERMON_EXTERN PetscErrorCode SVMKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
-PERMON_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMCrossValidation_Binary(SVM, PetscReal[], PetscInt, PetscReal[]);
+PERMON_EXTERN PetscErrorCode SVMKFoldCrossValidation_Binary(SVM, PetscReal[], PetscInt, PetscReal[]);
+PERMON_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM, PetscReal[], PetscInt, PetscReal[]);

--- a/src/svm/impls/binary/binaryimpl.h
+++ b/src/svm/impls/binary/binaryimpl.h
@@ -39,8 +39,8 @@ typedef struct {
 } SVM_Binary;
 
 typedef enum {SVM_CONVERGED_DEFAULT,SVM_CONVERGED_DUALITY_GAP,SVM_CONVERGED_MAXIMAL_DUAL_VIOLATION} SVMConvergedType;
-FLLOP_EXTERN const char *const SVMConvergedTypes[];
+PERMON_EXTERN const char *const SVMConvergedTypes[];
 
-FLLOP_EXTERN PetscErrorCode SVMCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
-FLLOP_EXTERN PetscErrorCode SVMKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
-FLLOP_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);
+PERMON_EXTERN PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM,PetscReal [],PetscInt,PetscReal []);

--- a/src/svm/impls/binary/crossvalidation.c
+++ b/src/svm/impls/binary/crossvalidation.c
@@ -1,4 +1,3 @@
-
 #include "binaryimpl.h"
 
 #undef __FUNCT__

--- a/src/svm/impls/binary/crossvalidation.c
+++ b/src/svm/impls/binary/crossvalidation.c
@@ -2,128 +2,125 @@
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMCrossValidation_Binary"
-PetscErrorCode SVMCrossValidation_Binary(SVM svm,PetscReal c_arr[],PetscInt m,PetscReal score[])
+PetscErrorCode SVMCrossValidation_Binary(SVM svm, PetscReal c_arr[], PetscInt m, PetscReal score[])
 {
   CrossValidationType cv_type;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetCrossValidationType(svm,&cv_type));
+  PetscCall(SVMGetCrossValidationType(svm, &cv_type));
   if (cv_type == CROSS_VALIDATION_KFOLD) {
-    PetscCall(SVMKFoldCrossValidation(svm,c_arr,m,score));
+    PetscCall(SVMKFoldCrossValidation(svm, c_arr, m, score));
   } else {
-    PetscCall(SVMStratifiedKFoldCrossValidation(svm,c_arr,m,score));
+    PetscCall(SVMStratifiedKFoldCrossValidation(svm, c_arr, m, score));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMKFoldCrossValidation_Binary"
-PetscErrorCode SVMKFoldCrossValidation_Binary(SVM svm,PetscReal c_arr[],PetscInt m,PetscReal score[])
+PetscErrorCode SVMKFoldCrossValidation_Binary(SVM svm, PetscReal c_arr[], PetscInt m, PetscReal score[])
 {
-  MPI_Comm          comm;
-  SVM               cross_svm;
+  MPI_Comm comm;
+  SVM      cross_svm;
 
-  QPS               qps;
+  QPS qps;
 
-  Mat               Xt,Xt_training,Xt_test;
-  Vec               y,y_training,y_test;
+  Mat Xt, Xt_training, Xt_test;
+  Vec y, y_training, y_test;
 
-  PetscInt          lo,hi,first,n;
-  PetscInt          i,j,k,l,nfolds;
+  PetscInt lo, hi, first, n;
+  PetscInt i, j, k, l, nfolds;
 
-  IS                is_training,is_test;
-  IS                is_cols;
+  IS is_training, is_test;
+  IS is_cols;
 
-  PetscInt          p;       /* penalty type */
-  PetscInt          svm_mod;
-  SVMLossType       svm_loss;
+  PetscInt    p; /* penalty type */
+  PetscInt    svm_mod;
+  SVMLossType svm_loss;
 
   PetscReal         s;
-  const ModelScore  *model_scores;
+  const ModelScore *model_scores;
   PetscInt          nscores;
 
-  PetscBool         info_set;
+  PetscBool info_set;
 
-  const char        *prefix;
+  const char *prefix;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
-  PetscCall(SVMGetLossType(svm,&svm_loss));
-  PetscCall(SVMGetMod(svm,&svm_mod));
-  PetscCall(SVMGetPenaltyType(svm,&p));
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+  PetscCall(SVMGetLossType(svm, &svm_loss));
+  PetscCall(SVMGetMod(svm, &svm_mod));
+  PetscCall(SVMGetPenaltyType(svm, &p));
 
   /* Create SVM used in cross validation */
-  PetscCall(SVMCreate(comm,&cross_svm));
-  PetscCall(SVMSetType(cross_svm,SVM_BINARY));
+  PetscCall(SVMCreate(comm, &cross_svm));
+  PetscCall(SVMSetType(cross_svm, SVM_BINARY));
 
   /* Set options of SVM used in cross validation */
-  PetscCall(SVMSetMod(cross_svm,svm_mod));
-  PetscCall(SVMSetLossType(cross_svm,svm_loss));
-  PetscCall(SVMSetPenaltyType(cross_svm,p));
-  PetscCall(SVMAppendOptionsPrefix(cross_svm,"cross_"));
+  PetscCall(SVMSetMod(cross_svm, svm_mod));
+  PetscCall(SVMSetLossType(cross_svm, svm_loss));
+  PetscCall(SVMSetPenaltyType(cross_svm, p));
+  PetscCall(SVMAppendOptionsPrefix(cross_svm, "cross_"));
   PetscCall(SVMSetFromOptions(cross_svm));
 
-  PetscCall(SVMGetOptionsPrefix(cross_svm,&prefix));
-  PetscCall(PetscOptionsHasName(NULL,prefix,"-svm_info",&info_set));
+  PetscCall(SVMGetOptionsPrefix(cross_svm, &prefix));
+  PetscCall(PetscOptionsHasName(NULL, prefix, "-svm_info", &info_set));
 
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,&y));
-  PetscCall(MatGetOwnershipRange(Xt,&lo,&hi));
-  PetscCall(MatGetOwnershipIS(Xt,NULL,&is_cols));
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, &y));
+  PetscCall(MatGetOwnershipRange(Xt, &lo, &hi));
+  PetscCall(MatGetOwnershipIS(Xt, NULL, &is_cols));
 
-  PetscCall(SVMGetHyperOptNScoreTypes(svm,&nscores));
-  PetscCall(SVMGetHyperOptScoreTypes(svm,&model_scores));
-  PetscCall(SVMGetNfolds(svm,&nfolds));
+  PetscCall(SVMGetHyperOptNScoreTypes(svm, &nscores));
+  PetscCall(SVMGetHyperOptScoreTypes(svm, &model_scores));
+  PetscCall(SVMGetNfolds(svm, &nfolds));
 
   for (i = 0; i < nfolds; ++i) {
-
-    if (info_set) {
-      PetscCall(PetscPrintf(comm,"SVM: fold %" PetscInt_FMT " of %" PetscInt_FMT "\n",i+1,nfolds));
-    }
+    if (info_set) { PetscCall(PetscPrintf(comm, "SVM: fold %" PetscInt_FMT " of %" PetscInt_FMT "\n", i + 1, nfolds)); }
 
     first = lo + i - lo % nfolds;
     if (first < lo) first += nfolds;
     n = (hi + nfolds - first - 1) / nfolds;
 
     /* Create test dataset */
-    PetscCall(ISCreateStride(comm,n,first,nfolds,&is_test));
-    PetscCall(MatCreateSubMatrix(Xt,is_test,is_cols,MAT_INITIAL_MATRIX,&Xt_test));
-    PetscCall(VecGetSubVector(y,is_test,&y_test));
+    PetscCall(ISCreateStride(comm, n, first, nfolds, &is_test));
+    PetscCall(MatCreateSubMatrix(Xt, is_test, is_cols, MAT_INITIAL_MATRIX, &Xt_test));
+    PetscCall(VecGetSubVector(y, is_test, &y_test));
 
     /* Create training dataset */
-    PetscCall(ISComplement(is_test,lo,hi,&is_training));
-    PetscCall(MatCreateSubMatrix(Xt,is_training,is_cols,MAT_INITIAL_MATRIX,&Xt_training));
-    PetscCall(VecGetSubVector(y,is_training,&y_training));
+    PetscCall(ISComplement(is_test, lo, hi, &is_training));
+    PetscCall(MatCreateSubMatrix(Xt, is_training, is_cols, MAT_INITIAL_MATRIX, &Xt_training));
+    PetscCall(VecGetSubVector(y, is_training, &y_training));
 
-    PetscCall(SVMSetTrainingDataset(cross_svm,Xt_training,y_training));
-    PetscCall(SVMSetTestDataset(cross_svm,Xt_test,y_test));
+    PetscCall(SVMSetTrainingDataset(cross_svm, Xt_training, y_training));
+    PetscCall(SVMSetTestDataset(cross_svm, Xt_test, y_test));
 
     /* Test C values on fold */
-    PetscCall(SVMGetQPS(cross_svm,&qps));
+    PetscCall(SVMGetQPS(cross_svm, &qps));
     qps->max_it = 1e7;
-    k = 0;
+    k           = 0;
     for (j = 0; j < m; j += p) {
-      PetscCall(SVMSetPenalty(cross_svm,p,&c_arr[j]));
+      PetscCall(SVMSetPenalty(cross_svm, p, &c_arr[j]));
       PetscCall(SVMTrain(cross_svm));
       PetscCall(SVMTest(cross_svm));
       for (l = 0; l < nscores; ++l) {
-        PetscCall(SVMGetModelScore(cross_svm,model_scores[l],&s));
+        PetscCall(SVMGetModelScore(cross_svm, model_scores[l], &s));
         score[k] += s;
       }
       ++k;
     }
     PetscCall(SVMReset(cross_svm));
-    PetscCall(SVMSetOptionsPrefix(cross_svm,prefix));
+    PetscCall(SVMSetOptionsPrefix(cross_svm, prefix));
 
-    PetscCall(VecRestoreSubVector(y,is_training,&y_training));
+    PetscCall(VecRestoreSubVector(y, is_training, &y_training));
     PetscCall(MatDestroy(&Xt_training));
-    PetscCall(VecRestoreSubVector(y,is_test,&y_test));
+    PetscCall(VecRestoreSubVector(y, is_test, &y_test));
     PetscCall(MatDestroy(&Xt_test));
     PetscCall(ISDestroy(&is_training));
     PetscCall(ISDestroy(&is_test));
   }
 
   n = m / p;
-  for (i = 0; i < n; ++i) score[i] /= (PetscReal) nscores * nfolds;
+  for (i = 0; i < n; ++i) score[i] /= (PetscReal)nscores * nfolds;
 
   PetscCall(ISDestroy(&is_cols));
   PetscCall(SVMDestroy(&cross_svm));
@@ -132,16 +129,16 @@ PetscErrorCode SVMKFoldCrossValidation_Binary(SVM svm,PetscReal c_arr[],PetscInt
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMFoldVecIdx_Binary_Private"
-static PetscErrorCode SVMFoldVecIdx_Binary_Private(Vec idx,PetscInt nfolds,PetscInt i,IS *is_training,IS *is_test)
+static PetscErrorCode SVMFoldVecIdx_Binary_Private(Vec idx, PetscInt nfolds, PetscInt i, IS *is_training, IS *is_test)
 {
-  PetscInt lo,hi;
-  PetscInt first,n;
+  PetscInt lo, hi;
+  PetscInt first, n;
 
-  IS       is_idx,is_idx_training;
-  Vec      idx_training,idx_test;
+  IS  is_idx, is_idx_training;
+  Vec idx_training, idx_test;
 
   PetscFunctionBegin;
-  PetscCall(VecGetOwnershipRange(idx,&lo,&hi));
+  PetscCall(VecGetOwnershipRange(idx, &lo, &hi));
 
   /* Determine first element of index set (local)*/
   first = lo + i - lo % nfolds;
@@ -150,16 +147,16 @@ static PetscErrorCode SVMFoldVecIdx_Binary_Private(Vec idx,PetscInt nfolds,Petsc
   n = (hi + nfolds - first - 1) / nfolds;
 
   /* Create index set for training */
-  PetscCall(ISCreateStride(PetscObjectComm((PetscObject) idx),n,first,nfolds,&is_idx));
-  PetscCall(VecGetSubVector(idx,is_idx,&idx_test));
-  PetscCall(ISCreateFromVec(idx_test,is_test));
-  PetscCall(VecRestoreSubVector(idx,is_idx,&idx_test));
+  PetscCall(ISCreateStride(PetscObjectComm((PetscObject)idx), n, first, nfolds, &is_idx));
+  PetscCall(VecGetSubVector(idx, is_idx, &idx_test));
+  PetscCall(ISCreateFromVec(idx_test, is_test));
+  PetscCall(VecRestoreSubVector(idx, is_idx, &idx_test));
 
   /* Create index set for test */
-  PetscCall(ISComplement(is_idx,lo,hi,&is_idx_training));
-  PetscCall(VecGetSubVector(idx,is_idx_training,&idx_training));
-  PetscCall(ISCreateFromVec(idx_training,is_training));
-  PetscCall(VecRestoreSubVector(idx,is_idx_training,&idx_training));
+  PetscCall(ISComplement(is_idx, lo, hi, &is_idx_training));
+  PetscCall(VecGetSubVector(idx, is_idx_training, &idx_training));
+  PetscCall(ISCreateFromVec(idx_training, is_training));
+  PetscCall(VecRestoreSubVector(idx, is_idx_training, &idx_training));
 
   /* Free memory */
   PetscCall(ISDestroy(&is_idx));
@@ -169,118 +166,115 @@ static PetscErrorCode SVMFoldVecIdx_Binary_Private(Vec idx,PetscInt nfolds,Petsc
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMStratifiedKFoldCrossValidation_Binary"
-PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM svm,PetscReal c_arr[],PetscInt m,PetscReal score[])
+PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM svm, PetscReal c_arr[], PetscInt m, PetscReal score[])
 {
-  SVM_Binary *svm_binary = (SVM_Binary *) svm->data;
+  SVM_Binary *svm_binary = (SVM_Binary *)svm->data;
 
-  MPI_Comm         comm;
-  SVM              cross_svm;
+  MPI_Comm comm;
+  SVM      cross_svm;
 
-  QPS              qps;
+  QPS qps;
 
-  Mat              Xt,Xt_training,Xt_test;
-  Vec              y,y_training,y_test;
+  Mat Xt, Xt_training, Xt_test;
+  Vec y, y_training, y_test;
 
-  IS               is_training,is_test;
-  IS               is_cols;
+  IS is_training, is_test;
+  IS is_cols;
 
-  IS               is_p,is_n;
-  Vec              idx_p,idx_n;
+  IS  is_p, is_n;
+  Vec idx_p, idx_n;
 
-  IS               is_training_p,is_test_p;
-  IS               is_training_n,is_test_n;
+  IS is_training_p, is_test_p;
+  IS is_training_n, is_test_n;
 
-  PetscInt         nfolds;
-  PetscInt         i,j,k,l;
+  PetscInt nfolds;
+  PetscInt i, j, k, l;
 
-  PetscInt         p;
-  PetscInt         svm_mod;
-  SVMLossType      svm_loss;
+  PetscInt    p;
+  PetscInt    svm_mod;
+  SVMLossType svm_loss;
 
-  PetscBool        info_set;
+  PetscBool info_set;
 
-  PetscReal        s;
+  PetscReal         s;
   const ModelScore *model_scores;
-  PetscInt         nscores;
+  PetscInt          nscores;
 
-  const char       *prefix;
+  const char *prefix;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
-  PetscCall(SVMGetLossType(svm,&svm_loss));
-  PetscCall(SVMGetMod(svm,&svm_mod));
-  PetscCall(SVMGetPenaltyType(svm,&p));
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+  PetscCall(SVMGetLossType(svm, &svm_loss));
+  PetscCall(SVMGetMod(svm, &svm_mod));
+  PetscCall(SVMGetPenaltyType(svm, &p));
 
   /* Create SVM used in cross validation */
-  PetscCall(SVMCreate(PetscObjectComm((PetscObject)svm),&cross_svm));
-  PetscCall(SVMSetType(cross_svm,SVM_BINARY));
+  PetscCall(SVMCreate(PetscObjectComm((PetscObject)svm), &cross_svm));
+  PetscCall(SVMSetType(cross_svm, SVM_BINARY));
 
   /* Set options of SVM used in cross validation */
-  PetscCall(SVMSetMod(cross_svm,svm_mod));
-  PetscCall(SVMSetLossType(cross_svm,svm_loss));
-  PetscCall(SVMSetPenaltyType(cross_svm,p));
-  PetscCall(SVMAppendOptionsPrefix(cross_svm,"cross_"));
+  PetscCall(SVMSetMod(cross_svm, svm_mod));
+  PetscCall(SVMSetLossType(cross_svm, svm_loss));
+  PetscCall(SVMSetPenaltyType(cross_svm, p));
+  PetscCall(SVMAppendOptionsPrefix(cross_svm, "cross_"));
   PetscCall(SVMSetFromOptions(cross_svm));
 
-  PetscCall(SVMGetOptionsPrefix(cross_svm,&prefix));
-  PetscCall(PetscOptionsHasName(NULL,prefix,"-svm_info",&info_set));
+  PetscCall(SVMGetOptionsPrefix(cross_svm, &prefix));
+  PetscCall(PetscOptionsHasName(NULL, prefix, "-svm_info", &info_set));
 
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,&y));
-  PetscCall(MatGetOwnershipIS(Xt,NULL,&is_cols));
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, &y));
+  PetscCall(MatGetOwnershipIS(Xt, NULL, &is_cols));
 
   /* Split positive and negative training samples */
   is_p = svm_binary->is_p;
   is_n = svm_binary->is_n;
 
   /* Create vectors that contain indices of positive and negative samples */
-  PetscCall(VecCreateFromIS(is_p,&idx_p));
-  PetscCall(VecCreateFromIS(is_n,&idx_n));
+  PetscCall(VecCreateFromIS(is_p, &idx_p));
+  PetscCall(VecCreateFromIS(is_n, &idx_n));
 
   /* Perform cross validation */
-  PetscCall(SVMGetHyperOptNScoreTypes(svm,&nscores));
-  PetscCall(SVMGetHyperOptScoreTypes(svm,&model_scores));
-  PetscCall(SVMGetNfolds(svm,&nfolds));
+  PetscCall(SVMGetHyperOptNScoreTypes(svm, &nscores));
+  PetscCall(SVMGetHyperOptScoreTypes(svm, &model_scores));
+  PetscCall(SVMGetNfolds(svm, &nfolds));
 
   for (i = 0; i < nfolds; ++i) {
-
-    if (info_set) {
-      PetscCall(PetscPrintf(comm,"SVM: fold %" PetscInt_FMT " of %" PetscInt_FMT "\n",i+1,nfolds));
-    }
+    if (info_set) { PetscCall(PetscPrintf(comm, "SVM: fold %" PetscInt_FMT " of %" PetscInt_FMT "\n", i + 1, nfolds)); }
 
     /* Fold positive samples */
-    PetscCall(SVMFoldVecIdx_Binary_Private(idx_p,nfolds,i,&is_training_p,&is_test_p));
+    PetscCall(SVMFoldVecIdx_Binary_Private(idx_p, nfolds, i, &is_training_p, &is_test_p));
     /* Fold positive samples */
-    PetscCall(SVMFoldVecIdx_Binary_Private(idx_n,nfolds,i,&is_training_n,&is_test_n));
+    PetscCall(SVMFoldVecIdx_Binary_Private(idx_n, nfolds, i, &is_training_n, &is_test_n));
 
     /* Union indices of positive and negative training samples */
-    PetscCall(ISExpand(is_training_p,is_training_n,&is_training));
+    PetscCall(ISExpand(is_training_p, is_training_n, &is_training));
     /* Union indices of positive and negative test samples */
-    PetscCall(ISExpand(is_test_p,is_test_n,&is_test));
+    PetscCall(ISExpand(is_test_p, is_test_n, &is_test));
 
     /* Create training dataset */
-    PetscCall(MatCreateSubMatrix(Xt,is_training,is_cols,MAT_INITIAL_MATRIX,&Xt_training));
-    PetscCall(VecGetSubVector(y,is_training,&y_training));
+    PetscCall(MatCreateSubMatrix(Xt, is_training, is_cols, MAT_INITIAL_MATRIX, &Xt_training));
+    PetscCall(VecGetSubVector(y, is_training, &y_training));
 
     /* Create test dataset */
-    PetscCall(MatCreateSubMatrix(Xt,is_test,is_cols,MAT_INITIAL_MATRIX,&Xt_test));
-    PetscCall(VecGetSubVector(y,is_test,&y_test));
+    PetscCall(MatCreateSubMatrix(Xt, is_test, is_cols, MAT_INITIAL_MATRIX, &Xt_test));
+    PetscCall(VecGetSubVector(y, is_test, &y_test));
 
-    PetscCall(SVMSetTrainingDataset(cross_svm,Xt_training,y_training));
-    PetscCall(SVMSetTestDataset(cross_svm,Xt_test,y_test));
+    PetscCall(SVMSetTrainingDataset(cross_svm, Xt_training, y_training));
+    PetscCall(SVMSetTestDataset(cross_svm, Xt_test, y_test));
 
     /* Test C values on fold */
-    PetscCall(SVMGetQPS(cross_svm,&qps));
+    PetscCall(SVMGetQPS(cross_svm, &qps));
     qps->max_it = 1e7;
-    k = 0;
+    k           = 0;
 
     for (j = 0; j < m; j += p) {
-      PetscCall(SVMSetPenalty(cross_svm,p,&c_arr[j]));
+      PetscCall(SVMSetPenalty(cross_svm, p, &c_arr[j]));
       PetscCall(SVMTrain(cross_svm));
       PetscCall(SVMTest(cross_svm));
 
       /* Get model scores */
       for (l = 0; l < nscores; ++l) {
-        PetscCall(SVMGetModelScore(cross_svm,model_scores[l],&s));
+        PetscCall(SVMGetModelScore(cross_svm, model_scores[l], &s));
         score[k] += s;
       }
 
@@ -288,13 +282,13 @@ PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM svm,PetscReal c_arr[
     }
 
     PetscCall(SVMReset(cross_svm));
-    PetscCall(SVMSetOptionsPrefix(cross_svm,prefix));
+    PetscCall(SVMSetOptionsPrefix(cross_svm, prefix));
 
     /* Free memory */
     PetscCall(MatDestroy(&Xt_training));
     PetscCall(MatDestroy(&Xt_test));
-    PetscCall(VecRestoreSubVector(y,is_training,&y_training));
-    PetscCall(VecRestoreSubVector(y,is_test,&y_test));
+    PetscCall(VecRestoreSubVector(y, is_training, &y_training));
+    PetscCall(VecRestoreSubVector(y, is_test, &y_test));
     PetscCall(ISDestroy(&is_training));
     PetscCall(ISDestroy(&is_test));
     PetscCall(ISDestroy(&is_training_n));
@@ -304,7 +298,7 @@ PetscErrorCode SVMStratifiedKFoldCrossValidation_Binary(SVM svm,PetscReal c_arr[
   }
 
   k = m / p;
-  for (i = 0; i < k; ++i) score[i] /= (PetscReal) nscores * nfolds;
+  for (i = 0; i < k; ++i) score[i] /= (PetscReal)nscores * nfolds;
 
   /* Free memory */
   PetscCall(ISDestroy(&is_cols));

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -1,7 +1,5 @@
-
 #include "probimpl.h"
 #include "../../utils/report.h"
-
 
 PetscErrorCode SVMReset_Probability(SVM svm)
 {

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -64,7 +64,6 @@ PetscErrorCode SVMView_Probability(SVM svm,PetscViewer v)
   PetscBool isascii;
 
   PetscFunctionBegin;
-
   comm = PetscObjectComm((PetscObject) svm);
   if (!v) v = PETSC_VIEWER_STDOUT_(comm);
   PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));

--- a/src/svm/impls/probability/prob.c
+++ b/src/svm/impls/probability/prob.c
@@ -3,7 +3,7 @@
 
 PetscErrorCode SVMReset_Probability(SVM svm)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
   PetscCall(MatDestroy(&svm_prob->Xt_training));
@@ -14,20 +14,20 @@ PetscErrorCode SVMReset_Probability(SVM svm)
   PetscCall(SVMDestroy(&svm_prob->inner));
   PetscCall(TaoDestroy(&svm_prob->tao));
 
-  PetscCall(VecDestroyVecs(2,&svm_prob->work_vecs));
+  PetscCall(VecDestroyVecs(2, &svm_prob->work_vecs));
   PetscCall(VecDestroy(&svm_prob->vec_dist));
   PetscCall(VecDestroy(&svm_prob->vec_targets));
 
   svm_prob->Xt_training = NULL;
   svm_prob->y_training  = NULL;
 
-  svm_prob->Xt_calib    = NULL;
-  svm_prob->y_calib     = NULL;
+  svm_prob->Xt_calib = NULL;
+  svm_prob->y_calib  = NULL;
 
-  svm_prob->inner       = NULL;
-  svm_prob->tao         = NULL;
+  svm_prob->inner = NULL;
+  svm_prob->tao   = NULL;
 
-  svm_prob->work_vecs   = NULL;
+  svm_prob->work_vecs = NULL;
 
   svm_prob->vec_dist    = NULL;
   svm_prob->vec_targets = NULL;
@@ -36,171 +36,168 @@ PetscErrorCode SVMReset_Probability(SVM svm)
 
 PetscErrorCode SVMDestroy_Probability(SVM svm)
 {
-
   PetscFunctionBegin;
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetInnerSVM_C"           ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTao_C"                ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C"    ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C"    ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetCalibrationDataset_C" ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetCalibrationDataset_C" ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetLabels_C"             ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMLoadCalibrationDataset_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMViewCalibrationDataset_C",NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C"      ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C"      ,NULL));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C"   ,NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetInnerSVM_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetTao_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetTrainingDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetTrainingDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetCalibrationDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetCalibrationDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetLabels_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMLoadCalibrationDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMViewCalibrationDataset_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetOptionsPrefix_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetOptionsPrefix_C", NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMAppendOptionsPrefix_C", NULL));
 
   PetscCall(SVMDestroyDefault(svm));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMView_Probability(SVM svm,PetscViewer v)
+PetscErrorCode SVMView_Probability(SVM svm, PetscViewer v)
 {
-  MPI_Comm  comm;
-  SVM       svm_uncalibrated;
+  MPI_Comm comm;
+  SVM      svm_uncalibrated;
 
-  PetscReal A,B;
+  PetscReal A, B;
   PetscBool isascii;
 
   PetscFunctionBegin;
-  comm = PetscObjectComm((PetscObject) svm);
+  comm = PetscObjectComm((PetscObject)svm);
   if (!v) v = PETSC_VIEWER_STDOUT_(comm);
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
 
   if (isascii) {
-    PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
-    PetscCall(SVMView(svm_uncalibrated,v));
+    PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
+    PetscCall(SVMView(svm_uncalibrated, v));
     PetscCall(SVMDestroy(&svm_uncalibrated));
 
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
-    PetscCall(SVMProbabilityGetSigmoidParams(svm,&A,&B));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
+    PetscCall(SVMProbabilityGetSigmoidParams(svm, &A, &B));
 
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"model parameters:\n"));
+    PetscCall(PetscViewerASCIIPrintf(v, "model parameters:\n"));
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"A=%.4f",(double)A));
-    PetscCall(PetscViewerASCIIPrintf(v,"B=%.4f\n",(double)B));
+    PetscCall(PetscViewerASCIIPrintf(v, "A=%.4f", (double)A));
+    PetscCall(PetscViewerASCIIPrintf(v, "B=%.4f\n", (double)B));
     PetscCall(PetscViewerASCIIPopTab(v));
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMView", ((PetscObject)v)->type_name);
+    SETERRQ(comm, PETSC_ERR_SUP, "Viewer type %s not supported for SVMView", ((PetscObject)v)->type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMViewScore_Probability(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewScore_Probability(SVM svm, PetscViewer v)
 {
-  MPI_Comm        comm;
+  MPI_Comm comm;
 
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
-  SVM             svm_uncalibrated;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
+  SVM              svm_uncalibrated;
 
-  PetscReal       threshold;
-  PetscBool       isascii;
+  PetscReal threshold;
+  PetscBool isascii;
 
   PetscFunctionBegin;
-  comm = PetscObjectComm((PetscObject) svm);
+  comm = PetscObjectComm((PetscObject)svm);
   if (!v) v = PETSC_VIEWER_STDOUT_(comm);
 
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
-    PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
-    PetscCall(SVMViewScore(svm_uncalibrated,v));
+    PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
+    PetscCall(SVMViewScore(svm_uncalibrated, v));
 
-    PetscCall(SVMProbabilityGetThreshold(svm,&threshold));
+    PetscCall(SVMProbabilityGetThreshold(svm, &threshold));
 
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"model performance scores with threshold=%.2f\n",(double) threshold));
+    PetscCall(PetscViewerASCIIPrintf(v, "model performance scores with threshold=%.2f\n", (double)threshold));
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(SVMViewBinaryClassificationReport(svm,svm_prob->confusion_matrix,svm_prob->model_scores,v));
+    PetscCall(SVMViewBinaryClassificationReport(svm, svm_prob->confusion_matrix, svm_prob->model_scores, v));
     PetscCall(PetscViewerASCIIPopTab(v));
     PetscCall(PetscViewerASCIIPopTab(v));
 
     /* Clean up */
     PetscCall(SVMDestroy(&svm_uncalibrated));
   } else {
-    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewScore", ((PetscObject)v)->type_name);
+    SETERRQ(comm, PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewScore", ((PetscObject)v)->type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMSetTrainingDataset_Probability(SVM svm,Mat Xt_training,Vec y_training)
+PetscErrorCode SVMSetTrainingDataset_Probability(SVM svm, Mat Xt_training, Vec y_training)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
-  Mat             Xt_calib;
-  PetscInt        k,l,n;
+  Mat      Xt_calib;
+  PetscInt k, l, n;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(Xt_training,MAT_CLASSID,2);
-  PetscCheckSameComm(svm,1,Xt_training,2);
-  PetscValidHeaderSpecific(y_training,VEC_CLASSID,3);
-  PetscCheckSameComm(svm,1,y_training,3);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(Xt_training, MAT_CLASSID, 2);
+  PetscCheckSameComm(svm, 1, Xt_training, 2);
+  PetscValidHeaderSpecific(y_training, VEC_CLASSID, 3);
+  PetscCheckSameComm(svm, 1, y_training, 3);
 
-  PetscCall(MatGetSize(Xt_training,&k,NULL));
-  PetscCall(VecGetSize(y_training,&l));
-  PetscCheck(k == l,PetscObjectComm((PetscObject) Xt_training),PETSC_ERR_ARG_SIZ,
-             "Dimensions are incompatible, X_training(%" PetscInt_FMT ",) != y_training(%" PetscInt_FMT ")",k,l);
+  PetscCall(MatGetSize(Xt_training, &k, NULL));
+  PetscCall(VecGetSize(y_training, &l));
+  PetscCheck(k == l, PetscObjectComm((PetscObject)Xt_training), PETSC_ERR_ARG_SIZ, "Dimensions are incompatible, X_training(%" PetscInt_FMT ",) != y_training(%" PetscInt_FMT ")", k, l);
 
-  PetscCall(SVMGetCalibrationDataset(svm,&Xt_calib,NULL));
+  PetscCall(SVMGetCalibrationDataset(svm, &Xt_calib, NULL));
   if (Xt_calib != NULL) {
-    PetscCall(MatGetSize(Xt_training,NULL,&l));
-    PetscCall(MatGetSize(Xt_calib,NULL,&n));
-    PetscCheck(l == n,PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,
-               "Dimensions are incompatible, X_training(,%" PetscInt_FMT ") != X_calib(,%" PetscInt_FMT ")",l,n);
+    PetscCall(MatGetSize(Xt_training, NULL, &l));
+    PetscCall(MatGetSize(Xt_calib, NULL, &n));
+    PetscCheck(l == n, PetscObjectComm((PetscObject)Xt_calib), PETSC_ERR_ARG_SIZ, "Dimensions are incompatible, X_training(,%" PetscInt_FMT ") != X_calib(,%" PetscInt_FMT ")", l, n);
   }
 
   PetscCall(MatDestroy(&svm_prob->Xt_training));
   svm_prob->Xt_training = Xt_training;
-  PetscCall(PetscObjectReference((PetscObject) Xt_training));
+  PetscCall(PetscObjectReference((PetscObject)Xt_training));
 
   PetscCall(VecDestroy(&svm_prob->y_training));
   svm_prob->y_training = y_training;
-  PetscCall(PetscObjectReference((PetscObject) y_training));
+  PetscCall(PetscObjectReference((PetscObject)y_training));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetTrainingDataset_Probability(SVM svm,Mat *Xt_training,Vec *y_training)
+PetscErrorCode SVMGetTrainingDataset_Probability(SVM svm, Mat *Xt_training, Vec *y_training)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
   if (Xt_training) {
-    PetscAssertPointer(Xt_training,2);
+    PetscAssertPointer(Xt_training, 2);
     *Xt_training = svm_prob->Xt_training;
   }
   if (y_training) {
-    PetscAssertPointer(y_training,3);
+    PetscAssertPointer(y_training, 3);
     *y_training = svm_prob->y_training;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode SVMGetNumberPositiveNegativeSamples_Probability_Private(Vec y,PetscInt *ntarget_lo,PetscInt *ntarget_hi)
+static PetscErrorCode SVMGetNumberPositiveNegativeSamples_Probability_Private(Vec y, PetscInt *ntarget_lo, PetscInt *ntarget_hi)
 {
-  Vec       tmp;
-  IS        is_p,is_n;
+  Vec tmp;
+  IS  is_p, is_n;
 
-  PetscInt  lo,hi,n;
+  PetscInt  lo, hi, n;
   PetscReal max;
 
   PetscFunctionBegin;
   /* Determine index sets of positive and negative samples */
-  PetscCall(VecGetOwnershipRange(y,&lo,&hi));
-  PetscCall(VecMax(y,NULL,&max));
-  PetscCall(VecDuplicate(y,&tmp));
-  PetscCall(VecSet(tmp,max));
+  PetscCall(VecGetOwnershipRange(y, &lo, &hi));
+  PetscCall(VecMax(y, NULL, &max));
+  PetscCall(VecDuplicate(y, &tmp));
+  PetscCall(VecSet(tmp, max));
 
   /* Index set for positive and negative samples */
-  PetscCall(VecWhichEqual(y,tmp,&is_p));
-  PetscCall(ISComplement(is_p,lo,hi,&is_n));
+  PetscCall(VecWhichEqual(y, tmp, &is_p));
+  PetscCall(ISComplement(is_p, lo, hi, &is_n));
 
-  PetscCall(ISGetSize(is_n,&n));
+  PetscCall(ISGetSize(is_n, &n));
   *ntarget_lo = n;
-  PetscCall(ISGetSize(is_p,&n));
+  PetscCall(ISGetSize(is_p, &n));
   *ntarget_hi = n;
 
   /* Clean up */
@@ -210,104 +207,102 @@ static PetscErrorCode SVMGetNumberPositiveNegativeSamples_Probability_Private(Ve
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMSetCalibrationDataset_Probability(SVM svm,Mat Xt_calib,Vec y_calib)
+PetscErrorCode SVMSetCalibrationDataset_Probability(SVM svm, Mat Xt_calib, Vec y_calib)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
-  Mat             Xt_training;
+  Mat Xt_training;
 
-  PetscInt        k,l;
-  PetscInt        n;
+  PetscInt k, l;
+  PetscInt n;
 
-  PetscInt        ntargets_lo,ntargets_hi;
+  PetscInt ntargets_lo, ntargets_hi;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(Xt_calib,MAT_CLASSID,2);
-  PetscCheckSameComm(svm,1,Xt_calib,2);
-  PetscValidHeaderSpecific(y_calib,VEC_CLASSID,3);
-  PetscCheckSameComm(svm,1,y_calib,3);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(Xt_calib, MAT_CLASSID, 2);
+  PetscCheckSameComm(svm, 1, Xt_calib, 2);
+  PetscValidHeaderSpecific(y_calib, VEC_CLASSID, 3);
+  PetscCheckSameComm(svm, 1, y_calib, 3);
 
-  PetscCall(MatGetSize(Xt_calib,&k,NULL));
-  PetscCall(VecGetSize(y_calib,&l));
-  PetscCheck(k == l,PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,
-             "Dimensions are incompatible, X_calib(%" PetscInt_FMT ",) != y_calib(%" PetscInt_FMT ")",k,l);
+  PetscCall(MatGetSize(Xt_calib, &k, NULL));
+  PetscCall(VecGetSize(y_calib, &l));
+  PetscCheck(k == l, PetscObjectComm((PetscObject)Xt_calib), PETSC_ERR_ARG_SIZ, "Dimensions are incompatible, X_calib(%" PetscInt_FMT ",) != y_calib(%" PetscInt_FMT ")", k, l);
 
-  PetscCall(SVMGetTrainingDataset(svm,&Xt_training,NULL));
+  PetscCall(SVMGetTrainingDataset(svm, &Xt_training, NULL));
   if (Xt_training != NULL) {
-    PetscCall(MatGetSize(Xt_calib,NULL,&l));
-    PetscCall(MatGetSize(Xt_training,NULL,&n));
-    PetscCheck(l == n,PetscObjectComm((PetscObject) Xt_calib),PETSC_ERR_ARG_SIZ,
-              "Dimensions are incompatible, X_calib(,%" PetscInt_FMT ") != X_training(,%" PetscInt_FMT ")",l,n);
+    PetscCall(MatGetSize(Xt_calib, NULL, &l));
+    PetscCall(MatGetSize(Xt_training, NULL, &n));
+    PetscCheck(l == n, PetscObjectComm((PetscObject)Xt_calib), PETSC_ERR_ARG_SIZ, "Dimensions are incompatible, X_calib(,%" PetscInt_FMT ") != X_training(,%" PetscInt_FMT ")", l, n);
   }
 
   PetscCall(MatDestroy(&svm_prob->Xt_calib));
   svm_prob->Xt_calib = Xt_calib;
-  PetscCall(PetscObjectReference((PetscObject) Xt_calib));
+  PetscCall(PetscObjectReference((PetscObject)Xt_calib));
 
   PetscCall(VecDestroy(&svm_prob->y_calib));
   svm_prob->y_calib = y_calib;
-  PetscCall(PetscObjectReference((PetscObject) y_calib));
+  PetscCall(PetscObjectReference((PetscObject)y_calib));
 
   /* Determine a number of positive and negative samples in calibration dataset */
-  PetscCall(SVMGetNumberPositiveNegativeSamples_Probability_Private(y_calib,&ntargets_lo,&ntargets_hi));
+  PetscCall(SVMGetNumberPositiveNegativeSamples_Probability_Private(y_calib, &ntargets_lo, &ntargets_hi));
   svm_prob->Nn_calib = ntargets_lo;
   svm_prob->Np_calib = ntargets_hi;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetCalibrationDataset_Probability(SVM svm,Mat *Xt_calib,Vec *y_calib)
+PetscErrorCode SVMGetCalibrationDataset_Probability(SVM svm, Mat *Xt_calib, Vec *y_calib)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
   if (Xt_calib) {
-    PetscAssertPointer(Xt_calib,2);
+    PetscAssertPointer(Xt_calib, 2);
     *Xt_calib = svm_prob->Xt_calib;
   }
 
   if (y_calib) {
-    PetscAssertPointer(y_calib,3);
+    PetscAssertPointer(y_calib, 3);
     *y_calib = svm_prob->y_calib;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetLabels_Probability(SVM svm,const PetscReal *labels[])
+PetscErrorCode SVMGetLabels_Probability(SVM svm, const PetscReal *labels[])
 {
-  SVM             svm_uncalibrated;
+  SVM              svm_uncalibrated;
   const PetscReal *labels_inner;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
-  PetscCall(SVMGetLabels(svm_uncalibrated,&labels_inner));
+  PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
+  PetscCall(SVMGetLabels(svm_uncalibrated, &labels_inner));
   *labels = labels_inner;
   PetscCall(SVMDestroy(&svm_uncalibrated));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode SVMCreateTAO_Probability_Private(SVM svm,Tao *tao)
+static PetscErrorCode SVMCreateTAO_Probability_Private(SVM svm, Tao *tao)
 {
-  Tao        tao_inner;
+  Tao tao_inner;
 
-  KSP        ksp;
-  PC         pc;
+  KSP ksp;
+  PC  pc;
 
   const char *prefix = NULL;
 
   PetscFunctionBegin;
-  PetscCall(TaoCreate(MPI_COMM_SELF,&tao_inner));
-  PetscCall(TaoSetType(tao_inner,TAONLS));
+  PetscCall(TaoCreate(MPI_COMM_SELF, &tao_inner));
+  PetscCall(TaoSetType(tao_inner, TAONLS));
 
   /* Disable preconditioning */
-  PetscCall(TaoGetKSP(tao_inner,&ksp));
-  PetscCall(PCCreate(MPI_COMM_SELF,&pc));
-  PetscCall(PCSetType(pc,PCNONE));
-  PetscCall(KSPSetPC(ksp,pc));
+  PetscCall(TaoGetKSP(tao_inner, &ksp));
+  PetscCall(PCCreate(MPI_COMM_SELF, &pc));
+  PetscCall(PCSetType(pc, PCNONE));
+  PetscCall(KSPSetPC(ksp, pc));
 
   /* Set prefix */
-  PetscCall(SVMGetOptionsPrefix(svm,&prefix));
-  PetscCall(TaoAppendOptionsPrefix(tao_inner,prefix));
+  PetscCall(SVMGetOptionsPrefix(svm, &prefix));
+  PetscCall(TaoAppendOptionsPrefix(tao_inner, prefix));
 
   *tao = tao_inner;
 
@@ -316,65 +311,65 @@ static PetscErrorCode SVMCreateTAO_Probability_Private(SVM svm,Tao *tao)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetTao_Probability(SVM svm,Tao *tao)
+PetscErrorCode SVMGetTao_Probability(SVM svm, Tao *tao)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
-  Tao             tao_inner;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
+  Tao              tao_inner;
 
   PetscFunctionBegin;
   if (!svm_prob->tao) {
-    PetscCall(SVMCreateTAO_Probability_Private(svm,&tao_inner));
+    PetscCall(SVMCreateTAO_Probability_Private(svm, &tao_inner));
     svm_prob->tao = tao_inner;
   }
 
-  PetscCall(PetscObjectReference((PetscObject) svm_prob->tao));
+  PetscCall(PetscObjectReference((PetscObject)svm_prob->tao));
   *tao = svm_prob->tao;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SVM svm)
 {
-  SVM_Probability   *svm_prob = (SVM_Probability *) svm->data;
-  SVM               svm_uncalibrated;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
+  SVM              svm_uncalibrated;
 
-  Mat               Xt_calib;
-  Vec               y_calib;
+  Mat Xt_calib;
+  Vec y_calib;
 
-  VecScatter        scatter;
-  Vec               dist;
+  VecScatter scatter;
+  Vec        dist;
 
-  Vec               vec_labels;
-  const PetscReal   *labels = NULL;
-  IS                is_labels;
+  Vec              vec_labels;
+  const PetscReal *labels = NULL;
+  IS               is_labels;
 
-  Vec               vec_targets,vec_targets_sub;
-  PetscReal         target_prob[2];
+  Vec       vec_targets, vec_targets_sub;
+  PetscReal target_prob[2];
 
-  PetscBool         label_to_target_prob;
+  PetscBool label_to_target_prob;
 
-  PetscInt          Np,Nn;
-  PetscInt          i;
+  PetscInt Np, Nn;
+  PetscInt i;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
-  PetscCall(SVMGetCalibrationDataset(svm,&Xt_calib,&y_calib));
+  PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
+  PetscCall(SVMGetCalibrationDataset(svm, &Xt_calib, &y_calib));
 
   /* Get distance samples from a separating hyperplane */
   PetscCall(VecDestroy(&svm_prob->vec_dist));
 
-  PetscCall(SVMGetDistancesFromHyperplane(svm_uncalibrated,Xt_calib,&dist));
-  PetscCall(VecScatterCreateToZero(dist,&scatter,&svm_prob->vec_dist));
-  PetscCall(VecScatterBegin(scatter,dist,svm_prob->vec_dist,INSERT_VALUES,SCATTER_FORWARD));
-  PetscCall(VecScatterEnd(scatter,dist,svm_prob->vec_dist,INSERT_VALUES,SCATTER_FORWARD));
+  PetscCall(SVMGetDistancesFromHyperplane(svm_uncalibrated, Xt_calib, &dist));
+  PetscCall(VecScatterCreateToZero(dist, &scatter, &svm_prob->vec_dist));
+  PetscCall(VecScatterBegin(scatter, dist, svm_prob->vec_dist, INSERT_VALUES, SCATTER_FORWARD));
+  PetscCall(VecScatterEnd(scatter, dist, svm_prob->vec_dist, INSERT_VALUES, SCATTER_FORWARD));
   PetscCall(VecScatterDestroy(&scatter));
 
-  PetscCall(SVMProbabilityGetConvertLabelsToTargetProbability(svm,&label_to_target_prob));
+  PetscCall(SVMProbabilityGetConvertLabelsToTargetProbability(svm, &label_to_target_prob));
   if (label_to_target_prob) {
     /*
      Transform labels to target probabilities as it proposed in
      http://www.cs.colorado.edu/~mozer/Teaching/syllabi/6622/papers/Platt1999.pdf
     */
-    PetscCall(SVMGetNumberPositiveNegativeSamples_Probability_Private(y_calib,&Np,&Nn));
+    PetscCall(SVMGetNumberPositiveNegativeSamples_Probability_Private(y_calib, &Np, &Nn));
     target_prob[0] = 1. / (Nn + 2);
     target_prob[1] = (Np + 1.) / (Np + 2.);
   } else {
@@ -382,23 +377,23 @@ static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SV
     target_prob[1] = 1.;
   }
 
-  PetscCall(SVMGetLabels(svm,&labels));
-  PetscCall(VecDuplicate(y_calib,&vec_labels));
-  PetscCall(VecDuplicate(y_calib,&vec_targets));
+  PetscCall(SVMGetLabels(svm, &labels));
+  PetscCall(VecDuplicate(y_calib, &vec_labels));
+  PetscCall(VecDuplicate(y_calib, &vec_targets));
 
   for (i = 0; i < 2; ++i) {
-    PetscCall(VecSet(vec_labels,labels[i]));
-    PetscCall(VecWhichEqual(y_calib,vec_labels,&is_labels));
-    PetscCall(VecGetSubVector(vec_targets,is_labels,&vec_targets_sub));
-    PetscCall(VecSet(vec_targets_sub,target_prob[i]));
-    PetscCall(VecRestoreSubVector(vec_targets,is_labels,&vec_targets_sub));
+    PetscCall(VecSet(vec_labels, labels[i]));
+    PetscCall(VecWhichEqual(y_calib, vec_labels, &is_labels));
+    PetscCall(VecGetSubVector(vec_targets, is_labels, &vec_targets_sub));
+    PetscCall(VecSet(vec_targets_sub, target_prob[i]));
+    PetscCall(VecRestoreSubVector(vec_targets, is_labels, &vec_targets_sub));
     PetscCall(ISDestroy(&is_labels));
   }
 
   /* Scatter targets to a root process */
-  PetscCall(VecScatterCreateToZero(vec_targets,&scatter,&svm_prob->vec_targets));
-  PetscCall(VecScatterBegin(scatter,vec_targets,svm_prob->vec_targets,INSERT_VALUES,SCATTER_FORWARD));
-  PetscCall(VecScatterEnd(scatter,vec_targets,svm_prob->vec_targets,INSERT_VALUES,SCATTER_FORWARD));
+  PetscCall(VecScatterCreateToZero(vec_targets, &scatter, &svm_prob->vec_targets));
+  PetscCall(VecScatterBegin(scatter, vec_targets, svm_prob->vec_targets, INSERT_VALUES, SCATTER_FORWARD));
+  PetscCall(VecScatterEnd(scatter, vec_targets, svm_prob->vec_targets, INSERT_VALUES, SCATTER_FORWARD));
   PetscCall(VecScatterDestroy(&scatter));
 
   /* Clean up */
@@ -409,32 +404,32 @@ static PetscErrorCode SVMTransformUncalibratedPredictions_Probability_Private(SV
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec params_sigmoid,PetscReal *fnc,Vec g,void *ctx)
+static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao, Vec params_sigmoid, PetscReal *fnc, Vec g, void *ctx)
 {
-  SVM             svm       = (SVM) ctx;
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM              svm      = (SVM)ctx;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
-  PetscReal       g_arr[2]  = {0.,0.};
-  PetscInt        idx[2]    = {0,1};
+  PetscReal g_arr[2] = {0., 0.};
+  PetscInt  idx[2]   = {0, 1};
 
-  PetscReal       fnc_inner = 0.;
-  PetscReal       tmp;
+  PetscReal fnc_inner = 0.;
+  PetscReal tmp;
 
-  Vec             *work_vecs = NULL;
-  Vec             *work_sub  = NULL;
-  PetscInt        N_works    = 2;
+  Vec     *work_vecs = NULL;
+  Vec     *work_sub  = NULL;
+  PetscInt N_works   = 2;
 
-  IS              is_p,is_n;
-  PetscInt        N;
+  IS       is_p, is_n;
+  PetscInt N;
 
-  PetscReal       A,B;
+  PetscReal        A, B;
   const PetscReal *params_sigmoid_arr = NULL;
 
   PetscFunctionBegin;
-  PetscCall(VecGetSize(svm_prob->vec_dist,&N));
+  PetscCall(VecGetSize(svm_prob->vec_dist, &N));
 
   if (!svm_prob->work_vecs) {
-    PetscCall(VecDuplicateVecs(svm_prob->vec_dist,N_works,&work_vecs));
+    PetscCall(VecDuplicateVecs(svm_prob->vec_dist, N_works, &work_vecs));
     svm_prob->work_vecs = work_vecs;
   } else {
     work_vecs = svm_prob->work_vecs;
@@ -442,63 +437,64 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec pa
 
   work_sub = svm_prob->work_sub;
 
-  PetscCall(VecSet(work_vecs[0],1.));
-  PetscCall(VecSet(work_vecs[1],0.));
+  PetscCall(VecSet(work_vecs[0], 1.));
+  PetscCall(VecSet(work_vecs[1], 0.));
 
   /* Actual parameters of sigmoid */
-  PetscCall(VecGetArrayRead(params_sigmoid,&params_sigmoid_arr));
-  A = params_sigmoid_arr[0]; B = params_sigmoid_arr[1];
-  PetscCall(VecRestoreArrayRead(params_sigmoid,&params_sigmoid_arr));
+  PetscCall(VecGetArrayRead(params_sigmoid, &params_sigmoid_arr));
+  A = params_sigmoid_arr[0];
+  B = params_sigmoid_arr[1];
+  PetscCall(VecRestoreArrayRead(params_sigmoid, &params_sigmoid_arr));
 
-  PetscCall(VecAXPBY(work_vecs[0],A,B,svm_prob->vec_dist));        /* work[0] <- A * dist + B  (AdpB) */
-  PetscCall(VecDot(svm_prob->vec_targets,work_vecs[0],&tmp));      /* target^T * AdpB */
+  PetscCall(VecAXPBY(work_vecs[0], A, B, svm_prob->vec_dist));  /* work[0] <- A * dist + B  (AdpB) */
+  PetscCall(VecDot(svm_prob->vec_targets, work_vecs[0], &tmp)); /* target^T * AdpB */
   fnc_inner = tmp;
 
-  PetscCall(VecWhichGreaterThan(work_vecs[0],work_vecs[1],&is_p));
-  PetscCall(ISComplement(is_p,0,N,&is_n));
+  PetscCall(VecWhichGreaterThan(work_vecs[0], work_vecs[1], &is_p));
+  PetscCall(ISComplement(is_p, 0, N, &is_n));
 
   /*
     CASE: A * dist + B >= 0
    */
 
-  PetscCall(VecGetSubVector(work_vecs[0],is_p,&work_sub[0]));
-  PetscCall(VecGetSubVector(work_vecs[1],is_p,&work_sub[1]));
+  PetscCall(VecGetSubVector(work_vecs[0], is_p, &work_sub[0]));
+  PetscCall(VecGetSubVector(work_vecs[1], is_p, &work_sub[1]));
 
-  PetscCall(VecScale(work_sub[0],-1.));                               /* work[0,is+] <- -1. * AdpB[is+]                             */
-  PetscCall(VecExp(work_sub[0]));                                     /* work[0,is+] <- exp(-1. * AdpB[is+])                        */
-  PetscCall(VecCopy(work_sub[0],work_sub[1]));                        /* work[1,is+] <- work[0,is+]                                 */
-  PetscCall(VecShift(work_sub[0],1.));                                /* work[0,is+] <- 1. + work[0,is+]                            */
+  PetscCall(VecScale(work_sub[0], -1.));        /* work[0,is+] <- -1. * AdpB[is+]                             */
+  PetscCall(VecExp(work_sub[0]));               /* work[0,is+] <- exp(-1. * AdpB[is+])                        */
+  PetscCall(VecCopy(work_sub[0], work_sub[1])); /* work[1,is+] <- work[0,is+]                                 */
+  PetscCall(VecShift(work_sub[0], 1.));         /* work[0,is+] <- 1. + work[0,is+]                            */
 
-  PetscCall(VecPointwiseDivide(work_sub[1],work_sub[1],work_sub[0])); /* work[1,is+] <- exp(-work[0,is+]) / (1 + exp(-work[0,is+])) */
+  PetscCall(VecPointwiseDivide(work_sub[1], work_sub[1], work_sub[0])); /* work[1,is+] <- exp(-work[0,is+]) / (1 + exp(-work[0,is+])) */
 
-  PetscCall(VecRestoreSubVector(work_vecs[0],is_p,&work_sub[0]));
-  PetscCall(VecRestoreSubVector(work_vecs[1],is_p,&work_sub[1]));
+  PetscCall(VecRestoreSubVector(work_vecs[0], is_p, &work_sub[0]));
+  PetscCall(VecRestoreSubVector(work_vecs[1], is_p, &work_sub[1]));
 
   /*
     CASE: A * dist + B < 0
    */
 
-  PetscCall(VecGetSubVector(work_vecs[0],is_n,&work_sub[0]));
-  PetscCall(VecGetSubVector(work_vecs[1],is_n,&work_sub[1]));
+  PetscCall(VecGetSubVector(work_vecs[0], is_n, &work_sub[0]));
+  PetscCall(VecGetSubVector(work_vecs[1], is_n, &work_sub[1]));
 
-  PetscCall(VecSum(work_sub[0],&tmp));
+  PetscCall(VecSum(work_sub[0], &tmp));
   fnc_inner -= tmp;
 
-  PetscCall(VecExp(work_sub[0]));                                   /* work[0,is-] <- exp(AdpB[is-])                        */
-  PetscCall(VecShift(work_sub[0],1.));                              /* work[0,is-] <- 1. + exp(AdpB[is-])                   */
-  PetscCall(VecCopy(work_sub[0],work_sub[1]));                      /* work[1,is-] <- work[0,is-]                           */
+  PetscCall(VecExp(work_sub[0]));               /* work[0,is-] <- exp(AdpB[is-])                        */
+  PetscCall(VecShift(work_sub[0], 1.));         /* work[0,is-] <- 1. + exp(AdpB[is-])                   */
+  PetscCall(VecCopy(work_sub[0], work_sub[1])); /* work[1,is-] <- work[0,is-]                           */
 
-  PetscCall(VecReciprocal(work_sub[1]));                            /* work[1,is-] <- 1. / (1. + exp(AdpB[is-])             */
+  PetscCall(VecReciprocal(work_sub[1])); /* work[1,is-] <- 1. / (1. + exp(AdpB[is-])             */
 
-  PetscCall(VecRestoreSubVector(work_vecs[0],is_n,&work_sub[0]));
-  PetscCall(VecRestoreSubVector(work_vecs[1],is_n,&work_sub[1]));
+  PetscCall(VecRestoreSubVector(work_vecs[0], is_n, &work_sub[0]));
+  PetscCall(VecRestoreSubVector(work_vecs[1], is_n, &work_sub[1]));
 
   /*
     Compute value of objective function
    */
 
   PetscCall(VecLog(work_vecs[0]));
-  PetscCall(VecSum(work_vecs[0],&tmp));
+  PetscCall(VecSum(work_vecs[0], &tmp));
   fnc_inner += tmp;
 
   *fnc = fnc_inner; /* Update a value of objective function */
@@ -507,11 +503,11 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec pa
     Compute gradient
    */
 
-  PetscCall(VecAYPX(work_vecs[1],-1.,svm_prob->vec_targets));
-  PetscCall(VecSum(work_vecs[1],&g_arr[1]));
-  PetscCall(VecDot(work_vecs[1],svm_prob->vec_dist,&g_arr[0]));
+  PetscCall(VecAYPX(work_vecs[1], -1., svm_prob->vec_targets));
+  PetscCall(VecSum(work_vecs[1], &g_arr[1]));
+  PetscCall(VecDot(work_vecs[1], svm_prob->vec_dist, &g_arr[0]));
 
-  PetscCall(VecSetValues(g,2,idx,g_arr,INSERT_VALUES));
+  PetscCall(VecSetValues(g, 2, idx, g_arr, INSERT_VALUES));
   PetscCall(VecAssemblyBegin(g));
   PetscCall(VecAssemblyEnd(g));
 
@@ -521,30 +517,30 @@ static PetscErrorCode TaoFormFunctionGradient_Probability_Private(Tao tao,Vec pa
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec params_sigmoid,Mat H,Mat Hpre,void *ctx)
+static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao, Vec params_sigmoid, Mat H, Mat Hpre, void *ctx)
 {
-  SVM             svm       = (SVM) ctx;
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM              svm      = (SVM)ctx;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
-  PetscReal       H_arr[4]  = {0.,0.,0.,0.};
-  PetscInt        idxm[2]   = {0,1};
-  PetscInt        idxn[2]   = {0,1};
+  PetscReal H_arr[4] = {0., 0., 0., 0.};
+  PetscInt  idxm[2]  = {0, 1};
+  PetscInt  idxn[2]  = {0, 1};
 
-  Vec             *work_vecs = NULL;
-  Vec             *work_sub  = NULL;
-  PetscInt        N_works    = 2;
+  Vec     *work_vecs = NULL;
+  Vec     *work_sub  = NULL;
+  PetscInt N_works   = 2;
 
-  IS              is_p,is_n;
-  PetscInt        N;
+  IS       is_p, is_n;
+  PetscInt N;
 
-  PetscReal       A,B;
+  PetscReal        A, B;
   const PetscReal *params_sigmoid_arr = NULL;
 
   PetscFunctionBegin;
-  PetscCall(VecGetSize(svm_prob->vec_dist,&N));
+  PetscCall(VecGetSize(svm_prob->vec_dist, &N));
 
   if (!svm_prob->work_vecs) {
-    PetscCall(VecDuplicateVecs(svm_prob->vec_dist,N_works,&work_vecs));
+    PetscCall(VecDuplicateVecs(svm_prob->vec_dist, N_works, &work_vecs));
     svm_prob->work_vecs = work_vecs;
   } else {
     work_vecs = svm_prob->work_vecs;
@@ -552,71 +548,72 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec params_sigm
 
   work_sub = svm_prob->work_sub;
 
-  PetscCall(VecSet(work_vecs[0],1.));
-  PetscCall(VecSet(work_vecs[1],0.));
+  PetscCall(VecSet(work_vecs[0], 1.));
+  PetscCall(VecSet(work_vecs[1], 0.));
 
   /* Actual parameters of sigmoid */
-  PetscCall(VecGetArrayRead(params_sigmoid,&params_sigmoid_arr));
-  A = params_sigmoid_arr[0]; B = params_sigmoid_arr[1];
-  PetscCall(VecRestoreArrayRead(params_sigmoid,&params_sigmoid_arr));
+  PetscCall(VecGetArrayRead(params_sigmoid, &params_sigmoid_arr));
+  A = params_sigmoid_arr[0];
+  B = params_sigmoid_arr[1];
+  PetscCall(VecRestoreArrayRead(params_sigmoid, &params_sigmoid_arr));
 
-  PetscCall(VecAXPBY(work_vecs[0],A,B,svm_prob->vec_dist));           /* work[0] <- A * dist + B  (AdpB) */
+  PetscCall(VecAXPBY(work_vecs[0], A, B, svm_prob->vec_dist)); /* work[0] <- A * dist + B  (AdpB) */
 
-  PetscCall(VecWhichGreaterThan(work_vecs[0],work_vecs[1],&is_p));
-  PetscCall(ISComplement(is_p,0,N,&is_n));
+  PetscCall(VecWhichGreaterThan(work_vecs[0], work_vecs[1], &is_p));
+  PetscCall(ISComplement(is_p, 0, N, &is_n));
 
   /*
    CASE: A * dist + B >= 0
    */
 
-  PetscCall(VecGetSubVector(work_vecs[0],is_p,&work_sub[0]));
-  PetscCall(VecGetSubVector(work_vecs[1],is_p,&work_sub[1]));
+  PetscCall(VecGetSubVector(work_vecs[0], is_p, &work_sub[0]));
+  PetscCall(VecGetSubVector(work_vecs[1], is_p, &work_sub[1]));
 
-  PetscCall(VecScale(work_sub[0],-1.));                               /* work[0,is+] <- -1. * AdpB[is+]           */
-  PetscCall(VecExp(work_sub[0]));                                     /* work[0,is+] <- exp(-1. * AdpB[is+])      */
-  PetscCall(VecCopy(work_sub[0],work_sub[1]));                        /* work[1,is+] <- work[0,is+]               */
+  PetscCall(VecScale(work_sub[0], -1.));        /* work[0,is+] <- -1. * AdpB[is+]           */
+  PetscCall(VecExp(work_sub[0]));               /* work[0,is+] <- exp(-1. * AdpB[is+])      */
+  PetscCall(VecCopy(work_sub[0], work_sub[1])); /* work[1,is+] <- work[0,is+]               */
 
-  PetscCall(VecShift(work_sub[1],1.));                                /* work[1,is+] <- 1. + work[1,is+]          */
+  PetscCall(VecShift(work_sub[1], 1.)); /* work[1,is+] <- 1. + work[1,is+]          */
 
-  PetscCall(VecPointwiseDivide(work_sub[0],work_sub[0],work_sub[1])); /* work[0,is+] <- work[0,is+] / work[1,is+] */
-  PetscCall(VecReciprocal(work_sub[1]));                              /* work[1,is+] <- 1. / work[1,is+]          */
+  PetscCall(VecPointwiseDivide(work_sub[0], work_sub[0], work_sub[1])); /* work[0,is+] <- work[0,is+] / work[1,is+] */
+  PetscCall(VecReciprocal(work_sub[1]));                                /* work[1,is+] <- 1. / work[1,is+]          */
 
-  PetscCall(VecRestoreSubVector(work_vecs[1],is_p,&work_sub[1]));
-  PetscCall(VecRestoreSubVector(work_vecs[0],is_p,&work_sub[0]));
+  PetscCall(VecRestoreSubVector(work_vecs[1], is_p, &work_sub[1]));
+  PetscCall(VecRestoreSubVector(work_vecs[0], is_p, &work_sub[0]));
 
   /*
    CASE: A * dist + B < 0
    */
 
-  PetscCall(VecGetSubVector(work_vecs[0],is_n,&work_sub[0]));
-  PetscCall(VecGetSubVector(work_vecs[1],is_n,&work_sub[1]));
+  PetscCall(VecGetSubVector(work_vecs[0], is_n, &work_sub[0]));
+  PetscCall(VecGetSubVector(work_vecs[1], is_n, &work_sub[1]));
 
-  PetscCall(VecExp(work_sub[0]));                                     /* work[0,is-] <- exp(AdpB[is-])           */
-  PetscCall(VecCopy(work_sub[0],work_sub[1]));                        /* work[1,is-] <- work[0,is-]              */
-  PetscCall(VecShift(work_sub[0],1.));                                /* work[0,is-] <- 1. + exp(AdpB[is-])      */
+  PetscCall(VecExp(work_sub[0]));               /* work[0,is-] <- exp(AdpB[is-])           */
+  PetscCall(VecCopy(work_sub[0], work_sub[1])); /* work[1,is-] <- work[0,is-]              */
+  PetscCall(VecShift(work_sub[0], 1.));         /* work[0,is-] <- 1. + exp(AdpB[is-])      */
 
-  PetscCall(VecPointwiseDivide(work_sub[1],work_sub[1],work_sub[0])); /* work[1,is-] <- work[1,is-] / work[0,is-] */
-  PetscCall(VecReciprocal(work_sub[0]));                              /* work[0,is-] <- 1. / work[0,is-]          */
+  PetscCall(VecPointwiseDivide(work_sub[1], work_sub[1], work_sub[0])); /* work[1,is-] <- work[1,is-] / work[0,is-] */
+  PetscCall(VecReciprocal(work_sub[0]));                                /* work[0,is-] <- 1. / work[0,is-]          */
 
-  PetscCall(VecRestoreSubVector(work_vecs[0],is_n,&work_sub[0]));
-  PetscCall(VecRestoreSubVector(work_vecs[1],is_n,&work_sub[1]));
+  PetscCall(VecRestoreSubVector(work_vecs[0], is_n, &work_sub[0]));
+  PetscCall(VecRestoreSubVector(work_vecs[1], is_n, &work_sub[1]));
 
   /* Form Hessian */
-  PetscCall(VecPointwiseMult(work_vecs[0],work_vecs[1],work_vecs[0]));
-  PetscCall(VecPointwiseMult(work_vecs[1],svm_prob->vec_dist,svm_prob->vec_dist));
+  PetscCall(VecPointwiseMult(work_vecs[0], work_vecs[1], work_vecs[0]));
+  PetscCall(VecPointwiseMult(work_vecs[1], svm_prob->vec_dist, svm_prob->vec_dist));
 
-  PetscCall(VecDot(work_vecs[0],work_vecs[1],&H_arr[0]));
-  PetscCall(VecDot(svm_prob->vec_dist,work_vecs[0],&H_arr[1]));
+  PetscCall(VecDot(work_vecs[0], work_vecs[1], &H_arr[0]));
+  PetscCall(VecDot(svm_prob->vec_dist, work_vecs[0], &H_arr[1]));
   H_arr[2] = H_arr[1];
-  PetscCall(VecSum(work_vecs[0],&H_arr[3]));
+  PetscCall(VecSum(work_vecs[0], &H_arr[3]));
 
   H_arr[0] += 1e-12;
   H_arr[3] += 1e-12;
 
   /* Update Hessian */
-  PetscCall(MatSetValues(H,2,idxm,2,idxn,H_arr,INSERT_VALUES));
-  PetscCall(MatAssemblyBegin(H,MAT_FINAL_ASSEMBLY));
-  PetscCall(MatAssemblyEnd(H,MAT_FINAL_ASSEMBLY));
+  PetscCall(MatSetValues(H, 2, idxm, 2, idxn, H_arr, INSERT_VALUES));
+  PetscCall(MatAssemblyBegin(H, MAT_FINAL_ASSEMBLY));
+  PetscCall(MatAssemblyEnd(H, MAT_FINAL_ASSEMBLY));
 
   /* Clean up */
   PetscCall(ISDestroy(&is_p));
@@ -626,54 +623,52 @@ static PetscErrorCode TaoFormHessian_Probability_Private(Tao tao,Vec params_sigm
 
 static PetscErrorCode SVMSetUp_Tao_Private(SVM svm)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
-  Tao             tao;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
+  Tao              tao;
 
-  Mat             H;
-  Vec             g;
-  Vec             x_init;
+  Mat H;
+  Vec g;
+  Vec x_init;
 
-  PetscInt        Nn,Np;
-  PetscReal       v;
+  PetscInt  Nn, Np;
+  PetscReal v;
 
   PetscFunctionBegin;
   /* Create Hessian */
-  PetscCall(MatCreateSeqDense(MPI_COMM_SELF,2,2,NULL,&H));
-  PetscCall(PetscObjectSetName((PetscObject) H,"H_bce"));
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) H,"H_bce_"));
+  PetscCall(MatCreateSeqDense(MPI_COMM_SELF, 2, 2, NULL, &H));
+  PetscCall(PetscObjectSetName((PetscObject)H, "H_bce"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)H, "H_bce_"));
   PetscCall(MatSetFromOptions(H));
 
-  PetscCall(VecCreateSeq(MPI_COMM_SELF,2,&g));
+  PetscCall(VecCreateSeq(MPI_COMM_SELF, 2, &g));
   PetscCall(VecSetFromOptions(g));
 
-  PetscCall(VecCreateSeq(MPI_COMM_SELF,2,&x_init));
+  PetscCall(VecCreateSeq(MPI_COMM_SELF, 2, &x_init));
   PetscCall(VecSetFromOptions(x_init));
 
-  PetscCall(SVMGetTao(svm,&tao));
+  PetscCall(SVMGetTao(svm, &tao));
 
   /* Set initial guess */
   Nn = svm_prob->Nn_calib;
   Np = svm_prob->Np_calib;
 
   /* Set a function for forming and updating gradient and Hessian */
-  PetscCall(TaoSetObjectiveAndGradient(tao,g,TaoFormFunctionGradient_Probability_Private,svm));
-  PetscCall(TaoSetHessian(tao,H,H,TaoFormHessian_Probability_Private,svm));
+  PetscCall(TaoSetObjectiveAndGradient(tao, g, TaoFormFunctionGradient_Probability_Private, svm));
+  PetscCall(TaoSetHessian(tao, H, H, TaoFormHessian_Probability_Private, svm));
 
   /* Set initial guess */
-  PetscCall(VecSetValue(x_init,0,0.,INSERT_VALUES));
+  PetscCall(VecSetValue(x_init, 0, 0., INSERT_VALUES));
   v = PetscLogReal((Nn + 1.) / (Np + 1.));
-  PetscCall(VecSetValue(x_init,1,v,INSERT_VALUES));
+  PetscCall(VecSetValue(x_init, 1, v, INSERT_VALUES));
 
   PetscCall(VecAssemblyBegin(x_init));
   PetscCall(VecAssemblyEnd(x_init));
-  PetscCall(TaoSetSolution(tao,x_init));
+  PetscCall(TaoSetSolution(tao, x_init));
 
-  PetscCall(TaoSetTolerances(tao,1e-5,1e-5,1e-5));
+  PetscCall(TaoSetTolerances(tao, 1e-5, 1e-5, 1e-5));
 
   /* Set tao solver from cli options */
-  if (svm->setfromoptionscalled) {
-    PetscCall(TaoSetFromOptions(tao));
-  }
+  if (svm->setfromoptionscalled) { PetscCall(TaoSetFromOptions(tao)); }
 
   /* Clean up */
   PetscCall(TaoDestroy(&tao));
@@ -690,110 +685,94 @@ PetscErrorCode SVMSetUp_Probability(SVM svm)
   MPI_Comm    comm;
   PetscMPIInt rank;
 
-  SVM         svm_uncalibrated;
+  SVM svm_uncalibrated;
 
-  Mat         Xt_training;
-  Vec         y_training;
+  Mat Xt_training;
+  Vec y_training;
 
-  Mat         Xt_calib;
-  Vec         y_calib;
+  Mat Xt_calib;
+  Vec y_calib;
 
-  Mat         Xt_test;
-  Vec         y_test;
+  Mat Xt_test;
+  Vec y_test;
 
   PetscFunctionBegin;
   if (svm->setupcalled) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
-  if (svm->setfromoptionscalled) {
-    PetscCall(SVMSetFromOptions(svm_uncalibrated));
-  }
+  PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
+  if (svm->setfromoptionscalled) { PetscCall(SVMSetFromOptions(svm_uncalibrated)); }
 
-  PetscCall(SVMGetCalibrationDataset(svm,&Xt_calib,&y_calib));
+  PetscCall(SVMGetCalibrationDataset(svm, &Xt_calib, &y_calib));
   if (Xt_calib != NULL) {
-    PetscCall(SVMGetTrainingDataset(svm,&Xt_training,&y_training));
+    PetscCall(SVMGetTrainingDataset(svm, &Xt_training, &y_training));
   } else {
     Xt_training = Xt_calib;
     y_training  = y_calib;
   }
 
-  PetscCall(SVMSetTrainingDataset(svm_uncalibrated,Xt_training,y_training));
+  PetscCall(SVMSetTrainingDataset(svm_uncalibrated, Xt_training, y_training));
 
-  PetscCall(SVMGetTestDataset(svm,&Xt_test,&y_test));
-  if (Xt_test && y_test) {
-    PetscCall(SVMSetTestDataset(svm_uncalibrated,Xt_test,y_test));
-  }
+  PetscCall(SVMGetTestDataset(svm, &Xt_test, &y_test));
+  if (Xt_test && y_test) { PetscCall(SVMSetTestDataset(svm_uncalibrated, Xt_test, y_test)); }
 
   PetscCall(SVMSetUp(svm_uncalibrated));
 
   /* Set up TAO solver. Since problem is small (dim=2), it is being solved on a root process. */
-  PetscCall(PetscObjectGetComm((PetscObject)svm,&comm));
-  PetscCallMPI(MPI_Comm_rank(comm,&rank));
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+  PetscCallMPI(MPI_Comm_rank(comm, &rank));
 
-  if (rank == 0) {
-    PetscCall(SVMSetUp_Tao_Private(svm));
-  }
+  if (rank == 0) { PetscCall(SVMSetUp_Tao_Private(svm)); }
 
   /* Clean up */
   PetscCall(SVMDestroy(&svm_uncalibrated));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMSetOptionsPrefix_Probability(SVM svm,const char prefix[])
+PetscErrorCode SVMSetOptionsPrefix_Probability(SVM svm, const char prefix[])
 {
   SVM inner;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) svm,prefix));
-  PetscCall(SVMGetInnerSVM(svm,&inner));
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) inner,prefix));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)svm, prefix));
+  PetscCall(SVMGetInnerSVM(svm, &inner));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)inner, prefix));
   PetscCall(SVMDestroy(&inner));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMAppendOptionsPrefix_Probability(SVM svm,const char prefix[])
+PetscErrorCode SVMAppendOptionsPrefix_Probability(SVM svm, const char prefix[])
 {
   SVM inner;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject) svm,prefix));
-  PetscCall(SVMGetInnerSVM(svm,&inner));
-  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject) inner,prefix));
+  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject)svm, prefix));
+  PetscCall(SVMGetInnerSVM(svm, &inner));
+  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject)inner, prefix));
   PetscCall(SVMDestroy(&inner));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetOptionsPrefix_Probability(SVM svm,const char *prefix[])
+PetscErrorCode SVMGetOptionsPrefix_Probability(SVM svm, const char *prefix[])
 {
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetOptionsPrefix((PetscObject) svm,prefix));
+  PetscCall(PetscObjectGetOptionsPrefix((PetscObject)svm, prefix));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMSetFromOptions_Probability(PetscOptionItems *PetscOptionsObject,SVM svm)
+PetscErrorCode SVMSetFromOptions_Probability(PetscOptionItems *PetscOptionsObject, SVM svm)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
-  PetscBool       to_target_probs;
-  PetscReal       threshold;
-  PetscBool       flg;
+  PetscBool to_target_probs;
+  PetscReal threshold;
+  PetscBool flg;
 
   PetscFunctionBegin;
   PetscObjectOptionsBegin((PetscObject)svm);
-  PetscCall(PetscOptionsBool("-svm_convert_labels_to_target_probs",
-                             "Convert sample labels to target probability as suggested by Platt. Default (true).",
-                             "SVMProbabilitySetConvertLabelsToTargetProbability",
-                             svm_prob->labels_to_target_probs,&to_target_probs,&flg));
-  if (flg) {
-    PetscCall(SVMProbabilitySetConvertLabelsToTargetProbability(svm,to_target_probs));
-  }
-  PetscCall(PetscOptionsReal("-svm_threshold",
-                             "Convert sample labels to target probability as suggested by Platt. Default (true).",
-                             "SVMProbSetConvertLabelsToTargetProbability",
-                             svm_prob->threshold,&threshold,&flg));
-  if (flg) {
-    PetscCall(SVMProbabilitySetThreshold(svm,threshold));
-  }
+  PetscCall(PetscOptionsBool("-svm_convert_labels_to_target_probs", "Convert sample labels to target probability as suggested by Platt. Default (true).", "SVMProbabilitySetConvertLabelsToTargetProbability", svm_prob->labels_to_target_probs, &to_target_probs, &flg));
+  if (flg) { PetscCall(SVMProbabilitySetConvertLabelsToTargetProbability(svm, to_target_probs)); }
+  PetscCall(PetscOptionsReal("-svm_threshold", "Convert sample labels to target probability as suggested by Platt. Default (true).", "SVMProbSetConvertLabelsToTargetProbability", svm_prob->threshold, &threshold, &flg));
+  if (flg) { PetscCall(SVMProbabilitySetThreshold(svm, threshold)); }
   PetscOptionsEnd();
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -803,35 +782,31 @@ PetscErrorCode SVMTrain_Probability(SVM svm)
   MPI_Comm    comm;
   PetscMPIInt rank;
 
-  SVM         svm_uncalibrated;
-  Tao         tao;
+  SVM svm_uncalibrated;
+  Tao tao;
 
-  PetscBool   post_train;
+  PetscBool post_train;
 
   PetscFunctionBegin;
   PetscCall(SVMSetUp(svm));
-  PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
+  PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
 
   /* Train uncalibrated svm model */
-  PetscCall(SVMGetAutoPostTrain(svm_uncalibrated,&post_train));
+  PetscCall(SVMGetAutoPostTrain(svm_uncalibrated, &post_train));
   PetscCall(SVMTrain(svm_uncalibrated));
 
   /* Train logistic regression over uncalibrated model (known as Platt's scaling) */
   PetscCall(SVMTransformUncalibratedPredictions_Probability_Private(svm));
-  PetscCall(SVMGetTao(svm,&tao));
+  PetscCall(SVMGetTao(svm, &tao));
 
   /* Solve underlying unconstrained problem on root */
-  PetscCall(PetscObjectGetComm((PetscObject)svm,&comm));
-  PetscCallMPI(MPI_Comm_rank(comm,&rank));
-  if (rank == 0) {
-    PetscCall(TaoSolve(tao));
-  }
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+  PetscCallMPI(MPI_Comm_rank(comm, &rank));
+  if (rank == 0) { PetscCall(TaoSolve(tao)); }
 
   /* Run post-processing (training) of a trained probability model */
-  PetscCall(SVMGetAutoPostTrain(svm,&post_train));
-  if (post_train) {
-    PetscCall(SVMPostTrain(svm));
-  }
+  PetscCall(SVMGetAutoPostTrain(svm, &post_train));
+  if (post_train) { PetscCall(SVMPostTrain(svm)); }
 
   /* Clean up */
   PetscCall(SVMDestroy(&svm_uncalibrated));
@@ -841,73 +816,71 @@ PetscErrorCode SVMTrain_Probability(SVM svm)
 
 PetscErrorCode SVMPostTrain_Probability(SVM svm)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
-  MPI_Comm        comm;
-  PetscMPIInt     rank;
+  MPI_Comm    comm;
+  PetscMPIInt rank;
 
-  Tao             tao;
-  Vec             x;
+  Tao              tao;
+  Vec              x;
   const PetscReal *x_arr = NULL;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject)svm,&comm));
-  PetscCallMPI(MPI_Comm_rank(comm,&rank));
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+  PetscCallMPI(MPI_Comm_rank(comm, &rank));
 
   if (rank == 0) {
-    PetscCall(SVMGetTao(svm,&tao));
-    PetscCall(TaoGetSolution(tao,&x));
+    PetscCall(SVMGetTao(svm, &tao));
+    PetscCall(TaoGetSolution(tao, &x));
 
-    PetscCall(VecGetArrayRead(x,&x_arr));
-    PetscCall(PetscMemcpy(svm_prob->sigmoid_params,x_arr,2 * sizeof(PetscReal)));
-    PetscCall(VecRestoreArrayRead(x,&x_arr));
+    PetscCall(VecGetArrayRead(x, &x_arr));
+    PetscCall(PetscMemcpy(svm_prob->sigmoid_params, x_arr, 2 * sizeof(PetscReal)));
+    PetscCall(VecRestoreArrayRead(x, &x_arr));
     /* Clean up */
     PetscCall(TaoDestroy(&tao));
   }
 
   /* Broadcast solution */
-  PetscCallMPI(MPI_Bcast(svm_prob->sigmoid_params,2,MPIU_REAL,0,comm));
+  PetscCallMPI(MPI_Bcast(svm_prob->sigmoid_params, 2, MPIU_REAL, 0, comm));
 
   /* Clean up */
   svm->posttraincalled = PETSC_TRUE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMPredict_Probability(SVM svm,Mat Xt,Vec *y_out)
+PetscErrorCode SVMPredict_Probability(SVM svm, Mat Xt, Vec *y_out)
 {
-  SVM       svm_uncalibrated;
+  SVM svm_uncalibrated;
 
-  Vec       pred;
+  Vec pred;
 
-  PetscInt  N_work_vec = 2;
-  Vec       *work_vecs = NULL;
-  Vec       work_sub[N_work_vec];
+  PetscInt N_work_vec = 2;
+  Vec     *work_vecs  = NULL;
+  Vec      work_sub[N_work_vec];
 
-  IS        is_p,is_n;
-  PetscInt  lo,hi;
+  IS       is_p, is_n;
+  PetscInt lo, hi;
 
-  PetscReal A,B;
+  PetscReal A, B;
 
   PetscFunctionBegin;
-  if (!svm->posttraincalled) {
-    PetscCall(SVMPostTrain(svm));
-  }
+  if (!svm->posttraincalled) { PetscCall(SVMPostTrain(svm)); }
 
-  PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
+  PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
 
-  PetscCall(SVMGetDistancesFromHyperplane(svm_uncalibrated,Xt,&pred));  /* Get distances from hyperplane */
-  PetscCall(SVMProbabilityGetSigmoidParams(svm,&A,&B));
+  PetscCall(SVMGetDistancesFromHyperplane(svm_uncalibrated, Xt, &pred)); /* Get distances from hyperplane */
+  PetscCall(SVMProbabilityGetSigmoidParams(svm, &A, &B));
 
   /* Create working vectors */
-  PetscCall(VecDuplicateVecs(pred,N_work_vec,&work_vecs));
-  PetscCall(VecSet(work_vecs[0],1.));
-  PetscCall(VecSet(work_vecs[1],0.));
+  PetscCall(VecDuplicateVecs(pred, N_work_vec, &work_vecs));
+  PetscCall(VecSet(work_vecs[0], 1.));
+  PetscCall(VecSet(work_vecs[1], 0.));
 
-  PetscCall(VecAXPBY(pred,B,A,work_vecs[0])); /* pred <- A * dist + B (AdpB) */
+  PetscCall(VecAXPBY(pred, B, A, work_vecs[0])); /* pred <- A * dist + B (AdpB) */
 
-  PetscCall(VecWhichGreaterThan(pred,work_vecs[1],&is_p));
-  PetscCall(VecGetOwnershipRange(pred,&lo,&hi));
-  PetscCall(ISComplement(is_p,lo,hi,&is_n));
+  PetscCall(VecWhichGreaterThan(pred, work_vecs[1], &is_p));
+  PetscCall(VecGetOwnershipRange(pred, &lo, &hi));
+  PetscCall(ISComplement(is_p, lo, hi, &is_n));
 
   /*
     Compute posterior probability
@@ -916,44 +889,44 @@ PetscErrorCode SVMPredict_Probability(SVM svm,Mat Xt,Vec *y_out)
   /*
     CASE: A * dist + B >= 0
    */
-  PetscCall(VecGetSubVector(pred        ,is_p,&work_sub[0]));
-  PetscCall(VecGetSubVector(work_vecs[0],is_p,&work_sub[1]));
+  PetscCall(VecGetSubVector(pred, is_p, &work_sub[0]));
+  PetscCall(VecGetSubVector(work_vecs[0], is_p, &work_sub[1]));
 
-  PetscCall(VecScale(work_sub[0],-1.));
+  PetscCall(VecScale(work_sub[0], -1.));
   PetscCall(VecExp(work_sub[0]));
-  PetscCall(VecAXPY(work_sub[1],1.,work_sub[0]));
-  PetscCall(VecPointwiseDivide(work_sub[0],work_sub[0],work_sub[1]));
+  PetscCall(VecAXPY(work_sub[1], 1., work_sub[0]));
+  PetscCall(VecPointwiseDivide(work_sub[0], work_sub[0], work_sub[1]));
 
-  PetscCall(VecRestoreSubVector(pred        ,is_p,&work_sub[0]));
-  PetscCall(VecRestoreSubVector(work_vecs[0],is_p,&work_sub[1]));
+  PetscCall(VecRestoreSubVector(pred, is_p, &work_sub[0]));
+  PetscCall(VecRestoreSubVector(work_vecs[0], is_p, &work_sub[1]));
 
   /*
     CASE: A * dist + B < 0
    */
-  PetscCall(VecGetSubVector(pred,is_n,&work_sub[0]));
+  PetscCall(VecGetSubVector(pred, is_n, &work_sub[0]));
 
   PetscCall(VecExp(work_sub[0]));
-  PetscCall(VecShift(work_sub[0],1.));
+  PetscCall(VecShift(work_sub[0], 1.));
   PetscCall(VecReciprocal(work_sub[0]));
 
-  PetscCall(VecRestoreSubVector(pred,is_n,&work_sub[0]));
+  PetscCall(VecRestoreSubVector(pred, is_n, &work_sub[0]));
 
   *y_out = pred;
 
   /* Clean up */
   PetscCall(ISDestroy(&is_n));
   PetscCall(ISDestroy(&is_p));
-  PetscCall(VecDestroyVecs(N_work_vec,&work_vecs));
+  PetscCall(VecDestroyVecs(N_work_vec, &work_vecs));
   PetscCall(SVMDestroy(&svm_uncalibrated));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMComputeModelScores_Probability(SVM svm,Vec y,Vec y_known)
+PetscErrorCode SVMComputeModelScores_Probability(SVM svm, Vec y, Vec y_known)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetBinaryClassificationReport(svm,y,y_known,svm_prob->confusion_matrix,svm_prob->model_scores));
+  PetscCall(SVMGetBinaryClassificationReport(svm, y, y_known, svm_prob->confusion_matrix, svm_prob->model_scores));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -968,15 +941,15 @@ PetscErrorCode SVMTest_Probability(SVM svm)
   Vec y_pred_prob;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTestDataset(svm,&Xt_test,&y_test));
+  PetscCall(SVMGetTestDataset(svm, &Xt_test, &y_test));
 
-  PetscCall(SVMGetInnerSVM(svm,&svm_uncalibrated));
-  PetscCall(SVMPredict(svm_uncalibrated,Xt_test,&y_pred_label));
-  PetscCall(SVMComputeModelScores(svm_uncalibrated,y_pred_label,y_test));
+  PetscCall(SVMGetInnerSVM(svm, &svm_uncalibrated));
+  PetscCall(SVMPredict(svm_uncalibrated, Xt_test, &y_pred_label));
+  PetscCall(SVMComputeModelScores(svm_uncalibrated, y_pred_label, y_test));
 
-  PetscCall(SVMPredict(svm,Xt_test,&y_pred_prob));
-  PetscCall(SVMProbabilityConvertProbabilityToLabels(svm,y_pred_prob));
-  PetscCall(SVMComputeModelScores(svm,y_pred_prob,y_test));
+  PetscCall(SVMPredict(svm, Xt_test, &y_pred_prob));
+  PetscCall(SVMProbabilityConvertProbabilityToLabels(svm, y_pred_prob));
+  PetscCall(SVMComputeModelScores(svm, y_pred_prob, y_test));
 
   /* Clean up */
   PetscCall(SVMDestroy(&svm_uncalibrated));
@@ -985,66 +958,66 @@ PetscErrorCode SVMTest_Probability(SVM svm)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetInnerSVM_Probability(SVM svm,SVM *inner_out)
+PetscErrorCode SVMGetInnerSVM_Probability(SVM svm, SVM *inner_out)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
-  MPI_Comm        comm;
-  SVM             inner;
+  MPI_Comm comm;
+  SVM      inner;
 
-  const char      *prefix = NULL;
+  const char *prefix = NULL;
 
   PetscFunctionBegin;
   if (!svm_prob->inner) {
-    PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
-    PetscCall(SVMCreate(comm,&inner));
-    PetscCall(SVMSetType(inner,SVM_BINARY));
+    PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+    PetscCall(SVMCreate(comm, &inner));
+    PetscCall(SVMSetType(inner, SVM_BINARY));
 
-    PetscCall(SVMSetOptionsPrefix(inner,"uncalibrated_"));
-    PetscCall(SVMGetOptionsPrefix(svm,&prefix));
-    PetscCall(SVMAppendOptionsPrefix(inner,prefix));
+    PetscCall(SVMSetOptionsPrefix(inner, "uncalibrated_"));
+    PetscCall(SVMGetOptionsPrefix(svm, &prefix));
+    PetscCall(SVMAppendOptionsPrefix(inner, prefix));
 
     svm_prob->inner = inner;
   }
 
-  PetscCall(PetscObjectReference((PetscObject) svm_prob->inner));
+  PetscCall(PetscObjectReference((PetscObject)svm_prob->inner));
   *inner_out = svm_prob->inner;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMLoadCalibrationDataset_Probability(SVM svm,PetscViewer v)
+PetscErrorCode SVMLoadCalibrationDataset_Probability(SVM svm, PetscViewer v)
 {
-  MPI_Comm  comm;
+  MPI_Comm comm;
 
-  Mat       Xt_calib,Xt_biased;
-  Vec       y_calib;
+  Mat Xt_calib, Xt_biased;
+  Vec y_calib;
 
   PetscReal user_bias;
   PetscInt  mod;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
-  PetscCall(MatCreate(comm,&Xt_calib));
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+  PetscCall(MatCreate(comm, &Xt_calib));
   /* Create matrix of calibration samples */
-  PetscCall(PetscObjectSetName((PetscObject) Xt_calib,"Xt_calib"));
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) Xt_calib,"Xt_calib_"));
+  PetscCall(PetscObjectSetName((PetscObject)Xt_calib, "Xt_calib"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)Xt_calib, "Xt_calib_"));
   PetscCall(MatSetFromOptions(Xt_calib));
   /* Create label vector of calibration samples */
-  PetscCall(VecCreate(comm,&y_calib));
-  PetscCall(PetscObjectSetName((PetscObject) y_calib,"Xt_calib_"));
+  PetscCall(VecCreate(comm, &y_calib));
+  PetscCall(PetscObjectSetName((PetscObject)y_calib, "Xt_calib_"));
   PetscCall(VecSetFromOptions(y_calib));
 
-  PetscCall(PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0));
-  PetscCall(PetscViewerLoadSVMDataset(Xt_calib,y_calib,v));
-  PetscCall(PetscLogEventEnd(SVM_LoadDataset,svm,0,0,0));
+  PetscCall(PetscLogEventBegin(SVM_LoadDataset, svm, 0, 0, 0));
+  PetscCall(PetscViewerLoadSVMDataset(Xt_calib, y_calib, v));
+  PetscCall(PetscLogEventEnd(SVM_LoadDataset, svm, 0, 0, 0));
 
-  PetscCall(SVMGetMod(svm,&mod));
+  PetscCall(SVMGetMod(svm, &mod));
   if (mod == 2) {
-    PetscCall(SVMGetUserBias(svm,&user_bias));
-    PetscCall(MatBiasedCreate(Xt_calib,user_bias,&Xt_biased));
+    PetscCall(SVMGetUserBias(svm, &user_bias));
+    PetscCall(MatBiasedCreate(Xt_calib, user_bias, &Xt_biased));
     Xt_calib = Xt_biased;
   }
-  PetscCall(SVMSetCalibrationDataset(svm,Xt_calib,y_calib));
+  PetscCall(SVMSetCalibrationDataset(svm, Xt_calib, y_calib));
 
   /* Clean up */
   PetscCall(MatDestroy(&Xt_calib));
@@ -1052,65 +1025,65 @@ PetscErrorCode SVMLoadCalibrationDataset_Probability(SVM svm,PetscViewer v)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMViewCalibrationDataset_Probability(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewCalibrationDataset_Probability(SVM svm, PetscViewer v)
 {
-  Mat        Xt;
-  Vec        y;
+  Mat Xt;
+  Vec y;
 
-  PetscBool  isascii;
+  PetscBool   isascii;
   const char *type_name = NULL;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetCalibrationDataset(svm,&Xt,&y));
-  PetscCheck(Xt && y,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Calibration dataset is not set");
+  PetscCall(SVMGetCalibrationDataset(svm, &Xt, &y));
+  PetscCheck(Xt && y, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Calibration dataset is not set");
 
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
     /* Print info related to svm type */
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
 
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(SVMViewDataset(svm,Xt,y,v));
+    PetscCall(SVMViewDataset(svm, Xt, y, v));
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
-    SETERRQ(PetscObjectComm((PetscObject) v),PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewCalibrationDataset",type_name);
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
+    SETERRQ(PetscObjectComm((PetscObject)v), PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewCalibrationDataset", type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMViewTrainingPredictions_Probability(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTrainingPredictions_Probability(SVM svm, PetscViewer v)
 {
-  Mat        Xt_training;
-  Vec        y_pred;
+  Mat Xt_training;
+  Vec y_pred;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTrainingDataset(svm,&Xt_training,NULL));
-  PetscCheck(Xt_training,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Training dataset is not set");
+  PetscCall(SVMGetTrainingDataset(svm, &Xt_training, NULL));
+  PetscCheck(Xt_training, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Training dataset is not set");
 
   /* View predictions on training samples */
-  PetscCall(SVMPredict(svm,Xt_training,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
-  PetscCall(VecView(y_pred,v));
+  PetscCall(SVMPredict(svm, Xt_training, &y_pred));
+  PetscCall(PetscObjectSetName((PetscObject)y_pred, "y_predictions"));
+  PetscCall(VecView(y_pred, v));
 
   /* Free memory */
   PetscCall(VecDestroy(&y_pred));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMViewTestPredictions_Probability(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTestPredictions_Probability(SVM svm, PetscViewer v)
 {
-  Mat        Xt_test;
-  Vec        y_pred;
+  Mat Xt_test;
+  Vec y_pred;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTestDataset(svm,&Xt_test,NULL));
-  PetscCheck(Xt_test,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Test dataset is not set");
+  PetscCall(SVMGetTestDataset(svm, &Xt_test, NULL));
+  PetscCheck(Xt_test, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Test dataset is not set");
 
   /* View predictions on test samples */
-  PetscCall(SVMPredict(svm,Xt_test,&y_pred));
-  PetscCall(PetscObjectSetName((PetscObject) y_pred,"y_predictions"));
-  PetscCall(VecView(y_pred,v));
+  PetscCall(SVMPredict(svm, Xt_test, &y_pred));
+  PetscCall(PetscObjectSetName((PetscObject)y_pred, "y_predictions"));
+  PetscCall(VecView(y_pred, v));
 
   /* Free memory */
   PetscCall(VecDestroy(&y_pred));
@@ -1123,11 +1096,11 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
 
   PetscFunctionBegin;
   PetscCall(PetscNew(&svm_prob));
-  svm->data = (void *) svm_prob;
+  svm->data = (void *)svm_prob;
 
-  svm_prob->inner       = NULL;
-  svm_prob->tao         = NULL;
-  svm_prob->work_vecs   = NULL;
+  svm_prob->inner     = NULL;
+  svm_prob->tao       = NULL;
+  svm_prob->work_vecs = NULL;
 
   svm_prob->Xt_training = NULL;
   svm_prob->y_training  = NULL;
@@ -1137,11 +1110,11 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
   svm_prob->vec_dist    = NULL;
   svm_prob->vec_targets = NULL;
 
-  svm_prob->Np_calib    = -1;
-  svm_prob->Nn_calib    = -1;
+  svm_prob->Np_calib               = -1;
+  svm_prob->Nn_calib               = -1;
   svm_prob->labels_to_target_probs = PETSC_TRUE;
 
-  svm_prob->threshold   = .5;
+  svm_prob->threshold = .5;
 
   svm->ops->setup                   = SVMSetUp_Probability;
   svm->ops->reset                   = SVMReset_Probability;
@@ -1157,75 +1130,73 @@ PetscErrorCode SVMCreate_Probability(SVM svm)
   svm->ops->viewtrainingpredictions = SVMViewTrainingPredictions_Probability;
   svm->ops->viewtestpredictions     = SVMViewTestPredictions_Probability;
 
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetInnerSVM_C"           ,SVMGetInnerSVM_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTao_C"                ,SVMGetTao_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetTrainingDataset_C"    ,SVMSetTrainingDataset_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetTrainingDataset_C"    ,SVMGetTrainingDataset_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetCalibrationDataset_C" ,SVMSetCalibrationDataset_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetCalibrationDataset_C" ,SVMGetCalibrationDataset_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetLabels_C"             ,SVMGetLabels_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMLoadCalibrationDataset_C",SVMLoadCalibrationDataset_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMViewCalibrationDataset_C",SVMViewCalibrationDataset_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMSetOptionsPrefix_C"      ,SVMSetOptionsPrefix_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMGetOptionsPrefix_C"      ,SVMGetOptionsPrefix_Probability));
-  PetscCall(PetscObjectComposeFunction((PetscObject) svm,"SVMAppendOptionsPrefix_C"   ,SVMAppendOptionsPrefix_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetInnerSVM_C", SVMGetInnerSVM_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetTao_C", SVMGetTao_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetTrainingDataset_C", SVMSetTrainingDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetTrainingDataset_C", SVMGetTrainingDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetCalibrationDataset_C", SVMSetCalibrationDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetCalibrationDataset_C", SVMGetCalibrationDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetLabels_C", SVMGetLabels_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMLoadCalibrationDataset_C", SVMLoadCalibrationDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMViewCalibrationDataset_C", SVMViewCalibrationDataset_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMSetOptionsPrefix_C", SVMSetOptionsPrefix_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMGetOptionsPrefix_C", SVMGetOptionsPrefix_Probability));
+  PetscCall(PetscObjectComposeFunction((PetscObject)svm, "SVMAppendOptionsPrefix_C", SVMAppendOptionsPrefix_Probability));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMProbabilitySetConvertLabelsToTargetProbability(SVM svm,PetscBool flg)
+PetscErrorCode SVMProbabilitySetConvertLabelsToTargetProbability(SVM svm, PetscBool flg)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (svm_prob->labels_to_target_probs == flg) {
-    PetscFunctionReturn(PETSC_SUCCESS);
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (svm_prob->labels_to_target_probs == flg) { PetscFunctionReturn(PETSC_SUCCESS); }
   svm_prob->labels_to_target_probs = flg;
-  svm->setupcalled = PETSC_FALSE;
+  svm->setupcalled                 = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMProbabilityGetConvertLabelsToTargetProbability(SVM svm,PetscBool *flg)
+PetscErrorCode SVMProbabilityGetConvertLabelsToTargetProbability(SVM svm, PetscBool *flg)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   *flg = svm_prob->labels_to_target_probs;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM svm,Vec y)
+PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM svm, Vec y)
 {
-  Vec            vec_threshold;
-  PetscReal      threshold;
+  Vec       vec_threshold;
+  PetscReal threshold;
 
-  Vec             y_sub;
+  Vec y_sub;
 
-  IS              is_p,is_n;
-  PetscInt        lo,hi;
+  IS       is_p, is_n;
+  PetscInt lo, hi;
 
   const PetscReal *labels = NULL;
 
   PetscFunctionBegin;
-  PetscCall(SVMProbabilityGetThreshold(svm,&threshold));
-  PetscCall(SVMGetLabels(svm,&labels));
+  PetscCall(SVMProbabilityGetThreshold(svm, &threshold));
+  PetscCall(SVMGetLabels(svm, &labels));
 
-  PetscCall(VecDuplicate(y,&vec_threshold));
-  PetscCall(VecSet(vec_threshold,threshold));
+  PetscCall(VecDuplicate(y, &vec_threshold));
+  PetscCall(VecSet(vec_threshold, threshold));
 
-  PetscCall(VecWhichGreaterThan(y,vec_threshold,&is_p));
-  PetscCall(VecGetOwnershipRange(y,&lo,&hi));
-  PetscCall(ISComplement(is_p,lo,hi,&is_n));
+  PetscCall(VecWhichGreaterThan(y, vec_threshold, &is_p));
+  PetscCall(VecGetOwnershipRange(y, &lo, &hi));
+  PetscCall(ISComplement(is_p, lo, hi, &is_n));
 
-  PetscCall(VecGetSubVector(y,is_n,&y_sub));
-  PetscCall(VecSet(y_sub,labels[0]));
-  PetscCall(VecRestoreSubVector(y,is_n,&y_sub));
+  PetscCall(VecGetSubVector(y, is_n, &y_sub));
+  PetscCall(VecSet(y_sub, labels[0]));
+  PetscCall(VecRestoreSubVector(y, is_n, &y_sub));
 
-  PetscCall(VecGetSubVector(y,is_p,&y_sub));
-  PetscCall(VecSet(y_sub,labels[1]));
-  PetscCall(VecRestoreSubVector(y,is_p,&y_sub));
+  PetscCall(VecGetSubVector(y, is_p, &y_sub));
+  PetscCall(VecSet(y_sub, labels[1]));
+  PetscCall(VecRestoreSubVector(y, is_p, &y_sub));
 
   /* Clean up */
   PetscCall(ISDestroy(&is_p));
@@ -1234,40 +1205,40 @@ PetscErrorCode SVMProbabilityConvertProbabilityToLabels(SVM svm,Vec y)
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMProbabilityGetSigmoidParams(SVM svm,PetscReal *A,PetscReal *B)
+PetscErrorCode SVMProbabilityGetSigmoidParams(SVM svm, PetscReal *A, PetscReal *B)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
   if (A) {
-    PetscAssertPointer(A,1);
+    PetscAssertPointer(A, 1);
     *A = svm_prob->sigmoid_params[0];
   }
   if (B) {
-    PetscAssertPointer(B,2);
+    PetscAssertPointer(B, 2);
     *B = svm_prob->sigmoid_params[1];
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMProbabilitySetThreshold(SVM svm,PetscReal threshold)
+PetscErrorCode SVMProbabilitySetThreshold(SVM svm, PetscReal threshold)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,threshold,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, threshold, 2);
   svm_prob->threshold = threshold;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMProbabilityGetThreshold(SVM svm,PetscReal *threshold)
+PetscErrorCode SVMProbabilityGetThreshold(SVM svm, PetscReal *threshold)
 {
-  SVM_Probability *svm_prob = (SVM_Probability *) svm->data;
+  SVM_Probability *svm_prob = (SVM_Probability *)svm->data;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(threshold,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(threshold, 2);
   *threshold = svm_prob->threshold;
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -3,26 +3,26 @@
 #include <permon/private/svmimpl.h>
 
 typedef struct {
-  Mat       Xt_training;
-  Vec       y_training;
+  Mat Xt_training;
+  Vec y_training;
 
-  Mat       Xt_calib;
-  Vec       y_calib;
+  Mat Xt_calib;
+  Vec y_calib;
 
-  PetscInt  Np_calib;
-  PetscInt  Nn_calib;
+  PetscInt Np_calib;
+  PetscInt Nn_calib;
 
-  SVM       inner;
+  SVM inner;
 
-  Vec       vec_dist;
-  Vec       vec_targets;
+  Vec vec_dist;
+  Vec vec_targets;
 
   PetscBool labels_to_target_probs;
 
-  Tao       tao;
+  Tao tao;
 
-  Vec       *work_vecs;
-  Vec       work_sub[2];
+  Vec *work_vecs;
+  Vec  work_sub[2];
 
   PetscReal sigmoid_params[2];
   PetscReal threshold;

--- a/src/svm/impls/probability/probimpl.h
+++ b/src/svm/impls/probability/probimpl.h
@@ -1,6 +1,4 @@
-
-#if !defined(__PROBIMPL_H)
-#define	__PROBIMPL_H
+#pragma once
 
 #include <permon/private/svmimpl.h>
 
@@ -33,5 +31,3 @@ typedef struct {
   PetscReal model_scores[16];
 
 } SVM_Probability;
-
-#endif

--- a/src/svm/interface/dlregissvm.c
+++ b/src/svm/interface/dlregissvm.c
@@ -1,4 +1,3 @@
-
 #include <permon/private/svmimpl.h>
 
 static PetscBool SVMPackageInitialized = PETSC_FALSE;

--- a/src/svm/interface/dlregissvm.c
+++ b/src/svm/interface/dlregissvm.c
@@ -6,18 +6,17 @@ static PetscBool SVMPackageInitialized = PETSC_FALSE;
 #define __FUNCT__ "SVMInitializePackage"
 PetscErrorCode SVMInitializePackage()
 {
-
   PetscFunctionBegin;
   if (SVMPackageInitialized) PetscFunctionReturn(PETSC_SUCCESS);
   SVMPackageInitialized = PETSC_TRUE;
 
   /* Register Classes */
-  PetscCall(PetscClassIdRegister("SVM",&SVM_CLASSID));
+  PetscCall(PetscClassIdRegister("SVM", &SVM_CLASSID));
   /* Register constructors */
   PetscCall(SVMRegisterAll());
   /* Register Events */
-  PetscCall(PetscLogEventRegister("SVMLoadDataset",SVM_CLASSID,&SVM_LoadDataset));
-  PetscCall(PetscLogEventRegister("SVMLoadGramian",SVM_CLASSID,&SVM_LoadGramian));
+  PetscCall(PetscLogEventRegister("SVMLoadDataset", SVM_CLASSID, &SVM_LoadDataset));
+  PetscCall(PetscLogEventRegister("SVMLoadGramian", SVM_CLASSID, &SVM_LoadGramian));
 
   PetscCall(PetscRegisterFinalize(SVMFinalizePackage));
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -27,13 +26,10 @@ PetscErrorCode SVMInitializePackage()
 #define __FUNCT__ "SVMFinalizePackage"
 PetscErrorCode SVMFinalizePackage()
 {
-
   PetscFunctionBegin;
-  if (SVMPackageInitialized) {
-    PetscCall(PetscFunctionListDestroy(&SVMList));
-  }
+  if (SVMPackageInitialized) { PetscCall(PetscFunctionListDestroy(&SVMList)); }
 
   SVMPackageInitialized = PETSC_FALSE;
-  SVMRegisterAllCalled = PETSC_FALSE;
+  SVMRegisterAllCalled  = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/interface/makefile
+++ b/src/svm/interface/makefile
@@ -3,8 +3,8 @@ ALL: lib
 CFLAGS   =
 FFLAGS   =
 SOURCEC  = dlregissvm.c svmregis.c svm.c
-SOURCEF  = 
-SOURCEH  = 
+SOURCEF  =
+SOURCEH  =
 OBJSC    = ${SOURCEC:.c=.o}
 LIBBASE  = libpermon
 DIRS     =

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -1906,7 +1906,6 @@ PetscErrorCode SVMGetLabels(SVM svm,const PetscReal *labels[])
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-
 #undef __FUNCT__
 #define __FUNCT__ "SVMSetAutoPostTrain"
 /*@

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -1,4 +1,3 @@
-
 #include <permon/private/svmimpl.h>
 #include "../utils/io.h"
 
@@ -2768,7 +2767,6 @@ PetscErrorCode SVMLoadDataset(SVM svm,PetscViewer v,Mat Xt,Vec y)
     SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMLoadDataset",type_name);
   }
   PetscCall(PetscLogEventEnd(SVM_LoadDataset,svm,0,0,0));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2834,7 +2832,6 @@ PetscErrorCode SVMLoadTrainingDataset(SVM svm,PetscViewer v)
   /* Free memory */
   PetscCall(MatDestroy(&Xt_training));
   PetscCall(VecDestroy(&y_training));
-
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -3156,6 +3153,5 @@ PetscErrorCode SVMViewDataset(SVM svm,Mat Xt,Vec y,PetscViewer v)
 
     SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewDataset",type_name);
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/interface/svm.c
+++ b/src/svm/interface/svm.c
@@ -2,10 +2,10 @@
 #include "../utils/io.h"
 
 PetscClassId  SVM_CLASSID;
-PetscLogEvent SVM_LoadDataset,SVM_LoadGramian;
+PetscLogEvent SVM_LoadDataset, SVM_LoadGramian;
 
-const char *const ModelScores[]={"accuracy","precision","recall","F1","jaccard","aucroc","ModelScore","model_",0};
-const char *const CrossValidationTypes[]={"kfold","stratified_kfold","CrossValidationType","cv_",0};
+const char *const ModelScores[]          = {"accuracy", "precision", "recall", "F1", "jaccard", "aucroc", "ModelScore", "model_", 0};
+const char *const CrossValidationTypes[] = {"kfold", "stratified_kfold", "CrossValidationType", "cv_", 0};
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMCreate"
@@ -24,17 +24,17 @@ const char *const CrossValidationTypes[]={"kfold","stratified_kfold","CrossValid
 
 .seealso SVMDestroy(), SVMReset(), SVMSetup(), SVMSetFromOptions()
 @*/
-PetscErrorCode SVMCreate(MPI_Comm comm,SVM *svm_out)
+PetscErrorCode SVMCreate(MPI_Comm comm, SVM *svm_out)
 {
   SVM svm;
 
   PetscFunctionBegin;
-  PetscAssertPointer(svm_out,2);
+  PetscAssertPointer(svm_out, 2);
 
 #if !defined(PETSC_USE_DYNAMIC_LIBRARIES)
   PetscCall(SVMInitializePackage());
 #endif
-  PetscCall(PetscHeaderCreate(svm,SVM_CLASSID,"SVM","SVM Classifier","SVM",comm,SVMDestroy,SVMView));
+  PetscCall(PetscHeaderCreate(svm, SVM_CLASSID, "SVM", "SVM Classifier", "SVM", comm, SVMDestroy, SVMView));
 
   svm->C      = 1.;
   svm->C_old  = 1.;
@@ -43,24 +43,24 @@ PetscErrorCode SVMCreate(MPI_Comm comm,SVM *svm_out)
   svm->Cn     = 1.;
   svm->Cn_old = 1.;
 
-  svm->logC_base   =  2.;
+  svm->logC_base   = 2.;
   svm->logC_start  = -2.;
-  svm->logC_step   =  1.;
-  svm->logC_end    =  2.;
-  svm->logCp_base  =  2.;
+  svm->logC_step   = 1.;
+  svm->logC_end    = 2.;
+  svm->logCp_base  = 2.;
   svm->logCp_start = -2.;
-  svm->logCp_end   =  2.;
-  svm->logCp_step  =  1.;
-  svm->logCn_base  =  2.;
+  svm->logCp_end   = 2.;
+  svm->logCp_step  = 1.;
+  svm->logCn_base  = 2.;
   svm->logCn_start = -2.;
-  svm->logCn_end   =  2.;
-  svm->logCn_step  =  1.;
+  svm->logCn_end   = 2.;
+  svm->logCn_step  = 1.;
 
-  svm->loss_type  = SVM_L1;
-  svm->user_bias  = 1.;
-  svm->svm_mod    = 2;
+  svm->loss_type = SVM_L1;
+  svm->user_bias = 1.;
+  svm->svm_mod   = 2;
 
-  PetscCall(PetscMemzero(svm->hopt_score_types,6* sizeof(ModelScore)));
+  PetscCall(PetscMemzero(svm->hopt_score_types, 6 * sizeof(ModelScore)));
 
   svm->penalty_type        = 1;
   svm->hyperoptset         = PETSC_FALSE;
@@ -98,19 +98,18 @@ PetscErrorCode SVMCreate(MPI_Comm comm,SVM *svm_out)
 @*/
 PetscErrorCode SVMReset(SVM svm)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
   PetscCall(MatDestroy(&svm->Xt_test));
   svm->Xt_test = NULL;
   PetscCall(VecDestroy(&svm->y_test));
-  svm->y_test  = NULL;
+  svm->y_test = NULL;
 
   PetscCall((*svm->ops->reset)(svm));
 
-  svm->setupcalled          = PETSC_FALSE;
-  svm->posttraincalled      = PETSC_FALSE;
+  svm->setupcalled     = PETSC_FALSE;
+  svm->posttraincalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -130,9 +129,8 @@ PetscErrorCode SVMReset(SVM svm)
 @*/
 PetscErrorCode SVMDestroyDefault(SVM svm)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   PetscCall(PetscFree(svm->data));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -153,17 +151,17 @@ PetscErrorCode SVMDestroyDefault(SVM svm)
 @*/
 PetscErrorCode SVMDestroy(SVM *svm)
 {
-  QPS  qps;
+  QPS   qps;
   void *cctx;
 
   PetscFunctionBegin;
   if (!*svm) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscValidHeaderSpecific(*svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(*svm, SVM_CLASSID, 1);
   --((PetscObject)(*svm))->refct;
   if (((PetscObject)(*svm))->refct == 1) {
-    PetscCall(SVMGetQPS(*svm,&qps));
-    PetscCall(QPSGetConvergenceContext(qps,&cctx));
+    PetscCall(SVMGetQPS(*svm, &qps));
+    PetscCall(QPSGetConvergenceContext(qps, &cctx));
     if (*svm != cctx) {
       *svm = 0;
       PetscFunctionReturn(PETSC_SUCCESS);
@@ -176,9 +174,7 @@ PetscErrorCode SVMDestroy(SVM *svm)
   ((PetscObject)(*svm))->refct = 0;
 
   PetscCall(SVMReset(*svm));
-  if ((*svm)->ops->destroy) {
-    PetscCall((*(*svm)->ops->destroy)(*svm));
-  }
+  if ((*svm)->ops->destroy) { PetscCall((*(*svm)->ops->destroy)(*svm)); }
 
   PetscCall(PetscHeaderDestroy(svm));
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -200,137 +196,99 @@ PetscErrorCode SVMDestroy(SVM *svm)
 @*/
 PetscErrorCode SVMSetFromOptions(SVM svm)
 {
-  PetscInt            svm_mod;
-  SVMLossType         loss_type;
-  PetscInt            penalty_type;
-  PetscReal           bias;
-  PetscReal           C;
+  PetscInt    svm_mod;
+  SVMLossType loss_type;
+  PetscInt    penalty_type;
+  PetscReal   bias;
+  PetscReal   C;
 
-  PetscBool           hyperoptset;
-  ModelScore          hyperopt_score_types[7];
-  PetscReal           logC_base,logC_stride[3];
+  PetscBool  hyperoptset;
+  ModelScore hyperopt_score_types[7];
+  PetscReal  logC_base, logC_stride[3];
 
   CrossValidationType cv_type;
   PetscInt            nfolds;
 
-  PetscBool           warm_start;
+  PetscBool warm_start;
 
-  PetscInt            n;
-  PetscBool           flg;
+  PetscInt  n;
+  PetscBool flg;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
   PetscObjectOptionsBegin((PetscObject)svm);
   // TODO move to SetFromOptions_Binary
-  PetscCall(PetscOptionsInt("-svm_binary_mod","","SVMSetMod",svm->svm_mod,&svm_mod,&flg));
-  if (flg) {
-    PetscCall(SVMSetMod(svm,svm_mod));
-  }
+  PetscCall(PetscOptionsInt("-svm_binary_mod", "", "SVMSetMod", svm->svm_mod, &svm_mod, &flg));
+  if (flg) { PetscCall(SVMSetMod(svm, svm_mod)); }
 
-  PetscCall(PetscOptionsEnum("-svm_loss_type","Specify the loss function for soft-margin SVM (non-separable samples).","SVMSetLossType",SVMLossTypes,(PetscEnum)svm->loss_type,(PetscEnum*)&loss_type,&flg));
-  if (flg) {
-    PetscCall(SVMSetLossType(svm,loss_type));
-  }
+  PetscCall(PetscOptionsEnum("-svm_loss_type", "Specify the loss function for soft-margin SVM (non-separable samples).", "SVMSetLossType", SVMLossTypes, (PetscEnum)svm->loss_type, (PetscEnum *)&loss_type, &flg));
+  if (flg) { PetscCall(SVMSetLossType(svm, loss_type)); }
 
-  PetscCall(PetscOptionsInt("-svm_penalty_type","Set type of misclasification error penalty.","SVMSetPenaltyType",svm->penalty_type,&penalty_type,&flg));
-  if (flg) {
-    PetscCall(SVMSetPenaltyType(svm,penalty_type));
-  }
+  PetscCall(PetscOptionsInt("-svm_penalty_type", "Set type of misclasification error penalty.", "SVMSetPenaltyType", svm->penalty_type, &penalty_type, &flg));
+  if (flg) { PetscCall(SVMSetPenaltyType(svm, penalty_type)); }
 
-  PetscCall(PetscOptionsReal("-svm_user_bias","Set a user defined bias for a relaxed bias formulation.","SVMSetUserBias",svm->user_bias,&bias,&flg));
-  if (flg) {
-    PetscCall(SVMSetUserBias(svm,bias));
-  }
+  PetscCall(PetscOptionsReal("-svm_user_bias", "Set a user defined bias for a relaxed bias formulation.", "SVMSetUserBias", svm->user_bias, &bias, &flg));
+  if (flg) { PetscCall(SVMSetUserBias(svm, bias)); }
 
-  PetscCall(PetscOptionsReal("-svm_C","Set SVM C (C).","SVMSetC",svm->C,&C,&flg));
-  if (flg) {
-    PetscCall(SVMSetC(svm,C));
-  }
+  PetscCall(PetscOptionsReal("-svm_C", "Set SVM C (C).", "SVMSetC", svm->C, &C, &flg));
+  if (flg) { PetscCall(SVMSetC(svm, C)); }
 
-  PetscCall(PetscOptionsReal("-svm_Cp","Set SVM Cp (Cp).","SVMSetCp",svm->Cp,&C,&flg));
-  if (flg) {
-    PetscCall(SVMSetCp(svm,C));
-  }
+  PetscCall(PetscOptionsReal("-svm_Cp", "Set SVM Cp (Cp).", "SVMSetCp", svm->Cp, &C, &flg));
+  if (flg) { PetscCall(SVMSetCp(svm, C)); }
 
-  PetscCall(PetscOptionsReal("-svm_Cn","Set SVM Cn (Cn).","SVMSetCn",svm->Cn,&C,&flg));
-  if (flg) {
-    PetscCall(SVMSetCn(svm,C));
-  }
+  PetscCall(PetscOptionsReal("-svm_Cn", "Set SVM Cn (Cn).", "SVMSetCn", svm->Cn, &C, &flg));
+  if (flg) { PetscCall(SVMSetCn(svm, C)); }
 
   /* Hyperparameter optimization options */
-  PetscCall(PetscOptionsBool("-svm_hyperopt","Specify whether hyperparameter optimization will be performed.","SVMSetHyperOpt",svm->hyperoptset,&hyperoptset,&flg));
-  if (flg) {
-    PetscCall(SVMSetHyperOpt(svm,hyperoptset));
-  }
+  PetscCall(PetscOptionsBool("-svm_hyperopt", "Specify whether hyperparameter optimization will be performed.", "SVMSetHyperOpt", svm->hyperoptset, &hyperoptset, &flg));
+  if (flg) { PetscCall(SVMSetHyperOpt(svm, hyperoptset)); }
 
   n = 7;
-  PetscCall(PetscOptionsEnumArray("-svm_hyperopt_score_types","Specify the score types for evaluating performance of model during hyperparameter optimization.","SVMSetHyperOptScoreTypes",ModelScores,(PetscEnum *) hyperopt_score_types,&n,&flg));
-  if (flg) {
-    PetscCall(SVMSetHyperOptScoreTypes(svm,n,hyperopt_score_types));
-  }
+  PetscCall(PetscOptionsEnumArray("-svm_hyperopt_score_types", "Specify the score types for evaluating performance of model during hyperparameter optimization.", "SVMSetHyperOptScoreTypes", ModelScores, (PetscEnum *)hyperopt_score_types, &n, &flg));
+  if (flg) { PetscCall(SVMSetHyperOptScoreTypes(svm, n, hyperopt_score_types)); }
 
   /* Grid search options (penalty type 1) */
-  PetscCall(PetscOptionsReal("-svm_gs_logC_base","Base of log of C values that specify grid (penalty type 1).","SVMGridSearchSetBaseLogC",svm->logC_base,&logC_base,&flg));
-  if (flg) {
-    PetscCall(SVMGridSearchSetBaseLogC(svm,logC_base));
-  }
+  PetscCall(PetscOptionsReal("-svm_gs_logC_base", "Base of log of C values that specify grid (penalty type 1).", "SVMGridSearchSetBaseLogC", svm->logC_base, &logC_base, &flg));
+  if (flg) { PetscCall(SVMGridSearchSetBaseLogC(svm, logC_base)); }
 
-  n = 3;
-  logC_stride[1] =  2.;
-  logC_stride[2] =  1.;
-  PetscCall(PetscOptionsRealArray("-svm_gs_logC_stride","Stride log C values that specify grid (penalty type 1)","SVMGridSearchSetStrideLogC",logC_stride,&n,&flg));
-  if (flg) {
-    PetscCall(SVMGridSearchSetStrideLogC(svm,logC_stride[0],logC_stride[1],logC_stride[2]));
-  }
+  n              = 3;
+  logC_stride[1] = 2.;
+  logC_stride[2] = 1.;
+  PetscCall(PetscOptionsRealArray("-svm_gs_logC_stride", "Stride log C values that specify grid (penalty type 1)", "SVMGridSearchSetStrideLogC", logC_stride, &n, &flg));
+  if (flg) { PetscCall(SVMGridSearchSetStrideLogC(svm, logC_stride[0], logC_stride[1], logC_stride[2])); }
 
   /* Grid search options (penalty type 2) */
-  PetscCall(PetscOptionsReal("-svm_gs_logCp_base","Base of log of C+ values that specify grid (penalty type 2).","SVMGridSearchSetPositiveBaseLogC",svm->logCp_base,&logC_base,&flg));
-  if (flg) {
-    PetscCall(SVMGridSearchSetPositiveBaseLogC(svm,logC_base));
-  }
+  PetscCall(PetscOptionsReal("-svm_gs_logCp_base", "Base of log of C+ values that specify grid (penalty type 2).", "SVMGridSearchSetPositiveBaseLogC", svm->logCp_base, &logC_base, &flg));
+  if (flg) { PetscCall(SVMGridSearchSetPositiveBaseLogC(svm, logC_base)); }
 
-  n = 3;
+  n              = 3;
   logC_stride[1] = 2.;
   logC_stride[2] = 1.;
-  PetscCall(PetscOptionsRealArray("-svm_gs_logCp_stride","Stride log C+ values that specify grid (penalty type 2).","SVMGridSearchSetPositiveStrideLogC",logC_stride,&n,&flg));
-  if (flg) {
-    PetscCall(SVMGridSearchSetPositiveStrideLogC(svm,logC_stride[0],logC_stride[1],logC_stride[2]));
-  }
+  PetscCall(PetscOptionsRealArray("-svm_gs_logCp_stride", "Stride log C+ values that specify grid (penalty type 2).", "SVMGridSearchSetPositiveStrideLogC", logC_stride, &n, &flg));
+  if (flg) { PetscCall(SVMGridSearchSetPositiveStrideLogC(svm, logC_stride[0], logC_stride[1], logC_stride[2])); }
 
-  PetscCall(PetscOptionsReal("-svm_gs_logCn_base","Base of log of C- values that specify grid (penalty type 2).","SVMGridSearchSetNegativeBaseLogC",svm->logCn_base,&logC_base,&flg));
-  if (flg) {
-    PetscCall(SVMGridSearchSetNegativeBaseLogC(svm,logC_base));
-  }
+  PetscCall(PetscOptionsReal("-svm_gs_logCn_base", "Base of log of C- values that specify grid (penalty type 2).", "SVMGridSearchSetNegativeBaseLogC", svm->logCn_base, &logC_base, &flg));
+  if (flg) { PetscCall(SVMGridSearchSetNegativeBaseLogC(svm, logC_base)); }
 
-  n = 3;
+  n              = 3;
   logC_stride[1] = 2.;
   logC_stride[2] = 1.;
-  PetscCall(PetscOptionsRealArray("-svm_gs_logCn_stride","Stride log C- values that specify grid (penalty type 2).","SVMGridSearchSetNegativeStrideLogC",logC_stride,&n,&flg));
-  if (flg) {
-    PetscCall(SVMGridSearchSetNegativeStrideLogC(svm,logC_stride[0],logC_stride[1],logC_stride[2]));
-  }
+  PetscCall(PetscOptionsRealArray("-svm_gs_logCn_stride", "Stride log C- values that specify grid (penalty type 2).", "SVMGridSearchSetNegativeStrideLogC", logC_stride, &n, &flg));
+  if (flg) { PetscCall(SVMGridSearchSetNegativeStrideLogC(svm, logC_stride[0], logC_stride[1], logC_stride[2])); }
 
   /* Cross validation options */
-  PetscCall(PetscOptionsEnum("-svm_cv_type","Specify the type of cross validation.","SVMSetCrossValidationType",CrossValidationTypes,(PetscEnum)svm->cv_type,(PetscEnum*)&cv_type,&flg));
-  if (flg) {
-    PetscCall(SVMSetCrossValidationType(svm,cv_type));
-  }
+  PetscCall(PetscOptionsEnum("-svm_cv_type", "Specify the type of cross validation.", "SVMSetCrossValidationType", CrossValidationTypes, (PetscEnum)svm->cv_type, (PetscEnum *)&cv_type, &flg));
+  if (flg) { PetscCall(SVMSetCrossValidationType(svm, cv_type)); }
 
-  PetscCall(PetscOptionsInt("-svm_nfolds","Set number of folds (nfolds).","SVMSetNfolds",svm->nfolds,&nfolds,&flg));
-  if (flg) {
-    PetscCall(SVMSetNfolds(svm,nfolds));
-  }
+  PetscCall(PetscOptionsInt("-svm_nfolds", "Set number of folds (nfolds).", "SVMSetNfolds", svm->nfolds, &nfolds, &flg));
+  if (flg) { PetscCall(SVMSetNfolds(svm, nfolds)); }
 
   /* Warm start */
-  PetscCall(PetscOptionsBool("-svm_warm_start","Specify whether warm start is used in cross-validation.","SVMSetWarmStart",svm->warm_start,&warm_start,&flg));
-  if (flg) {
-    PetscCall(SVMSetWarmStart(svm,warm_start));
-  }
+  PetscCall(PetscOptionsBool("-svm_warm_start", "Specify whether warm start is used in cross-validation.", "SVMSetWarmStart", svm->warm_start, &warm_start, &flg));
+  if (flg) { PetscCall(SVMSetWarmStart(svm, warm_start)); }
 
-  if (svm->ops->setfromoptions) {
-    PetscCall(svm->ops->setfromoptions(PetscOptionsObject,svm));
-  }
+  if (svm->ops->setfromoptions) { PetscCall(svm->ops->setfromoptions(PetscOptionsObject, svm)); }
   PetscOptionsEnd();
 
   svm->setfromoptionscalled = PETSC_TRUE;
@@ -352,28 +310,28 @@ PetscErrorCode SVMSetFromOptions(SVM svm)
 
 .seealso SVMCreate(), SVMType
 @*/
-PetscErrorCode SVMSetType(SVM svm,const SVMType type)
+PetscErrorCode SVMSetType(SVM svm, const SVMType type)
 {
   PetscErrorCode (*create_svm)(SVM);
   PetscBool issame = PETSC_FALSE;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(type,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(type, 2);
 
-  PetscCall(PetscObjectTypeCompare((PetscObject) svm,type,&issame));
+  PetscCall(PetscObjectTypeCompare((PetscObject)svm, type, &issame));
   if (issame) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCall(PetscFunctionListFind(SVMList,type,(void(**)(void))&create_svm));
-  PetscCheck(create_svm,PETSC_COMM_SELF,PETSC_ERR_ARG_UNKNOWN_TYPE,"Unable to find requested SVM type %s",type);
+  PetscCall(PetscFunctionListFind(SVMList, type, (void (**)(void))&create_svm));
+  PetscCheck(create_svm, PETSC_COMM_SELF, PETSC_ERR_ARG_UNKNOWN_TYPE, "Unable to find requested SVM type %s", type);
 
   /* Destroy the pre-existing private SVM context */
   if (svm->ops->destroy) PetscCall(svm->ops->destroy(svm));
   /* Reinitialize function pointers in SVMOps structure */
-  PetscCall(PetscMemzero(svm->ops,sizeof(struct _SVMOps)));
+  PetscCall(PetscMemzero(svm->ops, sizeof(struct _SVMOps)));
 
   PetscCall((*create_svm)(svm));
-  PetscCall(PetscObjectChangeTypeName((PetscObject)svm,type));
+  PetscCall(PetscObjectChangeTypeName((PetscObject)svm, type));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -392,14 +350,13 @@ PetscErrorCode SVMSetType(SVM svm,const SVMType type)
 
 .seealso SVMGetQPS(), SVMGetQP()
 @*/
-PetscErrorCode SVMSetQPS(SVM svm,QPS qps)
+PetscErrorCode SVMSetQPS(SVM svm, QPS qps)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(qps,QPS_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(qps, QPS_CLASSID, 2);
 
-  PetscTryMethod(svm,"SVMSetQPS_C",(SVM,QPS),(svm,qps));
+  PetscTryMethod(svm, "SVMSetQPS_C", (SVM, QPS), (svm, qps));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -420,14 +377,13 @@ PetscErrorCode SVMSetQPS(SVM svm,QPS qps)
 
 .seealso SVMSetQPS(), SVMGetQP()
 @*/
-PetscErrorCode SVMGetQPS(SVM svm,QPS *qps)
+PetscErrorCode SVMGetQPS(SVM svm, QPS *qps)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(qps,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(qps, 2);
 
-  PetscUseMethod(svm,"SVMGetQPS_C",(SVM,QPS *),(svm,qps));
+  PetscUseMethod(svm, "SVMGetQPS_C", (SVM, QPS *), (svm, qps));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -448,14 +404,13 @@ PetscErrorCode SVMGetQPS(SVM svm,QPS *qps)
 
 .seealso SVMSetQPS(), SVMGetQPS()
 @*/
-PetscErrorCode SVMGetQP(SVM svm,QP *qp)
+PetscErrorCode SVMGetQP(SVM svm, QP *qp)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(qp,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(qp, 2);
 
-  PetscUseMethod(svm,"SVMGetQP_C",(SVM,QP *),(svm,qp));
+  PetscUseMethod(svm, "SVMGetQP_C", (SVM, QP *), (svm, qp));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -474,15 +429,14 @@ PetscErrorCode SVMGetQP(SVM svm,QP *qp)
 
 .seealso SVMSetNfolds(), SVMCrossValidation()
 @*/
-PetscErrorCode SVMSetNfolds(SVM svm,PetscInt nfolds)
+PetscErrorCode SVMSetNfolds(SVM svm, PetscInt nfolds)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveInt(svm,nfolds,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveInt(svm, nfolds, 2);
 
-  PetscCheck(nfolds > 1,((PetscObject) svm)->comm, PETSC_ERR_ARG_OUTOFRANGE, "Argument must be greater than 1.");
-  svm->nfolds = nfolds;
+  PetscCheck(nfolds > 1, ((PetscObject)svm)->comm, PETSC_ERR_ARG_OUTOFRANGE, "Argument must be greater than 1.");
+  svm->nfolds      = nfolds;
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -504,12 +458,11 @@ PetscErrorCode SVMSetNfolds(SVM svm,PetscInt nfolds)
 
 .seealso SVMSetNfolds(), SVMCrossValidation()
 @*/
-PetscErrorCode SVMGetNfolds(SVM svm,PetscInt *nfolds)
+PetscErrorCode SVMGetNfolds(SVM svm, PetscInt *nfolds)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(nfolds,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(nfolds, 2);
   *nfolds = svm->nfolds;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -527,18 +480,17 @@ PetscErrorCode SVMGetNfolds(SVM svm,PetscInt *nfolds)
 
 .seealso SVMSetC(), SVMSetCp(), SVMSetCn(), SVM
 @*/
-PetscErrorCode SVMSetPenaltyType(SVM svm,PetscInt type)
+PetscErrorCode SVMSetPenaltyType(SVM svm, PetscInt type)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveInt(svm,type,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveInt(svm, type, 2);
   if (svm->penalty_type == type) PetscFunctionReturn(PETSC_SUCCESS);
 
-  PetscCheck(type == 1 || type == 2,((PetscObject) svm)->comm,PETSC_ERR_SUP,"Type of penalty (%" PetscInt_FMT ") is not supported. It must be 1 or 2",type);
+  PetscCheck(type == 1 || type == 2, ((PetscObject)svm)->comm, PETSC_ERR_SUP, "Type of penalty (%" PetscInt_FMT ") is not supported. It must be 1 or 2", type);
 
   svm->penalty_type = type;
-  svm->setupcalled = PETSC_FALSE;
+  svm->setupcalled  = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -557,12 +509,11 @@ PetscErrorCode SVMSetPenaltyType(SVM svm,PetscInt type)
 
 .seealso SVMSetC(), SVMSetCp(), SVMSetCn(), SVM
 @*/
-PetscErrorCode SVMGetPenaltyType(SVM svm,PetscInt *type)
+PetscErrorCode SVMGetPenaltyType(SVM svm, PetscInt *type)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(type,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(type, 2);
   *type = svm->penalty_type;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -582,22 +533,21 @@ PetscErrorCode SVMGetPenaltyType(SVM svm,PetscInt *type)
 
 .seealso SVMGetC(), SVMGridSearch()
 @*/
-PetscErrorCode SVMSetC(SVM svm,PetscReal C)
+PetscErrorCode SVMSetC(SVM svm, PetscReal C)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,C,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, C, 2);
 
   if (svm->C == C) {
     svm->C_old = C;
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
-  PetscCheck(C > 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Argument must be positive");
+  PetscCheck(C > 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Argument must be positive");
 
-  svm->C_old = svm->C;
-  svm->C     = C;
+  svm->C_old       = svm->C;
+  svm->C           = C;
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -619,12 +569,11 @@ PetscErrorCode SVMSetC(SVM svm,PetscReal C)
 
 .seealso SVMSetC(), SVMGridSearch()
 @*/
-PetscErrorCode SVMGetC(SVM svm,PetscReal *C)
+PetscErrorCode SVMGetC(SVM svm, PetscReal *C)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(C,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(C, 2);
   *C = svm->C;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -644,22 +593,21 @@ PetscErrorCode SVMGetC(SVM svm,PetscReal *C)
 
 .seealso SVMGetCp(), SVMSetCn(), SVMGetCn(), SVMGridSearch()
 @*/
-PetscErrorCode SVMSetCp(SVM svm,PetscReal Cp)
+PetscErrorCode SVMSetCp(SVM svm, PetscReal Cp)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,Cp,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, Cp, 2);
 
   if (svm->Cp == Cp) {
     svm->Cp_old = Cp;
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
-  PetscCheck(Cp > 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Argument must be positive");
+  PetscCheck(Cp > 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Argument must be positive");
 
-  svm->Cp_old = svm->Cp;
-  svm->Cp     = Cp;
+  svm->Cp_old      = svm->Cp;
+  svm->Cp          = Cp;
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -681,12 +629,11 @@ PetscErrorCode SVMSetCp(SVM svm,PetscReal Cp)
 
 .seealso SVMSetCp(), SVMSetCn(), SVMGetCn(), SVMGridSearch()
 @*/
-PetscErrorCode SVMGetCp(SVM svm,PetscReal *Cp)
+PetscErrorCode SVMGetCp(SVM svm, PetscReal *Cp)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(Cp,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(Cp, 2);
   *Cp = svm->Cp;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -706,22 +653,21 @@ PetscErrorCode SVMGetCp(SVM svm,PetscReal *Cp)
 
 .seealso SVMSetCp(), SVMGetCp(), SVMGetCn(), SVMGridSearch()
 @*/
-PetscErrorCode SVMSetCn(SVM svm,PetscReal Cn)
+PetscErrorCode SVMSetCn(SVM svm, PetscReal Cn)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,Cn,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, Cn, 2);
 
   if (svm->Cn == Cn) {
     svm->Cn_old = Cn;
     PetscFunctionReturn(PETSC_SUCCESS);
   }
 
-  PetscCheck(Cn > 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Argument must be positive");
+  PetscCheck(Cn > 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Argument must be positive");
 
-  svm->Cn_old = svm->Cn;
-  svm->Cn     = Cn;
+  svm->Cn_old      = svm->Cn;
+  svm->Cn          = Cn;
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -743,12 +689,11 @@ PetscErrorCode SVMSetCn(SVM svm,PetscReal Cn)
 
 .seealso SVMSetCp(), SVMSetCn(), SVMSetCn(), SVMGridSearch()
 @*/
-PetscErrorCode SVMGetCn(SVM svm,PetscReal *Cn)
+PetscErrorCode SVMGetCn(SVM svm, PetscReal *Cn)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(Cn,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(Cn, 2);
   *Cn = svm->Cn;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -773,28 +718,28 @@ PetscErrorCode SVMGetCn(SVM svm,PetscReal *Cn)
 
 .seealso SVMSetC(), SVMSetCp(), SVMSetCn(), SVM
 @*/
-PetscErrorCode SVMSetPenalty(SVM svm,PetscInt m,PetscReal p[])
+PetscErrorCode SVMSetPenalty(SVM svm, PetscInt m, PetscReal p[])
 {
   PetscInt penalty_type;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscCheck(m <= 2,((PetscObject) svm)->comm, PETSC_ERR_ARG_OUTOFRANGE, "Argument must be 1 or 2");
-  PetscValidLogicalCollectiveInt(svm,m,2);
-  PetscValidLogicalCollectiveReal(svm,p[0],3);
-  if (m == 2) PetscValidLogicalCollectiveReal(svm,p[1],3);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscCheck(m <= 2, ((PetscObject)svm)->comm, PETSC_ERR_ARG_OUTOFRANGE, "Argument must be 1 or 2");
+  PetscValidLogicalCollectiveInt(svm, m, 2);
+  PetscValidLogicalCollectiveReal(svm, p[0], 3);
+  if (m == 2) PetscValidLogicalCollectiveReal(svm, p[1], 3);
 
-  PetscCall(SVMGetPenaltyType(svm,&penalty_type));
+  PetscCall(SVMGetPenaltyType(svm, &penalty_type));
 
   if (penalty_type == 1) {
-    PetscCall(SVMSetC(svm,p[0]));
+    PetscCall(SVMSetC(svm, p[0]));
   } else {
     if (m == 1) {
-      PetscCall(SVMSetCp(svm,p[0]));
-      PetscCall(SVMSetCn(svm,p[0]));
+      PetscCall(SVMSetCp(svm, p[0]));
+      PetscCall(SVMSetCn(svm, p[0]));
     } else {
-      PetscCall(SVMSetCp(svm,p[0]));
-      PetscCall(SVMSetCn(svm,p[1]));
+      PetscCall(SVMSetCp(svm, p[0]));
+      PetscCall(SVMSetCn(svm, p[1]));
     }
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -815,16 +760,15 @@ PetscErrorCode SVMSetPenalty(SVM svm,PetscInt m,PetscReal p[])
 
 .seealso SVMGridSearch(), SVMGridSearchGetBaseLogC(), SVMGridSearchSetStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchSetBaseLogC(SVM svm,PetscReal logC_base)
+PetscErrorCode SVMGridSearchSetBaseLogC(SVM svm, PetscReal logC_base)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,logC_base,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, logC_base, 2);
 
-  PetscCheck(logC_base > 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Argument must be positive");
+  PetscCheck(logC_base > 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Argument must be positive");
 
-  svm->logC_base = logC_base;
+  svm->logC_base   = logC_base;
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -846,12 +790,11 @@ PetscErrorCode SVMGridSearchSetBaseLogC(SVM svm,PetscReal logC_base)
 
 .seealso SVMGridSearch(), SVMGridSearchSetBaseLogC(), SVMGridSearchSetStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchGetBaseLogC(SVM svm,PetscReal *logC_base)
+PetscErrorCode SVMGridSearchGetBaseLogC(SVM svm, PetscReal *logC_base)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(logC_base,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(logC_base, 2);
 
   *logC_base = svm->logC_base;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -874,23 +817,22 @@ PetscErrorCode SVMGridSearchGetBaseLogC(SVM svm,PetscReal *logC_base)
 
 .seealso SVMGridSearch(), SVMGridSearchSetBaseLogC(), SVMGridSearchGetStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchSetStrideLogC(SVM svm,PetscReal logC_start,PetscReal logC_end,PetscReal logC_step)
+PetscErrorCode SVMGridSearchSetStrideLogC(SVM svm, PetscReal logC_start, PetscReal logC_end, PetscReal logC_step)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,logC_start,2);
-  PetscValidLogicalCollectiveReal(svm,logC_end,3);
-  PetscValidLogicalCollectiveReal(svm,logC_step,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, logC_start, 2);
+  PetscValidLogicalCollectiveReal(svm, logC_end, 3);
+  PetscValidLogicalCollectiveReal(svm, logC_step, 4);
 
   /* Validating values of input parameters */
-  PetscCheck(logC_step != 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be 0");
-  PetscCheck(logC_start != logC_end,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Start (logC_start) and end (logC_end) cannot be same");
-  PetscCheck(logC_start <= logC_end || logC_step <= 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be greater than 0 if start (logC_start) is greater than end (logC_end)");
-  PetscCheck(logC_start >= logC_end || logC_step >= 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be less than 0 if start (logC_start) is less than end (logC_end)");
+  PetscCheck(logC_step != 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be 0");
+  PetscCheck(logC_start != logC_end, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Start (logC_start) and end (logC_end) cannot be same");
+  PetscCheck(logC_start <= logC_end || logC_step <= 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be greater than 0 if start (logC_start) is greater than end (logC_end)");
+  PetscCheck(logC_start >= logC_end || logC_step >= 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be less than 0 if start (logC_start) is less than end (logC_end)");
 
   svm->logC_start = logC_start;
-  svm->logC_end  = logC_end;
+  svm->logC_end   = logC_end;
   svm->logC_step  = logC_step;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -914,24 +856,17 @@ PetscErrorCode SVMGridSearchSetStrideLogC(SVM svm,PetscReal logC_start,PetscReal
 
 .seealso SVMGridSearch(), SVMGridSearchSetBaseLogC(), SVMGridSearchSetStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchGetStrideLogC(SVM svm,PetscReal *logC_start,PetscReal *logC_end,PetscReal *logC_step)
+PetscErrorCode SVMGridSearchGetStrideLogC(SVM svm, PetscReal *logC_start, PetscReal *logC_end, PetscReal *logC_step)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(logC_start,2);
-  PetscAssertPointer(logC_end,3);
-  PetscAssertPointer(logC_step,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(logC_start, 2);
+  PetscAssertPointer(logC_end, 3);
+  PetscAssertPointer(logC_step, 4);
 
-  if (logC_start) {
-    *logC_start = svm->logC_start;
-  }
-  if (logC_end) {
-    *logC_end = svm->logC_end;
-  }
-  if (logC_step) {
-    *logC_step = svm->logC_step;
-  }
+  if (logC_start) { *logC_start = svm->logC_start; }
+  if (logC_end) { *logC_end = svm->logC_end; }
+  if (logC_step) { *logC_step = svm->logC_step; }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -950,16 +885,15 @@ PetscErrorCode SVMGridSearchGetStrideLogC(SVM svm,PetscReal *logC_start,PetscRea
 
 .seealso SVMGridSearch(), SVMGridSearchGetPositiveBaseLogC(), SVMGridSearchSetPositiveStrideLogC(), SVMGridSearchSetNegativeBaseLogC(), SVMGridSearchSetNegativeStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchSetPositiveBaseLogC(SVM svm,PetscReal logCp_base)
+PetscErrorCode SVMGridSearchSetPositiveBaseLogC(SVM svm, PetscReal logCp_base)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,logCp_base,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, logCp_base, 2);
 
-  PetscCheck(logCp_base > 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Argument must be positive");
+  PetscCheck(logCp_base > 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Argument must be positive");
 
-  svm->logCp_base = logCp_base;
+  svm->logCp_base  = logCp_base;
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -981,12 +915,11 @@ PetscErrorCode SVMGridSearchSetPositiveBaseLogC(SVM svm,PetscReal logCp_base)
 
 .seealso SVMGridSearch(), SVMGridSearchSetPositiveBaseLogC(), SVMGridSearchSetPositiveStrideLogC(), SVMGridSearchSetNegativeBaseLogC(), SVMGridSearchSetNegativeStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchGetPositiveBaseLogC(SVM svm,PetscReal *logCp_base)
+PetscErrorCode SVMGridSearchGetPositiveBaseLogC(SVM svm, PetscReal *logCp_base)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(logCp_base,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(logCp_base, 2);
 
   *logCp_base = svm->logCp_base;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1009,20 +942,19 @@ PetscErrorCode SVMGridSearchGetPositiveBaseLogC(SVM svm,PetscReal *logCp_base)
 
 .seealso SVMGridSearch(), SVMGridSearchSetPositiveBaseLogC(), SVMGridSearchGetPositiveStrideLogC(), SVMGridSearchSetNegativeBaseLogC(), SVMGridSearchSetNegativeStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchSetPositiveStrideLogC(SVM svm,PetscReal logC_start,PetscReal logC_end,PetscReal logC_step)
+PetscErrorCode SVMGridSearchSetPositiveStrideLogC(SVM svm, PetscReal logC_start, PetscReal logC_end, PetscReal logC_step)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,logC_start,2);
-  PetscValidLogicalCollectiveReal(svm,logC_end,3);
-  PetscValidLogicalCollectiveReal(svm,logC_step,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, logC_start, 2);
+  PetscValidLogicalCollectiveReal(svm, logC_end, 3);
+  PetscValidLogicalCollectiveReal(svm, logC_step, 4);
 
   /* Validating values of input parameters */
-  PetscCheck(logC_step != 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be 0");
-  PetscCheck(logC_start != logC_end,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Start (logC_start) and end (logC_end) cannot be same");
-  PetscCheck(logC_start <= logC_end || logC_step <= 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be greater than 0 if start (logC_start) is greater than end (logC_end)");
-  PetscCheck(logC_start >= logC_end || logC_step >= 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be less than 0 if start (logC_start) is less than end (logC_end)");
+  PetscCheck(logC_step != 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be 0");
+  PetscCheck(logC_start != logC_end, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Start (logC_start) and end (logC_end) cannot be same");
+  PetscCheck(logC_start <= logC_end || logC_step <= 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be greater than 0 if start (logC_start) is greater than end (logC_end)");
+  PetscCheck(logC_start >= logC_end || logC_step >= 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be less than 0 if start (logC_start) is less than end (logC_end)");
 
   svm->logCp_start = logC_start;
   svm->logCp_end   = logC_end;
@@ -1049,24 +981,17 @@ PetscErrorCode SVMGridSearchSetPositiveStrideLogC(SVM svm,PetscReal logC_start,P
 
 .seealso SVMGridSearch(), SVMGridSearchSetPositiveBaseLogC(), SVMGridSearchSetPositiveStrideLogC(), SVMGridSearchSetNegativeBaseLogC(), SVMGridSearchSetNegativeStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchGetPositiveStrideLogC(SVM svm,PetscReal *logC_start,PetscReal *logC_end,PetscReal *logC_step)
+PetscErrorCode SVMGridSearchGetPositiveStrideLogC(SVM svm, PetscReal *logC_start, PetscReal *logC_end, PetscReal *logC_step)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(logC_start,2);
-  PetscAssertPointer(logC_end,3);
-  PetscAssertPointer(logC_step,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(logC_start, 2);
+  PetscAssertPointer(logC_end, 3);
+  PetscAssertPointer(logC_step, 4);
 
-  if (logC_start) {
-    *logC_start = svm->logCp_start;
-  }
-  if (logC_end) {
-    *logC_end = svm->logCp_end;
-  }
-  if (logC_step) {
-    *logC_step = svm->logCp_step;
-  }
+  if (logC_start) { *logC_start = svm->logCp_start; }
+  if (logC_end) { *logC_end = svm->logCp_end; }
+  if (logC_step) { *logC_step = svm->logCp_step; }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1085,16 +1010,15 @@ PetscErrorCode SVMGridSearchGetPositiveStrideLogC(SVM svm,PetscReal *logC_start,
 
 .seealso SVMGridSearch(), SVMGridSearchGetNegativeBaseLogC(), SVMGridSearchSetNegativeStrideLogC(), SVMGridSearchSetPositiveBaseLogC(), SVMGridSearchSetPositiveStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchSetNegativeBaseLogC(SVM svm,PetscReal logCn_base)
+PetscErrorCode SVMGridSearchSetNegativeBaseLogC(SVM svm, PetscReal logCn_base)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,logCn_base,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, logCn_base, 2);
 
-  PetscCheck(logCn_base > 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Argument must be positive");
+  PetscCheck(logCn_base > 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Argument must be positive");
 
-  svm->logCn_base = logCn_base;
+  svm->logCn_base  = logCn_base;
   svm->setupcalled = PETSC_FALSE;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1116,12 +1040,11 @@ PetscErrorCode SVMGridSearchSetNegativeBaseLogC(SVM svm,PetscReal logCn_base)
 
 .seealso SVMGridSearch(), SVMGridSearchSetNegativeBaseLogC(), SVMGridSearchSetNegativeStrideLogC(), SVMGridSearchSetPositiveBaseLogC(), SVMGridSearchSetPositiveStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchGetNegativeBaseLogC(SVM svm,PetscReal *logCn_base)
+PetscErrorCode SVMGridSearchGetNegativeBaseLogC(SVM svm, PetscReal *logCn_base)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(logCn_base,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(logCn_base, 2);
 
   *logCn_base = svm->logCn_base;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1144,20 +1067,19 @@ PetscErrorCode SVMGridSearchGetNegativeBaseLogC(SVM svm,PetscReal *logCn_base)
 
 .seealso SVMGridSearch(), SVMGridSearchSetNegativeBaseLogC(), SVMGridSearchGetNegativeStrideLogC(), SVMGridSearchSetPositiveBaseLogC(), SVMGridSearchSetPositiveStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchSetNegativeStrideLogC(SVM svm,PetscReal logC_start,PetscReal logC_end,PetscReal logC_step)
+PetscErrorCode SVMGridSearchSetNegativeStrideLogC(SVM svm, PetscReal logC_start, PetscReal logC_end, PetscReal logC_step)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,logC_start,2);
-  PetscValidLogicalCollectiveReal(svm,logC_end,3);
-  PetscValidLogicalCollectiveReal(svm,logC_step,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, logC_start, 2);
+  PetscValidLogicalCollectiveReal(svm, logC_end, 3);
+  PetscValidLogicalCollectiveReal(svm, logC_step, 4);
 
   /* Validating values of input parameters */
-  PetscCheck(logC_step != 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be 0");
-  PetscCheck(logC_start != logC_end,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Start (logC_start) and end (logC_end) cannot be same");
-  PetscCheck(logC_start <= logC_end || logC_step <= 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be greater than 0 if start (logC_start) is greater than end (logC_end)");
-  PetscCheck(logC_start >= logC_end || logC_step >= 0,PetscObjectComm((PetscObject) svm),PETSC_ERR_ARG_OUTOFRANGE,"Step (logC_step) cannot be less than 0 if start (logC_start) is less than end (logC_end)");
+  PetscCheck(logC_step != 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be 0");
+  PetscCheck(logC_start != logC_end, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Start (logC_start) and end (logC_end) cannot be same");
+  PetscCheck(logC_start <= logC_end || logC_step <= 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be greater than 0 if start (logC_start) is greater than end (logC_end)");
+  PetscCheck(logC_start >= logC_end || logC_step >= 0, PetscObjectComm((PetscObject)svm), PETSC_ERR_ARG_OUTOFRANGE, "Step (logC_step) cannot be less than 0 if start (logC_start) is less than end (logC_end)");
 
   svm->logCn_start = logC_start;
   svm->logCn_end   = logC_end;
@@ -1184,24 +1106,17 @@ PetscErrorCode SVMGridSearchSetNegativeStrideLogC(SVM svm,PetscReal logC_start,P
 
 .seealso SVMGridSearch(), SVMGridSearchSetNegativeBaseLogC(), SVMGridSearchSetNegativeStrideLogC(), SVMGridSearchSetPositiveBaseLogC(), SVMGridSearchSetPositiveStrideLogC(), SVMSetPenaltyType()
 @*/
-PetscErrorCode SVMGridSearchGetNegativeStrideLogC(SVM svm,PetscReal *logC_start,PetscReal *logC_end,PetscReal *logC_step)
+PetscErrorCode SVMGridSearchGetNegativeStrideLogC(SVM svm, PetscReal *logC_start, PetscReal *logC_end, PetscReal *logC_step)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(logC_start,2);
-  PetscAssertPointer(logC_end,3);
-  PetscAssertPointer(logC_step,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(logC_start, 2);
+  PetscAssertPointer(logC_end, 3);
+  PetscAssertPointer(logC_step, 4);
 
-  if (logC_start) {
-    *logC_start = svm->logCn_start;
-  }
-  if (logC_end) {
-    *logC_end = svm->logCn_end;
-  }
-  if (logC_step) {
-    *logC_step = svm->logCn_step;
-  }
+  if (logC_start) { *logC_start = svm->logCn_start; }
+  if (logC_end) { *logC_end = svm->logCn_end; }
+  if (logC_step) { *logC_step = svm->logCn_step; }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1220,14 +1135,13 @@ PetscErrorCode SVMGridSearchGetNegativeStrideLogC(SVM svm,PetscReal *logC_start,
 
 .seealso SVMLossType, SVMGetLossType()
 @*/
-PetscErrorCode SVMSetLossType(SVM svm,SVMLossType type)
+PetscErrorCode SVMSetLossType(SVM svm, SVMLossType type)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveEnum(svm,type,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveEnum(svm, type, 2);
   if (type != svm->loss_type) {
-    svm->loss_type = type;
+    svm->loss_type   = type;
     svm->setupcalled = PETSC_FALSE;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1250,12 +1164,11 @@ PetscErrorCode SVMSetLossType(SVM svm,SVMLossType type)
 
 .seealso PermonSVMType, SVMSetLossType()
 @*/
-PetscErrorCode SVMGetLossType(SVM svm,SVMLossType *type)
+PetscErrorCode SVMGetLossType(SVM svm, SVMLossType *type)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(type,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(type, 2);
   *type = svm->loss_type;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1275,14 +1188,13 @@ PetscErrorCode SVMGetLossType(SVM svm,SVMLossType *type)
 
 .seealso SVMGetMod()
 @*/
-PetscErrorCode SVMSetMod(SVM svm,PetscInt mod)
+PetscErrorCode SVMSetMod(SVM svm, PetscInt mod)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveInt(svm,mod,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveInt(svm, mod, 2);
   if (svm->svm_mod != mod) {
-    svm->svm_mod = mod;
+    svm->svm_mod     = mod;
     svm->setupcalled = PETSC_FALSE;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1305,11 +1217,10 @@ PetscErrorCode SVMSetMod(SVM svm,PetscInt mod)
 
 .seealso SVMSetMod()
 @*/
-PetscErrorCode SVMGetMod(SVM svm,PetscInt *mod)
+PetscErrorCode SVMGetMod(SVM svm, PetscInt *mod)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   *mod = svm->svm_mod;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1329,12 +1240,11 @@ PetscErrorCode SVMGetMod(SVM svm,PetscInt *mod)
 
 .seealso SVMAppendOptionsPrefix(), SVMGetOptionsPrefix(), SVM, QPS
 @*/
-PetscErrorCode SVMSetOptionsPrefix(SVM svm,const char prefix[])
+PetscErrorCode SVMSetOptionsPrefix(SVM svm, const char prefix[])
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscTryMethod(svm,"SVMSetOptionsPrefix_C",(SVM,const char []),(svm,prefix));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscTryMethod(svm, "SVMSetOptionsPrefix_C", (SVM, const char[]), (svm, prefix));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1353,12 +1263,11 @@ PetscErrorCode SVMSetOptionsPrefix(SVM svm,const char prefix[])
 
 .seealso SVMSetOptionsPrefix(), SVMGetOptionsPrefix(), SVM, QPS
 */
-PetscErrorCode SVMAppendOptionsPrefix(SVM svm,const char prefix[])
+PetscErrorCode SVMAppendOptionsPrefix(SVM svm, const char prefix[])
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscTryMethod(svm,"SVMAppendOptionsPrefix_C",(SVM,const char []),(svm,prefix));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscTryMethod(svm, "SVMAppendOptionsPrefix_C", (SVM, const char[]), (svm, prefix));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1379,12 +1288,11 @@ PetscErrorCode SVMAppendOptionsPrefix(SVM svm,const char prefix[])
 
 .seealso SVMSetOptionsPrefix(), SVM, QPS
 @*/
-PetscErrorCode SVMGetOptionsPrefix(SVM svm,const char *prefix[])
+PetscErrorCode SVMGetOptionsPrefix(SVM svm, const char *prefix[])
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscUseMethod(svm,"SVMGetOptionsPrefix_C",(SVM,const char *[]),(svm,prefix));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscUseMethod(svm, "SVMGetOptionsPrefix_C", (SVM, const char *[]), (svm, prefix));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1407,11 +1315,11 @@ PetscErrorCode SVMGetOptionsPrefix(SVM svm,const char *prefix[])
 
 .seealso PermonSVMType, SVMGetLossType()
 @*/
-PetscErrorCode SVMSetWarmStart(SVM svm,PetscBool flg)
+PetscErrorCode SVMSetWarmStart(SVM svm, PetscBool flg)
 {
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveBool(svm,flg,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveBool(svm, flg, 2);
   svm->warm_start = flg;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -1419,24 +1327,22 @@ PetscErrorCode SVMSetWarmStart(SVM svm,PetscBool flg)
 /*@
 
 @*/
-PetscErrorCode SVMGetInnerSVM(SVM svm,SVM *out)
+PetscErrorCode SVMGetInnerSVM(SVM svm, SVM *out)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscUseMethod(svm,"SVMGetInnerSVM_C",(SVM,SVM *),(svm,out));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscUseMethod(svm, "SVMGetInnerSVM_C", (SVM, SVM *), (svm, out));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /*@
 
 @*/
-PetscErrorCode SVMGetTao(SVM svm,Tao *tao)
+PetscErrorCode SVMGetTao(SVM svm, Tao *tao)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscUseMethod(svm,"SVMGetTao_C",(SVM,Tao *),(svm,tao));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscUseMethod(svm, "SVMGetTao_C", (SVM, Tao *), (svm, tao));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1456,9 +1362,8 @@ PetscErrorCode SVMGetTao(SVM svm,Tao *tao)
 @*/
 PetscErrorCode SVMSetUp(SVM svm)
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   if (svm->setupcalled) PetscFunctionReturnI(PETSC_SUCCESS);
 
   PetscCall(svm->ops->setup(svm));
@@ -1482,14 +1387,11 @@ PetscErrorCode SVMSetUp(SVM svm)
 
 .seealso PetscViewer
 @*/
-PetscErrorCode SVMView(SVM svm,PetscViewer v)
+PetscErrorCode SVMView(SVM svm, PetscViewer v)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (svm->ops->view) {
-    PetscCall(svm->ops->view(svm,v));
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (svm->ops->view) { PetscCall(svm->ops->view(svm, v)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1504,15 +1406,12 @@ PetscErrorCode SVMView(SVM svm,PetscViewer v)
 
 .seealso SVMLoadTrainingDataset, SVMPredict, PetscViewer
 @*/
-PetscErrorCode SVMViewTrainingPredictions(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTrainingPredictions(SVM svm, PetscViewer v)
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (v) PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
-  if (svm->ops->viewtrainingpredictions) {
-    PetscCall(svm->ops->viewtrainingpredictions(svm,v));
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (v) PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
+  if (svm->ops->viewtrainingpredictions) { PetscCall(svm->ops->viewtrainingpredictions(svm, v)); }
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -1527,15 +1426,12 @@ PetscErrorCode SVMViewTrainingPredictions(SVM svm,PetscViewer v)
 
 .seealso SVMLoadTestDataset, SVMPredict, PetscViewer
 @*/
-PetscErrorCode SVMViewTestPredictions(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTestPredictions(SVM svm, PetscViewer v)
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (v) {PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);}
-  if (svm->ops->viewtestpredictions) {
-    PetscCall(svm->ops->viewtestpredictions(svm,v));
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (v) { PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2); }
+  if (svm->ops->viewtestpredictions) { PetscCall(svm->ops->viewtestpredictions(svm, v)); }
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -1555,14 +1451,11 @@ PetscErrorCode SVMViewTestPredictions(SVM svm,PetscViewer v)
 
 .seealso PetscViewer
 @*/
-PetscErrorCode SVMViewScore(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewScore(SVM svm, PetscViewer v)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (svm->ops->viewscore) {
-    PetscCall(svm->ops->viewscore(svm,v));
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (svm->ops->viewscore) { PetscCall(svm->ops->viewscore(svm, v)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1579,14 +1472,13 @@ PetscErrorCode SVMViewScore(SVM svm,PetscViewer v)
 
 .seealso SVM, SVMGetGramian(), SVMLoadGramian()
 @*/
-PetscErrorCode SVMSetGramian(SVM svm,Mat G)
+PetscErrorCode SVMSetGramian(SVM svm, Mat G)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(G,MAT_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(G, MAT_CLASSID, 2);
 
-  PetscTryMethod(svm,"SVMSetGramian_C",(SVM,Mat),(svm,G));
+  PetscTryMethod(svm, "SVMSetGramian_C", (SVM, Mat), (svm, G));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1605,14 +1497,13 @@ PetscErrorCode SVMSetGramian(SVM svm,Mat G)
 
 .seealso SVM, SVMSetGramian(), SVMLoadGramian()
 @*/
-PetscErrorCode SVMGetGramian(SVM svm,Mat *G)
+PetscErrorCode SVMGetGramian(SVM svm, Mat *G)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(G,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(G, 2);
 
-  PetscUseMethod(svm,"SVMGetGramian_C",(SVM,Mat *),(svm,G));
+  PetscUseMethod(svm, "SVMGetGramian_C", (SVM, Mat *), (svm, G));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1631,14 +1522,13 @@ PetscErrorCode SVMGetGramian(SVM svm,Mat *G)
 
 .seealso SVM, QP, SVMGetOperator()
 @*/
-PetscErrorCode SVMSetOperator(SVM svm,Mat A)
+PetscErrorCode SVMSetOperator(SVM svm, Mat A)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(A,MAT_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(A, MAT_CLASSID, 2);
 
-  PetscTryMethod(svm,"SVMSetOperator_C",(SVM,Mat),(svm,A));
+  PetscTryMethod(svm, "SVMSetOperator_C", (SVM, Mat), (svm, A));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1659,14 +1549,13 @@ PetscErrorCode SVMSetOperator(SVM svm,Mat A)
 
 .seealso SVM, QP, SVMSetOperator()
 @*/
-PetscErrorCode SVMGetOperator(SVM svm,Mat *A)
+PetscErrorCode SVMGetOperator(SVM svm, Mat *A)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(A,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(A, 2);
 
-  PetscUseMethod(svm,"SVMGetOperator_C",(SVM,Mat *),(svm,A));
+  PetscUseMethod(svm, "SVMGetOperator_C", (SVM, Mat *), (svm, A));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1687,13 +1576,12 @@ PetscErrorCode SVMGetOperator(SVM svm,Mat *A)
 
 .seealso SVM, SVMSetOperator(), SVMGetOperator(), SVMSetGramian(), SVMGetGramian()
 @*/
-PetscErrorCode SVMComputeOperator(SVM svm,Mat *A)
+PetscErrorCode SVMComputeOperator(SVM svm, Mat *A)
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscTryMethod(svm,"SVMComputeOperator_C",(SVM,Mat *),(svm,A));
+  PetscTryMethod(svm, "SVMComputeOperator_C", (SVM, Mat *), (svm, A));
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -1713,17 +1601,16 @@ PetscErrorCode SVMComputeOperator(SVM svm,Mat *A)
 
 .seealso SVMGetTrainingDataset(), SVMSetTestDataset(), SVMGetTestDataset()
 @*/
-PetscErrorCode SVMSetTrainingDataset(SVM svm,Mat Xt_training,Vec y_training)
+PetscErrorCode SVMSetTrainingDataset(SVM svm, Mat Xt_training, Vec y_training)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(Xt_training,MAT_CLASSID,2);
-  PetscCheckSameComm(svm,1,Xt_training,2);
-  PetscValidHeaderSpecific(y_training,VEC_CLASSID,3);
-  PetscCheckSameComm(svm,1,y_training,3);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(Xt_training, MAT_CLASSID, 2);
+  PetscCheckSameComm(svm, 1, Xt_training, 2);
+  PetscValidHeaderSpecific(y_training, VEC_CLASSID, 3);
+  PetscCheckSameComm(svm, 1, y_training, 3);
 
-  PetscTryMethod(svm,"SVMSetTrainingDataset_C",(SVM,Mat,Vec),(svm,Xt_training,y_training));
+  PetscTryMethod(svm, "SVMSetTrainingDataset_C", (SVM, Mat, Vec), (svm, Xt_training, y_training));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1745,13 +1632,12 @@ PetscErrorCode SVMSetTrainingDataset(SVM svm,Mat Xt_training,Vec y_training)
 
 .seealso SVMSetTrainingDataset(), SVMSetTestDataset(), SVMGetTestDataset()
 @*/
-PetscErrorCode SVMGetTrainingDataset(SVM svm,Mat *Xt_training,Vec *y_training)
+PetscErrorCode SVMGetTrainingDataset(SVM svm, Mat *Xt_training, Vec *y_training)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscUseMethod(svm,"SVMGetTrainingDataset_C",(SVM,Mat *,Vec *),(svm,Xt_training,y_training));
+  PetscUseMethod(svm, "SVMGetTrainingDataset_C", (SVM, Mat *, Vec *), (svm, Xt_training, y_training));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1769,13 +1655,12 @@ PetscErrorCode SVMGetTrainingDataset(SVM svm,Mat *Xt_training,Vec *y_training)
 
 .seealso SVMSetTrainingDataset(), SVMGetTrainingDataset(), SVMSetTestDataset(), SVMGetTestDataset()
 @*/
-PetscErrorCode SVMSetCalibrationDataset(SVM svm,Mat Xt_calib,Vec y_calib)
+PetscErrorCode SVMSetCalibrationDataset(SVM svm, Mat Xt_calib, Vec y_calib)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscTryMethod(svm,"SVMSetCalibrationDataset_C",(SVM,Mat,Vec),(svm,Xt_calib,y_calib));
+  PetscTryMethod(svm, "SVMSetCalibrationDataset_C", (SVM, Mat, Vec), (svm, Xt_calib, y_calib));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1795,13 +1680,12 @@ PetscErrorCode SVMSetCalibrationDataset(SVM svm,Mat Xt_calib,Vec y_calib)
 
 .seealso SVMSetTrainingDataset(), SVMGetTrainingDataset(), SVMSetTestDataset(), SVMGetTestDataset()
 @*/
-PetscErrorCode SVMGetCalibrationDataset(SVM svm,Mat *Xt_calib,Vec *y_calib)
+PetscErrorCode SVMGetCalibrationDataset(SVM svm, Mat *Xt_calib, Vec *y_calib)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscUseMethod(svm,"SVMGetCalibrationDataset_C",(SVM,Mat *,Vec *),(svm,Xt_calib,y_calib));
+  PetscUseMethod(svm, "SVMGetCalibrationDataset_C", (SVM, Mat *, Vec *), (svm, Xt_calib, y_calib));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1821,23 +1705,22 @@ PetscErrorCode SVMGetCalibrationDataset(SVM svm,Mat *Xt_calib,Vec *y_calib)
 
 .seealso SVMSetTrainingDataset(), SVMGetTrainingDataset(), SVMGetTestDataset()
 @*/
-PetscErrorCode SVMSetTestDataset(SVM svm,Mat Xt_test,Vec y_test)
+PetscErrorCode SVMSetTestDataset(SVM svm, Mat Xt_test, Vec y_test)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(Xt_test,MAT_CLASSID,2);
-  PetscCheckSameComm(svm,1,Xt_test,2);
-  PetscValidHeaderSpecific(y_test,VEC_CLASSID,3);
-  PetscCheckSameComm(svm,1,y_test,3);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(Xt_test, MAT_CLASSID, 2);
+  PetscCheckSameComm(svm, 1, Xt_test, 2);
+  PetscValidHeaderSpecific(y_test, VEC_CLASSID, 3);
+  PetscCheckSameComm(svm, 1, y_test, 3);
 
   PetscCall(MatDestroy(&svm->Xt_test));
   svm->Xt_test = Xt_test;
-  PetscCall(PetscObjectReference((PetscObject) Xt_test));
+  PetscCall(PetscObjectReference((PetscObject)Xt_test));
 
   PetscCall(VecDestroy(&svm->y_test));
   svm->y_test = y_test;
-  PetscCall(PetscObjectReference((PetscObject) y_test));
+  PetscCall(PetscObjectReference((PetscObject)y_test));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1859,19 +1742,18 @@ PetscErrorCode SVMSetTestDataset(SVM svm,Mat Xt_test,Vec y_test)
 
 .seealso SVMSetTrainingDataset(), SVMGetTrainingDataset(), SVMSetTestDataset()
 @*/
-PetscErrorCode SVMGetTestDataset(SVM svm,Mat *Xt_test,Vec *y_test)
+PetscErrorCode SVMGetTestDataset(SVM svm, Mat *Xt_test, Vec *y_test)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
   if (Xt_test) {
-    PetscAssertPointer(Xt_test,2);
+    PetscAssertPointer(Xt_test, 2);
     *Xt_test = svm->Xt_test;
   }
 
   if (y_test) {
-    PetscAssertPointer(y_test,2);
+    PetscAssertPointer(y_test, 2);
     *y_test = svm->y_test;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1890,12 +1772,11 @@ PetscErrorCode SVMGetTestDataset(SVM svm,Mat *Xt_test,Vec *y_test)
 
 .seealso SVMSetTrainingDataset, SVMGetTrainingDataset
 @*/
-PetscErrorCode SVMGetLabels(SVM svm,const PetscReal *labels[])
+PetscErrorCode SVMGetLabels(SVM svm, const PetscReal *labels[])
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscUseMethod(svm,"SVMGetLabels_C",(SVM,const PetscReal *[]),(svm,labels));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscUseMethod(svm, "SVMGetLabels_C", (SVM, const PetscReal *[]), (svm, labels));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -1914,12 +1795,11 @@ PetscErrorCode SVMGetLabels(SVM svm,const PetscReal *labels[])
 
 .seealso SVMPostTrain()
 @*/
-PetscErrorCode SVMSetAutoPostTrain(SVM svm,PetscBool flg)
+PetscErrorCode SVMSetAutoPostTrain(SVM svm, PetscBool flg)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveBool(svm,flg,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveBool(svm, flg, 2);
 
   svm->autoposttrain = flg;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -1938,12 +1818,11 @@ PetscErrorCode SVMSetAutoPostTrain(SVM svm,PetscBool flg)
 
   Level: developer
 @*/
-PetscErrorCode SVMGetAutoPostTrain(SVM svm,PetscBool *flg)
+PetscErrorCode SVMGetAutoPostTrain(SVM svm, PetscBool *flg)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(flg,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(flg, 2);
   *flg = svm->autoposttrain;
   PetscFunctionReturn(0);
 }
@@ -1964,9 +1843,8 @@ PetscErrorCode SVMGetAutoPostTrain(SVM svm,PetscBool *flg)
 @*/
 PetscErrorCode SVMTrain(SVM svm)
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   PetscCall(svm->ops->train(svm));
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
@@ -1987,26 +1865,26 @@ PetscErrorCode SVMTrain(SVM svm)
 @*/
 PetscErrorCode SVMPostTrain(SVM svm)
 {
-  PetscBool view;
-  PetscViewer v;
+  PetscBool         view;
+  PetscViewer       v;
   PetscViewerFormat format;
 
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   PetscCall(svm->ops->posttrain(svm));
 
-  PetscCall(PetscOptionsCreateViewer(((PetscObject) svm)->comm,NULL,((PetscObject) svm)->prefix,"-svm_view",&v,&format,&view));
+  PetscCall(PetscOptionsCreateViewer(((PetscObject)svm)->comm, NULL, ((PetscObject)svm)->prefix, "-svm_view", &v, &format, &view));
   if (view) {
-    PetscCall(PetscViewerPushFormat(v,format));
-    PetscCall(SVMView(svm,v));
+    PetscCall(PetscViewerPushFormat(v, format));
+    PetscCall(SVMView(svm, v));
     PetscCall(PetscViewerPopFormat(v));
   }
   PetscCall(PetscViewerDestroy(&v));
 
-  PetscCall(PetscOptionsCreateViewer(((PetscObject) svm)->comm,NULL,((PetscObject) svm)->prefix,"-svm_view_training_predictions",&v,&format,&view));
+  PetscCall(PetscOptionsCreateViewer(((PetscObject)svm)->comm, NULL, ((PetscObject)svm)->prefix, "-svm_view_training_predictions", &v, &format, &view));
   if (view) {
-    PetscCall(PetscViewerPushFormat(v,format));
-    PetscCall(SVMViewTrainingPredictions(svm,v));
+    PetscCall(PetscViewerPushFormat(v, format));
+    PetscCall(SVMViewTrainingPredictions(svm, v));
     PetscCall(PetscViewerPopFormat(v));
   }
   PetscCall(PetscViewerDestroy(&v));
@@ -2029,13 +1907,12 @@ PetscErrorCode SVMPostTrain(SVM svm)
 
 .seealso SVMSetBias()
 @*/
-PetscErrorCode SVMSetSeparatingHyperplane(SVM svm,Vec w,PetscReal b)
+PetscErrorCode SVMSetSeparatingHyperplane(SVM svm, Vec w, PetscReal b)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscTryMethod(svm,"SVMSetSeparatingHyperplane_C",(SVM,Vec,PetscReal),(svm,w,b));
+  PetscTryMethod(svm, "SVMSetSeparatingHyperplane_C", (SVM, Vec, PetscReal), (svm, w, b));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2057,13 +1934,12 @@ PetscErrorCode SVMSetSeparatingHyperplane(SVM svm,Vec w,PetscReal b)
 
 .seealso: SVMTrain(), SVMPredict(), SVMTest()
 @*/
-PetscErrorCode SVMGetSeparatingHyperplane(SVM svm,Vec *w,PetscReal *b)
+PetscErrorCode SVMGetSeparatingHyperplane(SVM svm, Vec *w, PetscReal *b)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscUseMethod(svm,"SVMGetSeparatingHyperplane_C",(SVM,Vec *,PetscReal *),(svm,w,b));
+  PetscUseMethod(svm, "SVMGetSeparatingHyperplane_C", (SVM, Vec *, PetscReal *), (svm, w, b));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2082,13 +1958,12 @@ PetscErrorCode SVMGetSeparatingHyperplane(SVM svm,Vec *w,PetscReal *b)
 
 .seealso SVMGetBias(), SVMSetMod()
 @*/
-PetscErrorCode SVMSetBias(SVM svm,PetscReal bias)
+PetscErrorCode SVMSetBias(SVM svm, PetscReal bias)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscTryMethod(svm,"SVMSetBias_C",(SVM,PetscReal),(svm,bias));
+  PetscTryMethod(svm, "SVMSetBias_C", (SVM, PetscReal), (svm, bias));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2109,27 +1984,26 @@ PetscErrorCode SVMSetBias(SVM svm,PetscReal bias)
 
 .seealso SVMSetBias(), SVMSetMod()
 @*/
-PetscErrorCode SVMGetBias(SVM svm,PetscReal *bias)
+PetscErrorCode SVMGetBias(SVM svm, PetscReal *bias)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscUseMethod(svm,"SVMGetBias_C",(SVM,PetscReal *),(svm,bias));
+  PetscUseMethod(svm, "SVMGetBias_C", (SVM, PetscReal *), (svm, bias));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /*@
 
 @*/
-PetscErrorCode SVMSetUserBias(SVM svm,PetscReal bias)
+PetscErrorCode SVMSetUserBias(SVM svm, PetscReal bias)
 {
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveReal(svm,bias,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(svm, bias, 2);
 
   if (svm->user_bias != bias) {
-    svm->user_bias = bias;
+    svm->user_bias   = bias;
     svm->setupcalled = PETSC_FALSE;
   }
   PetscFunctionReturn(0);
@@ -2138,10 +2012,10 @@ PetscErrorCode SVMSetUserBias(SVM svm,PetscReal bias)
 /*@
 
 @*/
-PetscErrorCode SVMGetUserBias(SVM svm,PetscReal *bias)
+PetscErrorCode SVMGetUserBias(SVM svm, PetscReal *bias)
 {
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   *bias = svm->user_bias;
   PetscFunctionReturn(0);
 }
@@ -2160,13 +2034,10 @@ PetscErrorCode SVMGetUserBias(SVM svm,PetscReal *bias)
 @*/
 PetscErrorCode SVMReconstructHyperplane(SVM svm)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  if (svm->ops->reconstructhyperplane) {
-    PetscCall(svm->ops->reconstructhyperplane(svm));
-  }
+  if (svm->ops->reconstructhyperplane) { PetscCall(svm->ops->reconstructhyperplane(svm)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2186,13 +2057,12 @@ PetscErrorCode SVMReconstructHyperplane(SVM svm)
 
 .seealso: SVMPredict()
 @*/
-PetscErrorCode SVMGetDistancesFromHyperplane(SVM svm,Mat Xt,Vec *dist)
+PetscErrorCode SVMGetDistancesFromHyperplane(SVM svm, Mat Xt, Vec *dist)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscUseMethod(svm,"SVMGetDistancesFromHyperplane_C",(SVM,Mat,Vec *),(svm,Xt,dist));
+  PetscUseMethod(svm, "SVMGetDistancesFromHyperplane_C", (SVM, Mat, Vec *), (svm, Xt, dist));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2214,12 +2084,11 @@ PetscErrorCode SVMGetDistancesFromHyperplane(SVM svm,Mat Xt,Vec *dist)
 
 .seealso: SVMTrain(), SVMTest()
 @*/
-PetscErrorCode SVMPredict(SVM svm,Mat Xt_pred,Vec *y_pred)
+PetscErrorCode SVMPredict(SVM svm, Mat Xt_pred, Vec *y_pred)
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscCall(svm->ops->predict(svm,Xt_pred,y_pred));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscCall(svm->ops->predict(svm, Xt_pred, y_pred));
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -2244,21 +2113,21 @@ PetscErrorCode SVMTest(SVM svm)
   PetscBool         view;
 
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   PetscCall(svm->ops->test(svm));
 
-  PetscCall(PetscOptionsCreateViewer(((PetscObject)svm)->comm,NULL,((PetscObject)svm)->prefix,"-svm_view_report",&v,&format,&view));
+  PetscCall(PetscOptionsCreateViewer(((PetscObject)svm)->comm, NULL, ((PetscObject)svm)->prefix, "-svm_view_report", &v, &format, &view));
   if (view) {
-    PetscCall(PetscViewerPushFormat(v,format));
-    PetscCall(SVMViewScore(svm,v));
+    PetscCall(PetscViewerPushFormat(v, format));
+    PetscCall(SVMViewScore(svm, v));
     PetscCall(PetscViewerPopFormat(v));
   }
   PetscCall(PetscViewerDestroy(&v));
 
-  PetscCall(PetscOptionsCreateViewer(((PetscObject)svm)->comm,NULL,((PetscObject)svm)->prefix,"-svm_view_test_predictions",&v,&format,&view));
+  PetscCall(PetscOptionsCreateViewer(((PetscObject)svm)->comm, NULL, ((PetscObject)svm)->prefix, "-svm_view_test_predictions", &v, &format, &view));
   if (view) {
-    PetscCall(PetscViewerPushFormat(v,format));
-    PetscCall(SVMViewTestPredictions(svm,v));
+    PetscCall(PetscViewerPushFormat(v, format));
+    PetscCall(SVMViewTestPredictions(svm, v));
     PetscCall(PetscViewerPopFormat(v));
   }
   PetscCall(PetscViewerDestroy(&v));
@@ -2272,9 +2141,8 @@ PetscErrorCode SVMTest(SVM svm)
 @*/
 PetscErrorCode SVMConvergedSetUp(SVM svm)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   // call specific implementation of setting convergence test
   if (svm->ops->convergedsetup) PetscCall(svm->ops->convergedsetup(svm));
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -2288,7 +2156,7 @@ PetscErrorCode SVMConvergedSetUp(SVM svm)
 PetscErrorCode SVMDefaultConvergedCreate(SVM svm, void **ctx)
 {
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   *ctx = svm;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2301,7 +2169,7 @@ PetscErrorCode SVMDefaultConvergedCreate(SVM svm, void **ctx)
 PetscErrorCode SVMDefaultConvergedDestroy(void *ctx)
 {
   PetscFunctionBegin;
-  PetscCall(SVMDestroy((SVM*)&ctx));
+  PetscCall(SVMDestroy((SVM *)&ctx));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2321,13 +2189,12 @@ PetscErrorCode SVMDefaultConvergedDestroy(void *ctx)
 
 .seealso ModelScore, SVMComputeModelScores()
 @*/
-PetscErrorCode SVMGetModelScore(SVM svm,ModelScore score_type,PetscReal *s)
+PetscErrorCode SVMGetModelScore(SVM svm, ModelScore score_type, PetscReal *s)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
 
-  PetscUseMethod(svm,"SVMGetModelScore_C",(SVM,ModelScore,PetscReal *),(svm,score_type,s));
+  PetscUseMethod(svm, "SVMGetModelScore_C", (SVM, ModelScore, PetscReal *), (svm, score_type, s));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2345,12 +2212,11 @@ PetscErrorCode SVMGetModelScore(SVM svm,ModelScore score_type,PetscReal *s)
 
 .seealso SVMGridSearch(), SVMCrossValidation(), SVM
 @*/
-PetscErrorCode SVMSetHyperOpt(SVM svm,PetscBool flg)
+PetscErrorCode SVMSetHyperOpt(SVM svm, PetscBool flg)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveBool(svm,2,flg);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveBool(svm, 2, flg);
   svm->hyperoptset = flg;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2371,9 +2237,8 @@ PetscErrorCode SVMSetHyperOpt(SVM svm,PetscBool flg)
 @*/
 PetscErrorCode SVMGridSearch(SVM svm)
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
   PetscCall(svm->ops->gridsearch(svm));
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
@@ -2391,14 +2256,14 @@ PetscErrorCode SVMGridSearch(SVM svm)
 
 .seealso SVMGetHyperOptScoreTypes(), ModelScore
 @*/
-PetscErrorCode SVMSetHyperOptScoreTypes(SVM svm,PetscInt n,ModelScore types[])
+PetscErrorCode SVMSetHyperOptScoreTypes(SVM svm, PetscInt n, ModelScore types[])
 {
   PetscInt i;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  for (i = 0; i < n; ++i) PetscValidLogicalCollectiveEnum(svm,types[i],2);
-  PetscCall(PetscMemcpy(svm->hopt_score_types,types,n * sizeof(ModelScore)));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  for (i = 0; i < n; ++i) PetscValidLogicalCollectiveEnum(svm, types[i], 2);
+  PetscCall(PetscMemcpy(svm->hopt_score_types, types, n * sizeof(ModelScore)));
   svm->hopt_nscore_types = n;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2418,12 +2283,11 @@ PetscErrorCode SVMSetHyperOptScoreTypes(SVM svm,PetscInt n,ModelScore types[])
 
 seealso SVMSetHyperOptScoreTypes, ModelScore
 @*/
-PetscErrorCode SVMGetHyperOptNScoreTypes(SVM svm,PetscInt *n)
+PetscErrorCode SVMGetHyperOptNScoreTypes(SVM svm, PetscInt *n)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(n,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(n, 2);
   *n = svm->hopt_nscore_types;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2443,12 +2307,11 @@ PetscErrorCode SVMGetHyperOptNScoreTypes(SVM svm,PetscInt *n)
 
 .seealso SVMSetHyperOptScoreTypes(), ModelScore
 @*/
-PetscErrorCode SVMGetHyperOptScoreTypes(SVM svm,const ModelScore *types[])
+PetscErrorCode SVMGetHyperOptScoreTypes(SVM svm, const ModelScore *types[])
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(types,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(types, 2);
   *types = svm->hopt_score_types;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2466,12 +2329,11 @@ PetscErrorCode SVMGetHyperOptScoreTypes(SVM svm,const ModelScore *types[])
 
 .seealso SVMGetCrossValidationType(), CrossValidationType
 @*/
-PetscErrorCode SVMSetCrossValidationType(SVM svm,CrossValidationType type)
+PetscErrorCode SVMSetCrossValidationType(SVM svm, CrossValidationType type)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidLogicalCollectiveEnum(svm,type,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidLogicalCollectiveEnum(svm, type, 2);
   svm->cv_type = type;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2491,12 +2353,11 @@ PetscErrorCode SVMSetCrossValidationType(SVM svm,CrossValidationType type)
 
 .seealso SVMSetCrossValidationType(), CrossValidationType
 @*/
-PetscErrorCode SVMGetCrossValidationType(SVM svm,CrossValidationType *type)
+PetscErrorCode SVMGetCrossValidationType(SVM svm, CrossValidationType *type)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscAssertPointer(type,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscAssertPointer(type, 2);
   *type = svm->cv_type;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2520,12 +2381,11 @@ PetscErrorCode SVMGetCrossValidationType(SVM svm,CrossValidationType *type)
 
 .seealso: SVMKFoldCrossValidation(), SVMStratifiedKFoldCrossValidation(), SVMGridSearch(), SVMSetNfolds(), SVM
 @*/
-PetscErrorCode SVMCrossValidation(SVM svm,PetscReal c_arr[],PetscInt m,PetscReal score[])
+PetscErrorCode SVMCrossValidation(SVM svm, PetscReal c_arr[], PetscInt m, PetscReal score[])
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscCall(svm->ops->crossvalidation(svm,c_arr,m,score));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscCall(svm->ops->crossvalidation(svm, c_arr, m, score));
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -2548,12 +2408,11 @@ PetscErrorCode SVMCrossValidation(SVM svm,PetscReal c_arr[],PetscInt m,PetscReal
 
 .seealso: SVMStratifiedKFoldCrossValidation(), SVMGridSearch(), SVMSetNfolds(), SVM
 @*/
-PetscErrorCode SVMKFoldCrossValidation(SVM svm,PetscReal c_arr[],PetscInt m,PetscReal score[])
+PetscErrorCode SVMKFoldCrossValidation(SVM svm, PetscReal c_arr[], PetscInt m, PetscReal score[])
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscTryMethod(svm,"SVMKFoldCrossValidation_C",(SVM,PetscReal [],PetscInt, PetscReal []),(svm,c_arr,m,score));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscTryMethod(svm, "SVMKFoldCrossValidation_C", (SVM, PetscReal[], PetscInt, PetscReal[]), (svm, c_arr, m, score));
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -2562,12 +2421,11 @@ PetscErrorCode SVMKFoldCrossValidation(SVM svm,PetscReal c_arr[],PetscInt m,Pets
 /*@
 
 @*/
-PetscErrorCode SVMStratifiedKFoldCrossValidation(SVM svm,PetscReal c_arr[],PetscInt m,PetscReal score[])
+PetscErrorCode SVMStratifiedKFoldCrossValidation(SVM svm, PetscReal c_arr[], PetscInt m, PetscReal score[])
 {
-
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscTryMethod(svm,"SVMStratifiedKFoldCrossValidation_C",(SVM,PetscReal [],PetscInt, PetscReal []),(svm,c_arr,m,score));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscTryMethod(svm, "SVMStratifiedKFoldCrossValidation_C", (SVM, PetscReal[], PetscInt, PetscReal[]), (svm, c_arr, m, score));
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
 
@@ -2587,14 +2445,11 @@ PetscErrorCode SVMStratifiedKFoldCrossValidation(SVM svm,PetscReal c_arr[],Petsc
 
 .seealso SVMTrain(), SVMTest(), SVMGetModelScores()
 @*/
-PetscErrorCode SVMComputeModelScores(SVM svm,Vec y_pred,Vec y_known)
+PetscErrorCode SVMComputeModelScores(SVM svm, Vec y_pred, Vec y_known)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (svm->ops->computemodelscores) {
-    PetscCall(svm->ops->computemodelscores(svm,y_pred,y_known));
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (svm->ops->computemodelscores) { PetscCall(svm->ops->computemodelscores(svm, y_pred, y_known)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2614,12 +2469,9 @@ PetscErrorCode SVMComputeModelScores(SVM svm,Vec y_pred,Vec y_known)
 @*/
 PetscErrorCode SVMComputeHingeLoss(SVM svm)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (svm->ops->computehingeloss) {
-    PetscCall(svm->ops->computehingeloss(svm));
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (svm->ops->computehingeloss) { PetscCall(svm->ops->computehingeloss(svm)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2639,12 +2491,9 @@ PetscErrorCode SVMComputeHingeLoss(SVM svm)
 @*/
 PetscErrorCode SVMComputeModelParams(SVM svm)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  if (svm->ops->computemodelparams) {
-    PetscCall(svm->ops->computemodelparams(svm));
-  }
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  if (svm->ops->computemodelparams) { PetscCall(svm->ops->computemodelparams(svm)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2663,26 +2512,24 @@ PetscErrorCode SVMComputeModelParams(SVM svm)
 
 .seealso SVM, SVMSetGramian(), SVMGetGramian(), SVMViewGramian(), SVMLoadTrainingDataset()
 @*/
-PetscErrorCode SVMLoadGramian(SVM svm,PetscViewer v)
+PetscErrorCode SVMLoadGramian(SVM svm, PetscViewer v)
 {
-  MPI_Comm   comm;
-  PetscBool  view_io,view_dataset;
+  MPI_Comm  comm;
+  PetscBool view_io, view_dataset;
 
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
 
-  PetscCall(PetscLogEventBegin(SVM_LoadGramian,svm,0,0,0));
-  if (svm->ops->loadgramian) {
-    PetscCall(svm->ops->loadgramian(svm,v));
-  }
-  PetscCall(PetscLogEventEnd(SVM_LoadGramian,svm,0,0,0));
+  PetscCall(PetscLogEventBegin(SVM_LoadGramian, svm, 0, 0, 0));
+  if (svm->ops->loadgramian) { PetscCall(svm->ops->loadgramian(svm, v)); }
+  PetscCall(PetscLogEventEnd(SVM_LoadGramian, svm, 0, 0, 0));
 
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_io",&view_io));
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_gramian",&view_dataset));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_io", &view_io));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_gramian", &view_dataset));
   if (view_io || view_dataset) {
-    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
-    PetscCall(SVMViewGramian(svm,PETSC_VIEWER_STDOUT_(comm)));
+    PetscCall(PetscObjectGetComm((PetscObject)v, &comm));
+    PetscCall(SVMViewGramian(svm, PETSC_VIEWER_STDOUT_(comm)));
   }
   PetscFunctionReturnI(PETSC_SUCCESS);
 }
@@ -2702,16 +2549,13 @@ PetscErrorCode SVMLoadGramian(SVM svm,PetscViewer v)
 
 .seealso SVM, SVMSetGramian(), SVMGetGramian(), SVMLoadGramian(), SVMViewTrainingDataset()
 @*/
-PetscErrorCode SVMViewGramian(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewGramian(SVM svm, PetscViewer v)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
 
-  if (svm->ops->viewgramian) {
-    PetscCall(svm->ops->viewgramian(svm,v) );
-  }
+  if (svm->ops->viewgramian) { PetscCall(svm->ops->viewgramian(svm, v)); }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2730,33 +2574,33 @@ PetscErrorCode SVMViewGramian(SVM svm,PetscViewer v)
 
 .seealso SVM
 @*/
-PetscErrorCode SVMLoadDataset(SVM svm,PetscViewer v,Mat Xt,Vec y)
+PetscErrorCode SVMLoadDataset(SVM svm, PetscViewer v, Mat Xt, Vec y)
 {
   const char *type_name = NULL;
-  PetscBool  isascii,ishdf5,isbinary;
+  PetscBool   isascii, ishdf5, isbinary;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
-  PetscValidHeaderSpecific(Xt,MAT_CLASSID,3);
-  PetscCheckSameComm(svm,1,Xt,3);
-  PetscValidHeaderSpecific(y,VEC_CLASSID,4);
-  PetscCheckSameComm(svm,1,y,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
+  PetscValidHeaderSpecific(Xt, MAT_CLASSID, 3);
+  PetscCheckSameComm(svm, 1, Xt, 3);
+  PetscValidHeaderSpecific(y, VEC_CLASSID, 4);
+  PetscCheckSameComm(svm, 1, y, 4);
 
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERASCII,&isascii));
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERHDF5,&ishdf5));
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERBINARY,&isbinary));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERHDF5, &ishdf5));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERBINARY, &isbinary));
 
-  PetscCall(PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0));
+  PetscCall(PetscLogEventBegin(SVM_LoadDataset, svm, 0, 0, 0));
   if (isascii) {
-    PetscCall(DatasetLoad_SVMLight(Xt,y,v));
+    PetscCall(DatasetLoad_SVMLight(Xt, y, v));
   } else if (ishdf5 || isbinary) {
-    PetscCall(DatasetLoad_Binary(Xt,y,v));
+    PetscCall(DatasetLoad_Binary(Xt, y, v));
   } else {
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
-    SETERRQ(PetscObjectComm((PetscObject) v),PETSC_ERR_SUP,"Viewer type %s not supported for SVMLoadDataset",type_name);
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
+    SETERRQ(PetscObjectComm((PetscObject)v), PETSC_ERR_SUP, "Viewer type %s not supported for SVMLoadDataset", type_name);
   }
-  PetscCall(PetscLogEventEnd(SVM_LoadDataset,svm,0,0,0));
+  PetscCall(PetscLogEventEnd(SVM_LoadDataset, svm, 0, 0, 0));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -2773,51 +2617,49 @@ PetscErrorCode SVMLoadDataset(SVM svm,PetscViewer v,Mat Xt,Vec y)
 
 .seealso SVMLoadCalibrationDataset(), SVMLoadTestDataset(), SVM
 @*/
-PetscErrorCode SVMLoadTrainingDataset(SVM svm,PetscViewer v)
+PetscErrorCode SVMLoadTrainingDataset(SVM svm, PetscViewer v)
 {
-  MPI_Comm  comm;
+  MPI_Comm comm;
 
-  Mat       Xt_training;
-  Mat       Xt_biased;
-  Vec       y_training;
+  Mat Xt_training;
+  Mat Xt_biased;
+  Vec y_training;
 
   PetscReal user_bias;
   PetscInt  mod;
 
-  PetscBool view_io,view_dataset;
+  PetscBool view_io, view_dataset;
 
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
 
-  PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
   /* Create matrix of training samples */
-  PetscCall(MatCreate(comm,&Xt_training));
-  PetscCall(PetscObjectSetName((PetscObject) Xt_training,"Xt_training"));
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) Xt_training,"Xt_training_"));
+  PetscCall(MatCreate(comm, &Xt_training));
+  PetscCall(PetscObjectSetName((PetscObject)Xt_training, "Xt_training"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)Xt_training, "Xt_training_"));
   PetscCall(MatSetFromOptions(Xt_training));
 
-  PetscCall(VecCreate(comm,&y_training));
-  PetscCall(PetscObjectSetName((PetscObject) y_training,"y_training"));
+  PetscCall(VecCreate(comm, &y_training));
+  PetscCall(PetscObjectSetName((PetscObject)y_training, "y_training"));
   PetscCall(VecSetFromOptions(y_training));
 
-  PetscCall(PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0));
-  PetscCall(PetscViewerLoadSVMDataset(Xt_training,y_training,v));
-  PetscCall(PetscLogEventEnd(SVM_LoadDataset,svm,0,0,0));
+  PetscCall(PetscLogEventBegin(SVM_LoadDataset, svm, 0, 0, 0));
+  PetscCall(PetscViewerLoadSVMDataset(Xt_training, y_training, v));
+  PetscCall(PetscLogEventEnd(SVM_LoadDataset, svm, 0, 0, 0));
 
-  PetscCall(SVMGetMod(svm,&mod));
+  PetscCall(SVMGetMod(svm, &mod));
   if (mod == 2) {
-    PetscCall(SVMGetUserBias(svm,&user_bias));
-    PetscCall(MatBiasedCreate(Xt_training,user_bias,&Xt_biased));
+    PetscCall(SVMGetUserBias(svm, &user_bias));
+    PetscCall(MatBiasedCreate(Xt_training, user_bias, &Xt_biased));
     Xt_training = Xt_biased;
   }
-  PetscCall(SVMSetTrainingDataset(svm,Xt_training,y_training));
+  PetscCall(SVMSetTrainingDataset(svm, Xt_training, y_training));
 
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_io",&view_io));
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_training_dataset",&view_dataset));
-  if (view_io || view_dataset) {
-    PetscCall(SVMViewTrainingDataset(svm,PETSC_VIEWER_STDOUT_(PetscObjectComm((PetscObject) v))));
-  }
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_io", &view_io));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_training_dataset", &view_dataset));
+  if (view_io || view_dataset) { PetscCall(SVMViewTrainingDataset(svm, PETSC_VIEWER_STDOUT_(PetscObjectComm((PetscObject)v)))); }
 
   /* Free memory */
   PetscCall(MatDestroy(&Xt_training));
@@ -2842,29 +2684,29 @@ PetscErrorCode SVMLoadTrainingDataset(SVM svm,PetscViewer v)
 
 .seealso SVM, PetscViewer, SVMViewDataset(), SVMViewTestDataset()
 @*/
-PetscErrorCode SVMViewTrainingDataset(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTrainingDataset(SVM svm, PetscViewer v)
 {
-  Mat        Xt;
-  Vec        y;
+  Mat Xt;
+  Vec y;
 
-  PetscBool  isascii;
+  PetscBool   isascii;
   const char *type_name = NULL;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetTrainingDataset(svm,&Xt,&y));
-  PetscCheck(Xt && y,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Training dataset is not set");
+  PetscCall(SVMGetTrainingDataset(svm, &Xt, &y));
+  PetscCheck(Xt && y, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Training dataset is not set");
 
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
     /* Print info related to svm type */
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
 
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(SVMViewDataset(svm,Xt,y,v));
+    PetscCall(SVMViewDataset(svm, Xt, y, v));
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
-    SETERRQ(PetscObjectComm((PetscObject) v),PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewTrainingDataset",type_name);
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
+    SETERRQ(PetscObjectComm((PetscObject)v), PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewTrainingDataset", type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -2882,51 +2724,51 @@ PetscErrorCode SVMViewTrainingDataset(SVM svm,PetscViewer v)
 
 .seealso SVMLoadTrainingDataset(), SVMLoadCalibrationDataset(), SVM
 @*/
-PetscErrorCode SVMLoadTestDataset(SVM svm,PetscViewer v)
+PetscErrorCode SVMLoadTestDataset(SVM svm, PetscViewer v)
 {
-  MPI_Comm    comm;
+  MPI_Comm comm;
 
-  Mat         Xt_test;
-  Mat         Xt_biased;
-  Vec         y_test;
+  Mat Xt_test;
+  Mat Xt_biased;
+  Vec y_test;
 
-  PetscReal   user_bias;
-  PetscInt    mod;
+  PetscReal user_bias;
+  PetscInt  mod;
 
-  PetscBool  view_io,view_test_dataset;
+  PetscBool view_io, view_test_dataset;
 
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
 
-  PetscCall(PetscObjectGetComm((PetscObject) svm,&comm));
-  PetscCall(MatCreate(comm,&Xt_test));
+  PetscCall(PetscObjectGetComm((PetscObject)svm, &comm));
+  PetscCall(MatCreate(comm, &Xt_test));
   /* Create matrix of test samples */
-  PetscCall(PetscObjectSetName((PetscObject) Xt_test,"Xt_test"));
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) Xt_test,"Xt_test_"));
+  PetscCall(PetscObjectSetName((PetscObject)Xt_test, "Xt_test"));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)Xt_test, "Xt_test_"));
   PetscCall(MatSetFromOptions(Xt_test));
   /* Create label vector of test samples */
-  PetscCall(VecCreate(comm,&y_test));
+  PetscCall(VecCreate(comm, &y_test));
   PetscCall(VecSetFromOptions(y_test));
-  PetscCall(PetscObjectSetName((PetscObject) y_test,"y_test"));
+  PetscCall(PetscObjectSetName((PetscObject)y_test, "y_test"));
 
-  PetscCall(PetscLogEventBegin(SVM_LoadDataset,svm,0,0,0));
-  PetscCall(PetscViewerLoadSVMDataset(Xt_test,y_test,v));
-  PetscCall(PetscLogEventEnd(SVM_LoadDataset,svm,0,0,0));
+  PetscCall(PetscLogEventBegin(SVM_LoadDataset, svm, 0, 0, 0));
+  PetscCall(PetscViewerLoadSVMDataset(Xt_test, y_test, v));
+  PetscCall(PetscLogEventEnd(SVM_LoadDataset, svm, 0, 0, 0));
 
-  PetscCall(SVMGetMod(svm,&mod));
+  PetscCall(SVMGetMod(svm, &mod));
   if (mod == 2) {
-    PetscCall(SVMGetUserBias(svm,&user_bias));
-    PetscCall(MatBiasedCreate(Xt_test,user_bias,&Xt_biased));
+    PetscCall(SVMGetUserBias(svm, &user_bias));
+    PetscCall(MatBiasedCreate(Xt_test, user_bias, &Xt_biased));
     Xt_test = Xt_biased;
   }
-  PetscCall(SVMSetTestDataset(svm,Xt_test,y_test));
+  PetscCall(SVMSetTestDataset(svm, Xt_test, y_test));
 
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_io",&view_io));
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_test_dataset",&view_test_dataset));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_io", &view_io));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_test_dataset", &view_test_dataset));
   if (view_io || view_test_dataset) {
-    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
-    PetscCall(SVMViewTestDataset(svm,PETSC_VIEWER_STDOUT_(comm)));
+    PetscCall(PetscObjectGetComm((PetscObject)v, &comm));
+    PetscCall(SVMViewTestDataset(svm, PETSC_VIEWER_STDOUT_(comm)));
   }
 
   /* Free memory */
@@ -2952,32 +2794,32 @@ PetscErrorCode SVMLoadTestDataset(SVM svm,PetscViewer v)
 
 .seealso SVM, PetscViewer, SVMViewDataset(), SVMViewTrainingDataset()
 @*/
-PetscErrorCode SVMViewTestDataset(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewTestDataset(SVM svm, PetscViewer v)
 {
-  Mat        Xt;
-  Vec        y;
+  Mat Xt;
+  Vec y;
 
-  PetscBool  isascii;
+  PetscBool   isascii;
   const char *type_name = NULL;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
 
-  PetscCall(SVMGetTestDataset(svm,&Xt,&y));
-  PetscCheck(Xt && y,PetscObjectComm((PetscObject) v),PETSC_ERR_ARG_NULL,"Test dataset is not set");
+  PetscCall(SVMGetTestDataset(svm, &Xt, &y));
+  PetscCheck(Xt && y, PetscObjectComm((PetscObject)v), PETSC_ERR_ARG_NULL, "Test dataset is not set");
 
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
     /* Print info related to svm type */
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) svm,v));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)svm, v));
 
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(SVMViewDataset(svm,Xt,y,v));
+    PetscCall(SVMViewDataset(svm, Xt, y, v));
     PetscCall(PetscViewerASCIIPopTab(v));
   } else {
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
-    SETERRQ(PetscObjectComm((PetscObject) v),PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewTestDataset",type_name);
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
+    SETERRQ(PetscObjectComm((PetscObject)v), PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewTestDataset", type_name);
   }
   PetscFunctionReturn(0);
 }
@@ -2995,21 +2837,21 @@ PetscErrorCode SVMViewTestDataset(SVM svm,PetscViewer v)
 
 .seealso SVMLoadTrainingDataset(), SVMLoadTestDataset(), SVM
 @*/
-PetscErrorCode SVMLoadCalibrationDataset(SVM svm,PetscViewer v)
+PetscErrorCode SVMLoadCalibrationDataset(SVM svm, PetscViewer v)
 {
   MPI_Comm  comm;
-  PetscBool view_io,view_calibration_dataset;
+  PetscBool view_io, view_calibration_dataset;
 
   PetscFunctionBeginI;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,2);
-  PetscTryMethod(svm,"SVMLoadCalibrationDataset_C",(SVM,PetscViewer),(svm,v));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 2);
+  PetscTryMethod(svm, "SVMLoadCalibrationDataset_C", (SVM, PetscViewer), (svm, v));
 
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_io",&view_io));
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-svm_view_calibration_dataset",&view_calibration_dataset));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_io", &view_io));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-svm_view_calibration_dataset", &view_calibration_dataset));
   if (view_io || view_calibration_dataset) {
-    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
-    PetscCall(SVMViewCalibrationDataset(svm,PETSC_VIEWER_STDOUT_(comm)));
+    PetscCall(PetscObjectGetComm((PetscObject)v, &comm));
+    PetscCall(SVMViewCalibrationDataset(svm, PETSC_VIEWER_STDOUT_(comm)));
   }
   PetscFunctionReturnI(0);
 }
@@ -3029,12 +2871,11 @@ PetscErrorCode SVMLoadCalibrationDataset(SVM svm,PetscViewer v)
 
 .seealso SVM, PetscViewer, SVMViewDataset(), SVMViewTrainingDataset(), SVMViewTestDataset()
 @*/
-PetscErrorCode SVMViewCalibrationDataset(SVM svm,PetscViewer v)
+PetscErrorCode SVMViewCalibrationDataset(SVM svm, PetscViewer v)
 {
-
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscTryMethod(svm,"SVMViewCalibrationDataset_C",(SVM,PetscViewer),(svm,v));
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscTryMethod(svm, "SVMViewCalibrationDataset_C", (SVM, PetscViewer), (svm, v));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -3051,72 +2892,72 @@ PetscErrorCode SVMViewCalibrationDataset(SVM svm,PetscViewer v)
 
 .seealso SVM, PetscViewer, SVMViewTestDataset(), SVMViewTrainingDataset()
 @*/
-PetscErrorCode SVMViewDataset(SVM svm,Mat Xt,Vec y,PetscViewer v)
+PetscErrorCode SVMViewDataset(SVM svm, Mat Xt, Vec y, PetscViewer v)
 {
-  MPI_Comm   comm;
+  MPI_Comm    comm;
   const char *type_name = NULL;
 
-  PetscInt   M,M_plus,M_minus,N;
-  PetscReal  per_plus,per_minus;
+  PetscInt  M, M_plus, M_minus, N;
+  PetscReal per_plus, per_minus;
 
-  PetscInt   svm_mod;
+  PetscInt svm_mod;
 
-  Mat        Xt_inner;
-  PetscReal  bias;
+  Mat       Xt_inner;
+  PetscReal bias;
 
-  Vec        y_max = NULL;
-  IS         is_plus = NULL;
-  PetscReal  max;
+  Vec       y_max   = NULL;
+  IS        is_plus = NULL;
+  PetscReal max;
 
-  PetscBool  isascii;
+  PetscBool isascii;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(svm,SVM_CLASSID,1);
-  PetscValidHeaderSpecific(Xt,MAT_CLASSID,2);
-  PetscValidHeaderSpecific(y,VEC_CLASSID,3);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,4);
+  PetscValidHeaderSpecific(svm, SVM_CLASSID, 1);
+  PetscValidHeaderSpecific(Xt, MAT_CLASSID, 2);
+  PetscValidHeaderSpecific(y, VEC_CLASSID, 3);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 4);
 
-  PetscCall(PetscObjectTypeCompare((PetscObject)v,PETSCVIEWERASCII,&isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
   if (isascii) {
-    PetscCall(MatGetSize(Xt,&M,&N));
+    PetscCall(MatGetSize(Xt, &M, &N));
 
-    PetscCall(VecDuplicate(y,&y_max));
-    PetscCall(VecMax(y,NULL,&max));
-    PetscCall(VecSet(y_max,max));
+    PetscCall(VecDuplicate(y, &y_max));
+    PetscCall(VecMax(y, NULL, &max));
+    PetscCall(VecSet(y_max, max));
 
-    PetscCall(VecWhichEqual(y,y_max,&is_plus));
-    PetscCall(ISGetSize(is_plus,&M_plus));
+    PetscCall(VecWhichEqual(y, y_max, &is_plus));
+    PetscCall(ISGetSize(is_plus, &M_plus));
 
-    per_plus  = ((PetscReal) M_plus / (PetscReal) M) * 100.;
+    per_plus  = ((PetscReal)M_plus / (PetscReal)M) * 100.;
     M_minus   = M - M_plus;
     per_minus = 100. - per_plus;
 
-    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) Xt,v));
-    PetscCall(SVMGetMod(svm,&svm_mod));
+    PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)Xt, v));
+    PetscCall(SVMGetMod(svm, &svm_mod));
     if (svm_mod == 2) {
       N -= 1;
 
-      PetscCall(MatBiasedGetInnerMat(Xt,&Xt_inner));
-      PetscCall(MatBiasedGetBias(Xt,&bias));
+      PetscCall(MatBiasedGetInnerMat(Xt, &Xt_inner));
+      PetscCall(MatBiasedGetBias(Xt, &bias));
 
       PetscCall(PetscViewerASCIIPushTab(v));
-      PetscCall(PetscViewerASCIIPrintf(v,"Samples are augmented with additional dimension by means of bias %.2f\n",bias));
-      PetscCall(PetscViewerASCIIPrintf(v,"inner"));
-      PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject) Xt_inner,v));
+      PetscCall(PetscViewerASCIIPrintf(v, "Samples are augmented with additional dimension by means of bias %.2f\n", bias));
+      PetscCall(PetscViewerASCIIPrintf(v, "inner"));
+      PetscCall(PetscObjectPrintClassNamePrefixType((PetscObject)Xt_inner, v));
       PetscCall(PetscViewerASCIIPopTab(v));
 
       PetscCall(PetscViewerASCIIPushTab(v));
     }
 
     PetscCall(PetscViewerASCIIPushTab(v));
-    PetscCall(PetscViewerASCIIPrintf(v,"samples\t%5" PetscInt_FMT "\n",M));
-    PetscCall(PetscViewerASCIIPrintf(v,"samples+\t%5" PetscInt_FMT " (%.2f%%)\n",M_plus,(double)per_plus));
-    PetscCall(PetscViewerASCIIPrintf(v,"samples-\t%5" PetscInt_FMT " (%.2f%%)\n",M_minus,(double)per_minus));
+    PetscCall(PetscViewerASCIIPrintf(v, "samples\t%5" PetscInt_FMT "\n", M));
+    PetscCall(PetscViewerASCIIPrintf(v, "samples+\t%5" PetscInt_FMT " (%.2f%%)\n", M_plus, (double)per_plus));
+    PetscCall(PetscViewerASCIIPrintf(v, "samples-\t%5" PetscInt_FMT " (%.2f%%)\n", M_minus, (double)per_minus));
     if (svm_mod == 2) {
-      PetscCall(PetscViewerASCIIPrintf(v,"features\t%5" PetscInt_FMT " (%" PetscInt_FMT ")\n",N,N + 1));
+      PetscCall(PetscViewerASCIIPrintf(v, "features\t%5" PetscInt_FMT " (%" PetscInt_FMT ")\n", N, N + 1));
       PetscCall(PetscViewerASCIIPopTab(v));
     } else {
-      PetscCall(PetscViewerASCIIPrintf(v,"features\t%5" PetscInt_FMT "\n",N));
+      PetscCall(PetscViewerASCIIPrintf(v, "features\t%5" PetscInt_FMT "\n", N));
     }
     PetscCall(PetscViewerASCIIPopTab(v));
 
@@ -3124,10 +2965,10 @@ PetscErrorCode SVMViewDataset(SVM svm,Mat Xt,Vec y,PetscViewer v)
     PetscCall(VecDestroy(&y_max));
     PetscCall(ISDestroy(&is_plus));
   } else {
-    PetscCall(PetscObjectGetComm((PetscObject) v,&comm));
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
+    PetscCall(PetscObjectGetComm((PetscObject)v, &comm));
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
 
-    SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for SVMViewDataset",type_name);
+    SETERRQ(comm, PETSC_ERR_SUP, "Viewer type %s not supported for SVMViewDataset", type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/interface/svmregis.c
+++ b/src/svm/interface/svmregis.c
@@ -1,7 +1,7 @@
 #include <permon/private/svmimpl.h>
 
-FLLOP_EXTERN PetscErrorCode SVMCreate_Binary(SVM);
-FLLOP_EXTERN PetscErrorCode SVMCreate_Probability(SVM);
+PERMON_EXTERN PetscErrorCode SVMCreate_Binary(SVM);
+PERMON_EXTERN PetscErrorCode SVMCreate_Probability(SVM);
 
 /*
    Contains the list of registered Create routines of all SVM types

--- a/src/svm/interface/svmregis.c
+++ b/src/svm/interface/svmregis.c
@@ -1,4 +1,3 @@
-
 #include <permon/private/svmimpl.h>
 
 FLLOP_EXTERN PetscErrorCode SVMCreate_Binary(SVM);

--- a/src/svm/interface/svmregis.c
+++ b/src/svm/interface/svmregis.c
@@ -6,29 +6,27 @@ PERMON_EXTERN PetscErrorCode SVMCreate_Probability(SVM);
 /*
    Contains the list of registered Create routines of all SVM types
 */
-PetscFunctionList SVMList = 0;
-PetscBool SVMRegisterAllCalled = PETSC_FALSE;
+PetscFunctionList SVMList              = 0;
+PetscBool         SVMRegisterAllCalled = PETSC_FALSE;
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMRegisterAll"
 PetscErrorCode SVMRegisterAll()
 {
-
   PetscFunctionBegin;
   if (SVMRegisterAllCalled) PetscFunctionReturn(PETSC_SUCCESS);
   SVMRegisterAllCalled = PETSC_TRUE;
 
-  PetscCall(SVMRegister(SVM_BINARY,SVMCreate_Binary));
-  PetscCall(SVMRegister(SVM_PROBABILITY,SVMCreate_Probability));
+  PetscCall(SVMRegister(SVM_BINARY, SVMCreate_Binary));
+  PetscCall(SVMRegister(SVM_PROBABILITY, SVMCreate_Probability));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "SVMRegister"
-PetscErrorCode SVMRegister(const char sname[],PetscErrorCode (*function)(SVM))
+PetscErrorCode SVMRegister(const char sname[], PetscErrorCode (*function)(SVM))
 {
-
   PetscFunctionBegin;
-  PetscCall(PetscFunctionListAdd(&SVMList,sname,function));
+  PetscCall(PetscFunctionListAdd(&SVMList, sname, function));
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/utils/io.c
+++ b/src/svm/utils/io.c
@@ -6,41 +6,41 @@
 
 #include <limits.h>
 #if defined(PETSC_HAVE_UNISTD_H)
-#include <unistd.h>
+  #include <unistd.h>
 #endif
 
 #define DARRAY_INIT_CAPACITY 4
-#define DARRAY_GROW_FACTOR 2.0
+#define DARRAY_GROW_FACTOR   2.0
 
 #define DynamicArray_(type) \
-  {                               \
-    type      *data;              \
-    PetscInt  capacity;           \
-    PetscInt  size;               \
-    PetscReal grow_factor;        \
+  { \
+    type     *data; \
+    PetscInt  capacity; \
+    PetscInt  size; \
+    PetscReal grow_factor; \
   }
 
-#define DynamicArrayInit(a,_capacity_,_grow_factor_)      \
-  PetscCall(PetscMalloc(_capacity_ * sizeof(*a.data),&a.data)); \
-  a.size = 0;                                                   \
-  a.capacity = _capacity_;                                      \
+#define DynamicArrayInit(a, _capacity_, _grow_factor_) \
+  PetscCall(PetscMalloc(_capacity_ * sizeof(*a.data), &a.data)); \
+  a.size        = 0; \
+  a.capacity    = _capacity_; \
   a.grow_factor = _grow_factor_;
 
 #define DynamicArrayClear(a) \
   PetscCall(PetscFree(a.data)); \
-  a.capacity = 0;           \
-  a.size = 0;
+  a.capacity = 0; \
+  a.size     = 0;
 
-#define DynamicArrayPushBack(a,v) \
+#define DynamicArrayPushBack(a, v) \
   if (a.capacity == a.size) DynamicArrayResize(a); \
-  a.data[a.size] = v;                              \
+  a.data[a.size] = v; \
   ++a.size;
 
 #define DynamicArrayResize(a) \
   a.capacity = a.grow_factor * a.capacity; \
-  PetscCall(PetscRealloc(a.capacity * sizeof(*a.data),&a.data)); \
+  PetscCall(PetscRealloc(a.capacity * sizeof(*a.data), &a.data));
 
-#define DynamicArrayAddValue(a,v) \
+#define DynamicArrayAddValue(a, v) \
   PetscInt i; \
   for (i = 0; i < a.size; ++i) a.data[i] += v;
 
@@ -49,76 +49,69 @@ struct ArrReal DynamicArray_(PetscReal);
 
 #undef __FUNCT__
 #define __FUNCT__ "IOReadBuffer_SVMLight_Private"
-static PetscErrorCode IOReadBuffer_SVMLight_Private(MPI_Comm comm,const char *filename,char **chunk_buff)
+static PetscErrorCode IOReadBuffer_SVMLight_Private(MPI_Comm comm, const char *filename, char **chunk_buff)
 {
-  PetscMPIInt comm_size,comm_rank,chunk_size_reduced;
+  PetscMPIInt comm_size, comm_rank, chunk_size_reduced;
   MPI_File    fh;
-  char        *chunk_buff_inner;
-  PetscInt    overlap,nreads;
-  MPI_Offset  chunk_size,chunk_size_overlaped,chunk_size_shrink,chunk_size_tmp,p;
-  MPI_Offset  file_size,offset,offset_reduced;
-  PetscInt    eol_pos,eol_start;
+  char       *chunk_buff_inner;
+  PetscInt    overlap, nreads;
+  MPI_Offset  chunk_size, chunk_size_overlaped, chunk_size_shrink, chunk_size_tmp, p;
+  MPI_Offset  file_size, offset, offset_reduced;
+  PetscInt    eol_pos, eol_start;
   PetscBool   eol_found;
   PetscInt    i;
 
   PetscFunctionBegin;
-  PetscCallMPI(MPI_Comm_size(comm,&comm_size));
-  PetscCallMPI(MPI_Comm_rank(comm,&comm_rank));
+  PetscCallMPI(MPI_Comm_size(comm, &comm_size));
+  PetscCallMPI(MPI_Comm_rank(comm, &comm_rank));
 
   chunk_buff_inner = NULL;
-  overlap = PETSC_DECIDE;
-  eol_start = 0;
-  eol_pos = 0;
-  eol_found = PETSC_FALSE;
+  overlap          = PETSC_DECIDE;
+  eol_start        = 0;
+  eol_pos          = 0;
+  eol_found        = PETSC_FALSE;
 
-  PetscCall(PetscOptionsGetInt(NULL,NULL,"-svm_io_overlap",&overlap,NULL));
-  PetscCheck(overlap >= 0 || overlap == PETSC_DECIDE,comm, PETSC_ERR_ARG_OUTOFRANGE, "Overlap must be greater or equal to zero");
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-svm_io_overlap", &overlap, NULL));
+  PetscCheck(overlap >= 0 || overlap == PETSC_DECIDE, comm, PETSC_ERR_ARG_OUTOFRANGE, "Overlap must be greater or equal to zero");
 
-  PetscCallMPI(MPI_File_open(comm,filename,MPI_MODE_RDONLY,MPI_INFO_NULL,&fh));
-  PetscCallMPI(MPI_File_get_size(fh,&file_size));
+  PetscCallMPI(MPI_File_open(comm, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh));
+  PetscCallMPI(MPI_File_get_size(fh, &file_size));
 
   /* Determine overlap size of chunk buffers, and reading offsets */
   if (overlap == PETSC_DECIDE) {
     overlap = 200;
-    while (file_size / comm_size < overlap) {
-      overlap /= 10;
-    }
+    while (file_size / comm_size < overlap) { overlap /= 10; }
     if (overlap == 0) overlap = 1;
   }
 
-  chunk_size = file_size / comm_size + ((file_size % comm_size) > comm_rank);
+  chunk_size           = file_size / comm_size + ((file_size % comm_size) > comm_rank);
   chunk_size_overlaped = chunk_size;
-  if (comm_rank != comm_size-1) chunk_size_overlaped += overlap;
+  if (comm_rank != comm_size - 1) chunk_size_overlaped += overlap;
   {
     MPI_Offset chunk_size_o = chunk_size;
-    PetscCallMPI(MPI_Scan(&chunk_size_o,&offset,1,MPI_OFFSET,MPI_SUM,comm));
+    PetscCallMPI(MPI_Scan(&chunk_size_o, &offset, 1, MPI_OFFSET, MPI_SUM, comm));
   }
   offset -= chunk_size;
 
   /* Allocation of chunk buffers and reading appropriate part of file */
-  PetscCall(PetscMalloc(chunk_size_overlaped * sizeof(char),&chunk_buff_inner));
+  PetscCall(PetscMalloc(chunk_size_overlaped * sizeof(char), &chunk_buff_inner));
 
   /* Loop reading at most 32 bit Int bytes */
-  nreads = (PetscInt)(1 + ((chunk_size_overlaped-1)/PETSC_INT32_MAX)); /* ceil number of reads */
-  chunk_size_reduced = (PetscMPIInt)(chunk_size_overlaped/nreads);
-  for (i=0; i<nreads -1; i++) {
-    PetscCallMPI(MPI_File_read_at_all(fh,offset+i*chunk_size_reduced,&chunk_buff_inner[i*chunk_size_reduced],chunk_size_reduced,MPI_CHAR,MPI_STATUS_IGNORE));
-  }
+  nreads             = (PetscInt)(1 + ((chunk_size_overlaped - 1) / PETSC_INT32_MAX)); /* ceil number of reads */
+  chunk_size_reduced = (PetscMPIInt)(chunk_size_overlaped / nreads);
+  for (i = 0; i < nreads - 1; i++) { PetscCallMPI(MPI_File_read_at_all(fh, offset + i * chunk_size_reduced, &chunk_buff_inner[i * chunk_size_reduced], chunk_size_reduced, MPI_CHAR, MPI_STATUS_IGNORE)); }
   /* Read the last chunk */
-  offset_reduced = (nreads-1)*chunk_size_reduced;
-  chunk_size_reduced = (PetscMPIInt)(chunk_size_overlaped - (nreads-1)*chunk_size_reduced);
-  if (chunk_size_reduced) {
-    PetscCallMPI(MPI_File_read_at_all(fh,offset+offset_reduced,&chunk_buff_inner[offset_reduced],chunk_size_reduced,MPI_CHAR,MPI_STATUS_IGNORE));
-  }
+  offset_reduced     = (nreads - 1) * chunk_size_reduced;
+  chunk_size_reduced = (PetscMPIInt)(chunk_size_overlaped - (nreads - 1) * chunk_size_reduced);
+  if (chunk_size_reduced) { PetscCallMPI(MPI_File_read_at_all(fh, offset + offset_reduced, &chunk_buff_inner[offset_reduced], chunk_size_reduced, MPI_CHAR, MPI_STATUS_IGNORE)); }
 
   /* Check EOL in end of buffers without overlaps */
-  if (chunk_buff_inner[chunk_size-1] == '\n') eol_found = PETSC_TRUE;
+  if (chunk_buff_inner[chunk_size - 1] == '\n') eol_found = PETSC_TRUE;
 
   /* Determine EOLs in overlaps */
   chunk_size_tmp = chunk_size;
   if ((comm_rank != comm_size - 1) && !eol_found) {
     while (!eol_found) {
-
       for (p = chunk_size; p < chunk_size_overlaped; ++p) {
         ++eol_pos;
         if (chunk_buff_inner[p] == '\n') {
@@ -139,26 +132,22 @@ static PetscErrorCode IOReadBuffer_SVMLight_Private(MPI_Comm comm,const char *fi
           eol_found = PETSC_TRUE;
         }
 
-        PetscCall(PetscRealloc(chunk_size_overlaped * sizeof(char),&chunk_buff_inner));
-        PetscCallMPI(MPI_File_read_at(fh,offset + chunk_size,&chunk_buff_inner[chunk_size],overlap,MPI_CHAR,MPI_STATUS_IGNORE));
+        PetscCall(PetscRealloc(chunk_size_overlaped * sizeof(char), &chunk_buff_inner));
+        PetscCallMPI(MPI_File_read_at(fh, offset + chunk_size, &chunk_buff_inner[chunk_size], overlap, MPI_CHAR, MPI_STATUS_IGNORE));
       }
     }
   }
 
-  if (comm_rank != comm_size-1) {
-    PetscCallMPI(MPI_Send(&eol_pos,1,MPIU_INT,comm_rank + 1,0,comm));
-  }
-  if (comm_rank != 0) {
-    PetscCallMPI(MPI_Recv(&eol_start,1,MPIU_INT,comm_rank - 1,0,comm,MPI_STATUS_IGNORE));
-  }
+  if (comm_rank != comm_size - 1) { PetscCallMPI(MPI_Send(&eol_pos, 1, MPIU_INT, comm_rank + 1, 0, comm)); }
+  if (comm_rank != 0) { PetscCallMPI(MPI_Recv(&eol_start, 1, MPIU_INT, comm_rank - 1, 0, comm, MPI_STATUS_IGNORE)); }
 
   /* Buffer shrink */
   if (comm_rank == 0) {
-    PetscCall(PetscRealloc((chunk_size_tmp+eol_pos+1) * sizeof(char),&chunk_buff_inner));
-    chunk_buff_inner[chunk_size_tmp+eol_pos] = 0;
+    PetscCall(PetscRealloc((chunk_size_tmp + eol_pos + 1) * sizeof(char), &chunk_buff_inner));
+    chunk_buff_inner[chunk_size_tmp + eol_pos] = 0;
   } else if ((chunk_size_shrink = chunk_size_tmp + eol_pos - eol_start) != 0) {
-    PetscCall(PetscMemmove(chunk_buff_inner,chunk_buff_inner + eol_start,chunk_size_shrink * sizeof(char)));
-    PetscCall(PetscRealloc((chunk_size_tmp+eol_pos-eol_start+1) * sizeof(char),&chunk_buff_inner));
+    PetscCall(PetscMemmove(chunk_buff_inner, chunk_buff_inner + eol_start, chunk_size_shrink * sizeof(char)));
+    PetscCall(PetscRealloc((chunk_size_tmp + eol_pos - eol_start + 1) * sizeof(char), &chunk_buff_inner));
     chunk_buff_inner[chunk_size_shrink] = 0;
   } else {
     PetscCall(PetscFree(chunk_buff_inner));
@@ -173,98 +162,98 @@ static PetscErrorCode IOReadBuffer_SVMLight_Private(MPI_Comm comm,const char *fi
 
 #undef __FUNCT__
 #define __FUNCT__ "IOParseBuffer_SVMLight_Private"
-static PetscErrorCode IOParseBuffer_SVMLight_Private(MPI_Comm comm,char *buff,struct ArrInt *i,struct ArrInt *j,struct ArrReal *a,struct ArrInt *k,struct ArrReal *y,PetscInt *N)
+static PetscErrorCode IOParseBuffer_SVMLight_Private(MPI_Comm comm, char *buff, struct ArrInt *i, struct ArrInt *j, struct ArrReal *a, struct ArrInt *k, struct ArrReal *y, PetscInt *N)
 {
-  struct ArrInt  i_in,j_in,k_in;
-  struct ArrReal a_in,y_in;
+  struct ArrInt  i_in, j_in, k_in;
+  struct ArrReal a_in, y_in;
 
-  PetscInt   array_init_capacity;
-  PetscReal  array_grow_factor;
+  PetscInt  array_init_capacity;
+  PetscReal array_grow_factor;
 
-  char       *line = NULL,*word = NULL,*key = NULL,*v = NULL;
+  char *line = NULL, *word = NULL, *key = NULL, *v = NULL;
 #if (_POSIX_VERSION >= 200112L)
-  char       *ptr_line = NULL,*ptr_word = NULL;
+  char *ptr_line = NULL, *ptr_word = NULL;
 #else
-  PetscToken token_line,token_word;
+  PetscToken token_line, token_word;
 #endif
 
-  PetscInt   col,N_in;
-  PetscReal  value,yi;
+  PetscInt  col, N_in;
+  PetscReal value, yi;
 
   PetscFunctionBegin;
   array_init_capacity = DARRAY_INIT_CAPACITY;
-  array_grow_factor = DARRAY_GROW_FACTOR;
+  array_grow_factor   = DARRAY_GROW_FACTOR;
 
-  PetscCall(PetscOptionsGetInt(NULL,NULL,"-svm_io_darray_init_size",&array_init_capacity,NULL));
-  PetscCheck(array_init_capacity > 0,comm,PETSC_ERR_ARG_OUTOFRANGE,"Initial size of dynamic array must be greater than zero");
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-svm_io_darray_init_size", &array_init_capacity, NULL));
+  PetscCheck(array_init_capacity > 0, comm, PETSC_ERR_ARG_OUTOFRANGE, "Initial size of dynamic array must be greater than zero");
 
-  PetscCall(PetscOptionsGetReal(NULL,NULL,"-svm_io_darray_grow_factor",&array_grow_factor,NULL));
-  PetscCheck(array_grow_factor > 1.,comm,PETSC_ERR_ARG_OUTOFRANGE,"Grow factor of dynamic array must be greater than one");
+  PetscCall(PetscOptionsGetReal(NULL, NULL, "-svm_io_darray_grow_factor", &array_grow_factor, NULL));
+  PetscCheck(array_grow_factor > 1., comm, PETSC_ERR_ARG_OUTOFRANGE, "Grow factor of dynamic array must be greater than one");
 
-  DynamicArrayInit(i_in,array_init_capacity,array_grow_factor);
-  DynamicArrayPushBack(i_in,0);
+  DynamicArrayInit(i_in, array_init_capacity, array_grow_factor);
+  DynamicArrayPushBack(i_in, 0);
 
   if (buff) {
-    DynamicArrayInit(y_in,array_init_capacity,array_grow_factor);
-    DynamicArrayInit(k_in,array_init_capacity,array_grow_factor);
+    DynamicArrayInit(y_in, array_init_capacity, array_grow_factor);
+    DynamicArrayInit(k_in, array_init_capacity, array_grow_factor);
 
-    DynamicArrayInit(j_in,array_init_capacity,array_grow_factor);
-    DynamicArrayInit(a_in,array_init_capacity,array_grow_factor);
+    DynamicArrayInit(j_in, array_init_capacity, array_grow_factor);
+    DynamicArrayInit(a_in, array_init_capacity, array_grow_factor);
 
     N_in = 0;
 #if (_POSIX_VERSION >= 200112L)
-    line = strtok_r(buff,"\n",&ptr_line);
+    line = strtok_r(buff, "\n", &ptr_line);
 
     while (line) {
-      word = strtok_r(line," ",&ptr_word);
-      yi = (PetscReal) atoi(word);
+      word = strtok_r(line, " ", &ptr_word);
+      yi   = (PetscReal)atoi(word);
 
-      DynamicArrayPushBack(k_in,y_in.size);
-      DynamicArrayPushBack(y_in,yi);
+      DynamicArrayPushBack(k_in, y_in.size);
+      DynamicArrayPushBack(y_in, yi);
 
-      while ((word = strtok_r(NULL," ",&ptr_word))) {
-        key = strtok(word,":");
-        col = (PetscInt) atoi(key);
+      while ((word = strtok_r(NULL, " ", &ptr_word))) {
+        key = strtok(word, ":");
+        col = (PetscInt)atoi(key);
 
         if (col > N_in) N_in = col;
         col -= 1; /*Column indices start from 1 in SVMLight format*/
 
-        DynamicArrayPushBack(j_in,col);
+        DynamicArrayPushBack(j_in, col);
 
-        v = strtok(NULL,":");
-        value = (PetscReal) atof(v);
-        DynamicArrayPushBack(a_in,value);
+        v     = strtok(NULL, ":");
+        value = (PetscReal)atof(v);
+        DynamicArrayPushBack(a_in, value);
       }
-      DynamicArrayPushBack(i_in,a_in.size);
+      DynamicArrayPushBack(i_in, a_in.size);
 
-      line = strtok_r(NULL,"\n",&ptr_line);
+      line = strtok_r(NULL, "\n", &ptr_line);
     }
 #else
-    PetscCall(PetscTokenCreate(buff,'\n',&token_line));
-    while(PETSC_TRUE) {
-      PetscCall(PetscTokenFind(token_line,&line));
+    PetscCall(PetscTokenCreate(buff, '\n', &token_line));
+    while (PETSC_TRUE) {
+      PetscCall(PetscTokenFind(token_line, &line));
       if (line) {
-        PetscCall(PetscTokenCreate(line,' ',&token_word));
+        PetscCall(PetscTokenCreate(line, ' ', &token_word));
 
-        PetscCall(PetscTokenFind(token_word,&word));
-        yi = (PetscReal) atof(word);
+        PetscCall(PetscTokenFind(token_word, &word));
+        yi = (PetscReal)atof(word);
 
-        PermonDynamicArrayPushBack(k_in,y_in.size);
-        PermonDynamicArrayPushBack(y_in,yi);
+        PermonDynamicArrayPushBack(k_in, y_in.size);
+        PermonDynamicArrayPushBack(y_in, yi);
 
         while (PETSC_TRUE) {
-          PetscCall(PetscTokenFind(token_word,&word));
+          PetscCall(PetscTokenFind(token_word, &word));
           if (word) {
-            key = strtok(word,":");
-            col = (PetscInt) atoi(key);
+            key = strtok(word, ":");
+            col = (PetscInt)atoi(key);
 
             if (col > N_in) N_in = col;
             col -= 1; /*Column indices start from 1 in SVMLight format*/
-            PermonDynamicArrayPushBack(j_in,col);
+            PermonDynamicArrayPushBack(j_in, col);
 
-            v = strtok(NULL,":");
-            value = (PetscReal) atof(v);
-            PermonDynamicArrayPushBack(a_in,value);
+            v     = strtok(NULL, ":");
+            value = (PetscReal)atof(v);
+            PermonDynamicArrayPushBack(a_in, value);
           } else {
             break;
           }
@@ -272,7 +261,7 @@ static PetscErrorCode IOParseBuffer_SVMLight_Private(MPI_Comm comm,char *buff,st
       } else {
         break;
       }
-      PermonDynamicArrayPushBack(i_in,a_in.size);
+      PermonDynamicArrayPushBack(i_in, a_in.size);
       PetscCall(PetscTokenDestroy(&token_word));
     }
     PetscCall(PetscTokenDestroy(&token_line));
@@ -284,7 +273,7 @@ static PetscErrorCode IOParseBuffer_SVMLight_Private(MPI_Comm comm,char *buff,st
     a_in.data = NULL;
   }
 
-  PetscCallMPI(MPI_Allreduce(MPI_IN_PLACE,&N_in,1,MPIU_INT,MPI_MAX,comm));
+  PetscCallMPI(MPI_Allreduce(MPI_IN_PLACE, &N_in, 1, MPIU_INT, MPI_MAX, comm));
 
   *i = i_in;
   *j = j_in;
@@ -297,43 +286,43 @@ static PetscErrorCode IOParseBuffer_SVMLight_Private(MPI_Comm comm,char *buff,st
 
 #undef __FUNCT__
 #define __FUNCT__ "DatasetAssembly_SVMLight_Private"
-static PetscErrorCode DatasetAssembly_SVMLight_Private(Mat Xt,Vec labels,char *buff)
+static PetscErrorCode DatasetAssembly_SVMLight_Private(Mat Xt, Vec labels, char *buff)
 {
   MPI_Comm comm;
 
-  struct   ArrInt  i,j,k;
-  struct   ArrReal a,y;
+  struct ArrInt  i, j, k;
+  struct ArrReal a, y;
 
-  PetscInt offset,m,N;
+  PetscInt offset, m, N;
   PetscInt rbs;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject) Xt,&comm));
+  PetscCall(PetscObjectGetComm((PetscObject)Xt, &comm));
 
-  PetscCall(IOParseBuffer_SVMLight_Private(comm,buff,&i,&j,&a,&k,&y,&N));
+  PetscCall(IOParseBuffer_SVMLight_Private(comm, buff, &i, &j, &a, &k, &y, &N));
   m = (buff) ? i.size - 1 : 0;
   /* local to global: label vector indices */
   offset = (k.data) ? k.size : 0;
-  PetscCallMPI(MPI_Scan(MPI_IN_PLACE,&offset,1,MPIU_INT,MPI_SUM,comm));
+  PetscCallMPI(MPI_Scan(MPI_IN_PLACE, &offset, 1, MPIU_INT, MPI_SUM, comm));
   if (k.data) {
     offset -= k.size;
-    DynamicArrayAddValue(k,offset);
+    DynamicArrayAddValue(k, offset);
   }
 
   /* Assembly the Xt matrix */
-  PetscCall(MatSetType(Xt,MATAIJ));
-  PetscCall(MatSetSizes(Xt,m,PETSC_DECIDE,PETSC_DECIDE,N));
-  PetscCall(MatSeqAIJSetPreallocationCSR(Xt,i.data,j.data,a.data));
-  PetscCall(MatMPIAIJSetPreallocationCSR(Xt,i.data,j.data,a.data));
+  PetscCall(MatSetType(Xt, MATAIJ));
+  PetscCall(MatSetSizes(Xt, m, PETSC_DECIDE, PETSC_DECIDE, N));
+  PetscCall(MatSeqAIJSetPreallocationCSR(Xt, i.data, j.data, a.data));
+  PetscCall(MatMPIAIJSetPreallocationCSR(Xt, i.data, j.data, a.data));
 
   /* Assembly vector of labels */
-  PetscCall(MatGetBlockSizes(Xt,&rbs,NULL));
-  PetscCall(VecSetSizes(labels,Xt->rmap->n,PETSC_DETERMINE));
-  PetscCall(VecSetBlockSize(labels,rbs));
-  PetscCall(VecSetType(labels,Xt->defaultvectype));
-  PetscCall(PetscLayoutReference(Xt->rmap,&labels->map));
+  PetscCall(MatGetBlockSizes(Xt, &rbs, NULL));
+  PetscCall(VecSetSizes(labels, Xt->rmap->n, PETSC_DETERMINE));
+  PetscCall(VecSetBlockSize(labels, rbs));
+  PetscCall(VecSetType(labels, Xt->defaultvectype));
+  PetscCall(PetscLayoutReference(Xt->rmap, &labels->map));
 
-  if (y.data) PetscCall(VecSetValues(labels,y.size,k.data,y.data,INSERT_VALUES));
+  if (y.data) PetscCall(VecSetValues(labels, y.size, k.data, y.data, INSERT_VALUES));
   PetscCall(VecAssemblyBegin(labels));
   PetscCall(VecAssemblyEnd(labels));
 
@@ -347,19 +336,19 @@ static PetscErrorCode DatasetAssembly_SVMLight_Private(Mat Xt,Vec labels,char *b
 
 #undef __FUNCT__
 #define __FUNCT__ "DatasetLoad_SVMLight"
-PetscErrorCode DatasetLoad_SVMLight(Mat Xt,Vec y,PetscViewer v)
+PetscErrorCode DatasetLoad_SVMLight(Mat Xt, Vec y, PetscViewer v)
 {
-  MPI_Comm   comm;
+  MPI_Comm comm;
 
-  const char *file_name = NULL;
+  const char *file_name  = NULL;
   char       *chunk_buff = NULL;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject) Xt,&comm));
-  PetscCall(PetscViewerFileGetName(v,&file_name));
+  PetscCall(PetscObjectGetComm((PetscObject)Xt, &comm));
+  PetscCall(PetscViewerFileGetName(v, &file_name));
 
-  PetscCall(IOReadBuffer_SVMLight_Private(comm,file_name,&chunk_buff));
-  PetscCall(DatasetAssembly_SVMLight_Private(Xt,y,chunk_buff));
+  PetscCall(IOReadBuffer_SVMLight_Private(comm, file_name, &chunk_buff));
+  PetscCall(DatasetAssembly_SVMLight_Private(Xt, y, chunk_buff));
 
   if (chunk_buff) { PetscCall(PetscFree(chunk_buff)); }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -367,15 +356,15 @@ PetscErrorCode DatasetLoad_SVMLight(Mat Xt,Vec y,PetscViewer v)
 
 #undef __FUNCT__
 #define __FUNCT__ "PetscViewerSVMLightOpen"
-PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm comm,const char name[],PetscViewer *v)
+PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm comm, const char name[], PetscViewer *v)
 {
   PetscViewer v_inner;
 
   PetscFunctionBegin;
-  PetscCall(PetscViewerCreate(comm,&v_inner));
-  PetscCall(PetscViewerSetType(v_inner,PETSCVIEWERASCII));
-  PetscCall(PetscViewerFileSetMode(v_inner,FILE_MODE_READ));
-  PetscCall(PetscViewerFileSetName(v_inner,name));
+  PetscCall(PetscViewerCreate(comm, &v_inner));
+  PetscCall(PetscViewerSetType(v_inner, PETSCVIEWERASCII));
+  PetscCall(PetscViewerFileSetMode(v_inner, FILE_MODE_READ));
+  PetscCall(PetscViewerFileSetName(v_inner, name));
 
   *v = v_inner;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -383,29 +372,29 @@ PetscErrorCode PetscViewerSVMLightOpen(MPI_Comm comm,const char name[],PetscView
 
 #undef __FUNCT__
 #define __FUNCT__ "DatasetLoad_Binary"
-PetscErrorCode DatasetLoad_Binary(Mat Xt,Vec y,PetscViewer v)
+PetscErrorCode DatasetLoad_Binary(Mat Xt, Vec y, PetscViewer v)
 {
-  char       Xt_name[256];
+  char        Xt_name[256];
   const char *Xt_name_tmp;
-  char       y_name[256];
+  char        y_name[256];
   const char *y_name_tmp;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetName((PetscObject) Xt,&Xt_name_tmp));
-  PetscCall(PetscStrncpy(Xt_name,Xt_name_tmp,sizeof(Xt_name)));
-  PetscCall(PetscObjectGetName((PetscObject) y,&y_name_tmp));
-  PetscCall(PetscStrncpy(y_name,y_name_tmp,sizeof(y_name)));
+  PetscCall(PetscObjectGetName((PetscObject)Xt, &Xt_name_tmp));
+  PetscCall(PetscStrncpy(Xt_name, Xt_name_tmp, sizeof(Xt_name)));
+  PetscCall(PetscObjectGetName((PetscObject)y, &y_name_tmp));
+  PetscCall(PetscStrncpy(y_name, y_name_tmp, sizeof(y_name)));
 
-  PetscCall(PetscObjectSetName((PetscObject) Xt,"X"));
-  PetscCall(MatLoad(Xt,v));
+  PetscCall(PetscObjectSetName((PetscObject)Xt, "X"));
+  PetscCall(MatLoad(Xt, v));
   PetscCall(MatSetFromOptions(Xt));
 
-  PetscCall(PetscObjectSetName((PetscObject) y,"y"));
-  PetscCall(VecLoad(y,v));
+  PetscCall(PetscObjectSetName((PetscObject)y, "y"));
+  PetscCall(VecLoad(y, v));
   PetscCall(VecSetFromOptions(y));
 
-  PetscCall(PetscObjectSetName((PetscObject) Xt,Xt_name));
-  PetscCall(PetscObjectSetName((PetscObject) y,y_name));
+  PetscCall(PetscObjectSetName((PetscObject)Xt, Xt_name));
+  PetscCall(PetscObjectSetName((PetscObject)y, y_name));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -423,29 +412,29 @@ PetscErrorCode DatasetLoad_Binary(Mat Xt,Vec y,PetscViewer v)
 
 .seealso SVM
 @*/
-PetscErrorCode PetscViewerLoadSVMDataset(Mat Xt,Vec y,PetscViewer v)
+PetscErrorCode PetscViewerLoadSVMDataset(Mat Xt, Vec y, PetscViewer v)
 {
   const char *type_name = NULL;
-  PetscBool  isascii,ishdf5,isbinary;
+  PetscBool   isascii, ishdf5, isbinary;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(Xt,MAT_CLASSID,1);
-  PetscValidHeaderSpecific(y,VEC_CLASSID,2);
-  PetscValidHeaderSpecific(v,PETSC_VIEWER_CLASSID,3);
-  PetscCheckSameComm(v,1,Xt,2);
-  PetscCheckSameComm(v,1,y,3);
+  PetscValidHeaderSpecific(Xt, MAT_CLASSID, 1);
+  PetscValidHeaderSpecific(y, VEC_CLASSID, 2);
+  PetscValidHeaderSpecific(v, PETSC_VIEWER_CLASSID, 3);
+  PetscCheckSameComm(v, 1, Xt, 2);
+  PetscCheckSameComm(v, 1, y, 3);
 
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERASCII,&isascii));
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERHDF5,&ishdf5));
-  PetscCall(PetscObjectTypeCompare((PetscObject) v,PETSCVIEWERBINARY,&isbinary));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERASCII, &isascii));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERHDF5, &ishdf5));
+  PetscCall(PetscObjectTypeCompare((PetscObject)v, PETSCVIEWERBINARY, &isbinary));
 
   if (isascii) {
-    PetscCall(DatasetLoad_SVMLight(Xt,y,v));
+    PetscCall(DatasetLoad_SVMLight(Xt, y, v));
   } else if (ishdf5 || isbinary) {
-    PetscCall(DatasetLoad_Binary(Xt,y,v));
+    PetscCall(DatasetLoad_Binary(Xt, y, v));
   } else {
-    PetscCall(PetscObjectGetType((PetscObject) v,&type_name));
-    SETERRQ(PetscObjectComm((PetscObject) v),PETSC_ERR_SUP,"Viewer type %s not supported for PetscViewerLoadDataset",type_name);
+    PetscCall(PetscObjectGetType((PetscObject)v, &type_name));
+    SETERRQ(PetscObjectComm((PetscObject)v), PETSC_ERR_SUP, "Viewer type %s not supported for PetscViewerLoadDataset", type_name);
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/utils/io.c
+++ b/src/svm/utils/io.c
@@ -21,7 +21,7 @@
   }
 
 #define DynamicArrayInit(a,_capacity_,_grow_factor_)      \
-  PetscCall(PetscMalloc(_capacity_ * sizeof(*(a.data)),&(a.data))); \
+  PetscCall(PetscMalloc(_capacity_ * sizeof(*a.data),&a.data)); \
   a.size = 0;                                                   \
   a.capacity = _capacity_;                                      \
   a.grow_factor = _grow_factor_;
@@ -38,7 +38,7 @@
 
 #define DynamicArrayResize(a) \
   a.capacity = a.grow_factor * a.capacity; \
-  PetscCall(PetscRealloc(a.capacity * sizeof(*(a.data)),&a.data)); \
+  PetscCall(PetscRealloc(a.capacity * sizeof(*a.data),&a.data)); \
 
 #define DynamicArrayAddValue(a,v) \
   PetscInt i; \

--- a/src/svm/utils/io.c
+++ b/src/svm/utils/io.c
@@ -342,7 +342,6 @@ static PetscErrorCode DatasetAssembly_SVMLight_Private(Mat Xt,Vec labels,char *b
   DynamicArrayClear(i);
   if (j.data) DynamicArrayClear(j);
   if (a.data) DynamicArrayClear(a);
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -452,6 +451,5 @@ PetscErrorCode PetscViewerLoadSVMDataset(Mat Xt,Vec y,PetscViewer v)
 
     SETERRQ(comm,PETSC_ERR_SUP,"Viewer type %s not supported for PetscViewerLoadDataset",type_name);
   }
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/utils/io.h
+++ b/src/svm/utils/io.h
@@ -1,9 +1,6 @@
-#if !defined(__IO_H)
-#define	__IO_H
+#pragma once
 
 #include <permonsvm.h>
 
 FLLOP_EXTERN PetscErrorCode DatasetLoad_SVMLight(Mat,Vec,PetscViewer);
 FLLOP_EXTERN PetscErrorCode DatasetLoad_Binary(Mat,Vec,PetscViewer);
-
-#endif

--- a/src/svm/utils/io.h
+++ b/src/svm/utils/io.h
@@ -2,5 +2,5 @@
 
 #include <permonsvm.h>
 
-FLLOP_EXTERN PetscErrorCode DatasetLoad_SVMLight(Mat,Vec,PetscViewer);
-FLLOP_EXTERN PetscErrorCode DatasetLoad_Binary(Mat,Vec,PetscViewer);
+PERMON_EXTERN PetscErrorCode DatasetLoad_SVMLight(Mat,Vec,PetscViewer);
+PERMON_EXTERN PetscErrorCode DatasetLoad_Binary(Mat,Vec,PetscViewer);

--- a/src/svm/utils/io.h
+++ b/src/svm/utils/io.h
@@ -2,5 +2,5 @@
 
 #include <permonsvm.h>
 
-PERMON_EXTERN PetscErrorCode DatasetLoad_SVMLight(Mat,Vec,PetscViewer);
-PERMON_EXTERN PetscErrorCode DatasetLoad_Binary(Mat,Vec,PetscViewer);
+PERMON_EXTERN PetscErrorCode DatasetLoad_SVMLight(Mat, Vec, PetscViewer);
+PERMON_EXTERN PetscErrorCode DatasetLoad_Binary(Mat, Vec, PetscViewer);

--- a/src/svm/utils/matutils.c
+++ b/src/svm/utils/matutils.c
@@ -1,4 +1,3 @@
-
 #include <petsc/private/matimpl.h>
 #include <permonsvm.h>
 

--- a/src/svm/utils/matutils.c
+++ b/src/svm/utils/matutils.c
@@ -2,8 +2,8 @@
 #include <permonsvm.h>
 
 typedef struct {
-    Mat       inner;
-    PetscReal bias;
+  Mat       inner;
+  PetscReal bias;
 } MatCtx;
 
 #undef __FUNCT__
@@ -14,61 +14,61 @@ PetscErrorCode MatDestroy_Biased(Mat A)
   MatCtx *ctx = NULL;
 
   PetscFunctionBegin;
-  PetscCall(MatShellGetContext(A,&ptr));
-  ctx = (MatCtx *) ptr;
+  PetscCall(MatShellGetContext(A, &ptr));
+  ctx = (MatCtx *)ptr;
 
   PetscCall(MatDestroy(&ctx->inner));
   PetscCall(PetscFree(ctx));
-  PetscCall(PetscObjectComposeFunction((PetscObject)A,"MatGetOwnershipIS_C",NULL));
+  PetscCall(PetscObjectComposeFunction((PetscObject)A, "MatGetOwnershipIS_C", NULL));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 #undef __FUNCT__
 #define __FUNCT__ "MatMult_Biased"
-PetscErrorCode MatMult_Biased(Mat A,Vec x,Vec y)
+PetscErrorCode MatMult_Biased(Mat A, Vec x, Vec y)
 {
-  MPI_Comm          comm;
-  PetscMPIInt       comm_size,comm_rank;
-  MPI_Request       req;
+  MPI_Comm    comm;
+  PetscMPIInt comm_size, comm_rank;
+  MPI_Request req;
 
-  PetscInt          n;
-  PetscInt          low,hi;
-  PetscScalar       a,b;
+  PetscInt    n;
+  PetscInt    low, hi;
+  PetscScalar a, b;
 
-  IS                is_col;
-  Vec               x_sub;
+  IS                 is_col;
+  Vec                x_sub;
   const PetscScalar *x_arr;
 
-  void              *ptr = NULL;
-  MatCtx            *ctx = NULL;
+  void   *ptr = NULL;
+  MatCtx *ctx = NULL;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject) A,&comm));
-  PetscCallMPI(MPI_Comm_size(comm,&comm_size));
-  PetscCallMPI(MPI_Comm_rank(comm,&comm_rank));
+  PetscCall(PetscObjectGetComm((PetscObject)A, &comm));
+  PetscCallMPI(MPI_Comm_size(comm, &comm_size));
+  PetscCallMPI(MPI_Comm_rank(comm, &comm_rank));
 
-  PetscCall(MatShellGetContext(A,&ptr));
-  ctx = (MatCtx *) ptr;
+  PetscCall(MatShellGetContext(A, &ptr));
+  ctx = (MatCtx *)ptr;
 
   if (comm_rank == comm_size - 1) {
-    PetscCall(VecGetLocalSize(x,&n));
-    PetscCall(VecGetArrayRead(x,&x_arr));
+    PetscCall(VecGetLocalSize(x, &n));
+    PetscCall(VecGetArrayRead(x, &x_arr));
     a = x_arr[n - 1];
-    PetscCall(VecRestoreArrayRead(y,&x_arr));
+    PetscCall(VecRestoreArrayRead(y, &x_arr));
   }
-  PetscCallMPI(MPI_Ibcast(&a,1,MPIU_SCALAR,comm_size - 1,comm,&req));
-  PetscCallMPI(MPI_Wait(&req,MPI_STATUS_IGNORE));
+  PetscCallMPI(MPI_Ibcast(&a, 1, MPIU_SCALAR, comm_size - 1, comm, &req));
+  PetscCallMPI(MPI_Wait(&req, MPI_STATUS_IGNORE));
 
-  PetscCall(VecGetOwnershipRange(x,&low,&hi));
+  PetscCall(VecGetOwnershipRange(x, &low, &hi));
   if (comm_rank == comm_size - 1) hi -= 1;
-  PetscCall(ISCreateStride(comm,hi - low,low,1,&is_col));
+  PetscCall(ISCreateStride(comm, hi - low, low, 1, &is_col));
 
-  PetscCall(VecGetSubVector(x,is_col,&x_sub));
-  PetscCall(MatMult(ctx->inner,x_sub,y));
-  PetscCall(VecRestoreSubVector(x,is_col,&x_sub));
+  PetscCall(VecGetSubVector(x, is_col, &x_sub));
+  PetscCall(MatMult(ctx->inner, x_sub, y));
+  PetscCall(VecRestoreSubVector(x, is_col, &x_sub));
 
   b = ctx->bias * a;
-  PetscCall(VecShift(y,b));
+  PetscCall(VecShift(y, b));
 
   /* Free memory */
   PetscCall(ISDestroy(&is_col));
@@ -77,42 +77,42 @@ PetscErrorCode MatMult_Biased(Mat A,Vec x,Vec y)
 
 #undef __FUNCT__
 #define __FUNCT__ "MatMultTranspose_Biased"
-PetscErrorCode MatMultTranspose_Biased(Mat A,Vec x,Vec y)
+PetscErrorCode MatMultTranspose_Biased(Mat A, Vec x, Vec y)
 {
   MPI_Comm    comm;
-  PetscMPIInt comm_size,comm_rank;
+  PetscMPIInt comm_size, comm_rank;
 
   PetscInt    n;
-  PetscInt    low,hi;
+  PetscInt    low, hi;
   PetscScalar a;
 
-  IS          is_col;
-  Vec         y_sub;
+  IS  is_col;
+  Vec y_sub;
 
-  void        *ptr = NULL;
-  MatCtx      *ctx = NULL;
+  void   *ptr = NULL;
+  MatCtx *ctx = NULL;
 
   PetscFunctionBegin;
-  PetscCall(PetscObjectGetComm((PetscObject) A,&comm));
-  PetscCallMPI(MPI_Comm_size(comm,&comm_size));
-  PetscCallMPI(MPI_Comm_rank(comm,&comm_rank));
+  PetscCall(PetscObjectGetComm((PetscObject)A, &comm));
+  PetscCallMPI(MPI_Comm_size(comm, &comm_size));
+  PetscCallMPI(MPI_Comm_rank(comm, &comm_rank));
 
-  PetscCall(MatShellGetContext(A,&ptr));
-  ctx = (MatCtx *) ptr;
+  PetscCall(MatShellGetContext(A, &ptr));
+  ctx = (MatCtx *)ptr;
 
-  PetscCall(VecGetOwnershipRange(y,&low,&hi));
+  PetscCall(VecGetOwnershipRange(y, &low, &hi));
   if (comm_rank == comm_size - 1) hi -= 1;
-  PetscCall(ISCreateStride(comm,hi - low,low,1,&is_col));
+  PetscCall(ISCreateStride(comm, hi - low, low, 1, &is_col));
 
-  PetscCall(VecGetSubVector(y,is_col,&y_sub));
-  PetscCall(MatMultTranspose(ctx->inner,x,y_sub));
-  PetscCall(VecRestoreSubVector(y,is_col,&y_sub));
+  PetscCall(VecGetSubVector(y, is_col, &y_sub));
+  PetscCall(MatMultTranspose(ctx->inner, x, y_sub));
+  PetscCall(VecRestoreSubVector(y, is_col, &y_sub));
 
-  PetscCall(VecSum(x,&a));
+  PetscCall(VecSum(x, &a));
   if (comm_rank == comm_size - 1) {
-    PetscCall(VecGetSize(y,&n));
+    PetscCall(VecGetSize(y, &n));
     a *= ctx->bias;
-    PetscCall(VecSetValue(y,n - 1,a,INSERT_VALUES));
+    PetscCall(VecSetValue(y, n - 1, a, INSERT_VALUES));
   }
   PetscCall(VecAssemblyBegin(y));
   PetscCall(VecAssemblyEnd(y));
@@ -123,25 +123,23 @@ PetscErrorCode MatMultTranspose_Biased(Mat A,Vec x,Vec y)
 
 #undef __FUNCT__
 #define __FUNCT__ "MatGetOwnershipIS_Biased"
-PetscErrorCode MatGetOwnershipIS_Biased(Mat mat,IS *rows,IS *cols)
+PetscErrorCode MatGetOwnershipIS_Biased(Mat mat, IS *rows, IS *cols)
 {
-  void     *ptr;
-  MatCtx   *ctx;
+  void   *ptr;
+  MatCtx *ctx;
 
   PetscInt ncols;
   IS       cols_inner;
 
   PetscFunctionBegin;
-  PetscCall(MatShellGetContext(mat,&ptr));
-  ctx = (MatCtx *) ptr;
+  PetscCall(MatShellGetContext(mat, &ptr));
+  ctx = (MatCtx *)ptr;
 
-  if (rows) {
-    PetscCall(MatGetOwnershipIS(ctx->inner,rows,NULL));
-  }
+  if (rows) { PetscCall(MatGetOwnershipIS(ctx->inner, rows, NULL)); }
 
   if (cols) {
-    PetscCall(MatGetSize(ctx->inner,NULL,&ncols));
-    PetscCall(ISCreateStride(PetscObjectComm((PetscObject) mat),ncols,0,1,&cols_inner));
+    PetscCall(MatGetSize(ctx->inner, NULL, &ncols));
+    PetscCall(ISCreateStride(PetscObjectComm((PetscObject)mat), ncols, 0, 1, &cols_inner));
     *cols = cols_inner;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -149,53 +147,51 @@ PetscErrorCode MatGetOwnershipIS_Biased(Mat mat,IS *rows,IS *cols)
 
 #undef __FUNCT__
 #define __FUNCT__ "MatCreateSubMatrix_Biased"
-PetscErrorCode MatCreateSubMatrix_Biased(Mat A,IS isrow,IS iscol,MatReuse cll,Mat *out)
+PetscErrorCode MatCreateSubMatrix_Biased(Mat A, IS isrow, IS iscol, MatReuse cll, Mat *out)
 {
   MPI_Comm    comm;
-  PetscMPIInt comm_size,comm_rank;
+  PetscMPIInt comm_size, comm_rank;
 
-  Mat         A_sub;
-  PetscInt    m,n,M,N;
-  Mat         mat_inner;
-  VecType     vtype;
+  Mat      A_sub;
+  PetscInt m, n, M, N;
+  Mat      mat_inner;
+  VecType  vtype;
 
-  void        *ptr     = NULL;
-  MatCtx      *ctx     = NULL;
-  MatCtx      *new_ctx = NULL;
+  void   *ptr     = NULL;
+  MatCtx *ctx     = NULL;
+  MatCtx *new_ctx = NULL;
 
   PetscFunctionBegin;
-  PetscCall(MatShellGetContext(A,&ptr));
-  ctx = (MatCtx *) ptr;
+  PetscCall(MatShellGetContext(A, &ptr));
+  ctx = (MatCtx *)ptr;
 
-  PetscCall(PetscObjectGetComm((PetscObject) ctx->inner,&comm));
-  PetscCallMPI(MPI_Comm_size(comm,&comm_size));
-  PetscCallMPI(MPI_Comm_rank(comm,&comm_rank));
+  PetscCall(PetscObjectGetComm((PetscObject)ctx->inner, &comm));
+  PetscCallMPI(MPI_Comm_size(comm, &comm_size));
+  PetscCallMPI(MPI_Comm_rank(comm, &comm_rank));
 
-  PetscCall(MatCreateSubMatrix(ctx->inner,isrow,iscol,cll,&A_sub));
+  PetscCall(MatCreateSubMatrix(ctx->inner, isrow, iscol, cll, &A_sub));
 
   PetscCall(PetscNew(&new_ctx));
   new_ctx->inner = A_sub;
   new_ctx->bias  = ctx->bias;
 
-  PetscCall(MatGetLocalSize(A_sub,&m,&n));
-  PetscCall(MatGetSize(A_sub,&M,&N));
+  PetscCall(MatGetLocalSize(A_sub, &m, &n));
+  PetscCall(MatGetSize(A_sub, &M, &N));
 
-  if (comm_rank == comm_size - 1) {
-      n += 1;
-  }
+  if (comm_rank == comm_size - 1) { n += 1; }
   N += 1;
 
-  PetscCall(MatCreateShell(comm,m,n,M,N,new_ctx,&mat_inner));
+  PetscCall(MatCreateShell(comm, m, n, M, N, new_ctx, &mat_inner));
   /* Set shell matrix functions */
-  PetscCall(MatShellSetOperation(mat_inner,MATOP_DESTROY         ,(void(*)(void))MatDestroy_Biased));
-  PetscCall(MatShellSetOperation(mat_inner,MATOP_MULT            ,(void(*)(void))MatMult_Biased));
-  PetscCall(MatShellSetOperation(mat_inner,MATOP_MULT_TRANSPOSE  ,(void(*)(void))MatMultTranspose_Biased));
-  PetscCall(MatShellSetOperation(mat_inner,MATOP_CREATE_SUBMATRIX,(void(*)(void))MatCreateSubMatrix_Biased));
-  PetscCall(PetscObjectComposeFunction((PetscObject) mat_inner,"MatGetOwnershipIS_C",MatGetOwnershipIS_Biased));
+  PetscCall(MatShellSetOperation(mat_inner, MATOP_DESTROY, (void (*)(void))MatDestroy_Biased));
+  PetscCall(MatShellSetOperation(mat_inner, MATOP_MULT, (void (*)(void))MatMult_Biased));
+  PetscCall(MatShellSetOperation(mat_inner, MATOP_MULT_TRANSPOSE, (void (*)(void))MatMultTranspose_Biased));
+  PetscCall(MatShellSetOperation(mat_inner, MATOP_CREATE_SUBMATRIX, (void (*)(void))MatCreateSubMatrix_Biased));
+  PetscCall(PetscObjectComposeFunction((PetscObject)mat_inner, "MatGetOwnershipIS_C", MatGetOwnershipIS_Biased));
 
   /* Set the default vector type for the shell to be the same as for the matrix A */
-  PetscCall(MatGetVecType(A,&vtype));
-  PetscCall(MatShellSetVecType(mat_inner,vtype));
+  PetscCall(MatGetVecType(A, &vtype));
+  PetscCall(MatShellSetVecType(mat_inner, vtype));
 
   *out = mat_inner;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -223,17 +219,17 @@ PetscErrorCode MatCreateSubMatrix_Biased(Mat A,IS isrow,IS iscol,MatReuse cll,Ma
 
 .seealso MatBiasedCreate()
 */
-PetscErrorCode MatBiasedGetInnerMat(Mat A,Mat *inner)
+PetscErrorCode MatBiasedGetInnerMat(Mat A, Mat *inner)
 {
   void   *ptr;
   MatCtx *ctx;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(A,MAT_CLASSID,1);
-  PetscAssertPointer(inner,2);
+  PetscValidHeaderSpecific(A, MAT_CLASSID, 1);
+  PetscAssertPointer(inner, 2);
 
-  PetscCall(MatShellGetContext(A,&ptr));
-  ctx = (MatCtx *) ptr;
+  PetscCall(MatShellGetContext(A, &ptr));
+  ctx = (MatCtx *)ptr;
 
   *inner = ctx->inner;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -256,17 +252,17 @@ PetscErrorCode MatBiasedGetInnerMat(Mat A,Mat *inner)
 
 .seealso MatBiasedCreate()
 @*/
-PetscErrorCode MatBiasedGetBias(Mat A,PetscReal *bias)
+PetscErrorCode MatBiasedGetBias(Mat A, PetscReal *bias)
 {
   void   *ptr;
   MatCtx *ctx;
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(A,MAT_CLASSID,1);
-  PetscAssertPointer(bias,2);
+  PetscValidHeaderSpecific(A, MAT_CLASSID, 1);
+  PetscAssertPointer(bias, 2);
 
-  PetscCall(MatShellGetContext(A,&ptr));
-  ctx = (MatCtx *) ptr;
+  PetscCall(MatShellGetContext(A, &ptr));
+  ctx = (MatCtx *)ptr;
 
   *bias = ctx->bias;
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -293,59 +289,59 @@ PetscErrorCode MatBiasedGetBias(Mat A,PetscReal *bias)
 
 .seealso MatBiasedGetBias(), MatBiasedGetInnerMat()
 @*/
-PetscErrorCode MatBiasedCreate(Mat A,PetscReal bias,Mat *A_biased)
+PetscErrorCode MatBiasedCreate(Mat A, PetscReal bias, Mat *A_biased)
 {
   MPI_Comm    comm;
-  PetscMPIInt comm_size,comm_rank;
+  PetscMPIInt comm_size, comm_rank;
 
-  Mat         A_biased_inner;
-  PetscInt    m,n,M,N;
-  MatCtx      *ctx = NULL;
-  VecType     vtype;
+  Mat      A_biased_inner;
+  PetscInt m, n, M, N;
+  MatCtx  *ctx = NULL;
+  VecType  vtype;
 
-  const char  *A_name,*A_prefix;
+  const char *A_name, *A_prefix;
   char        A_name_inner[50];
 
   PetscFunctionBegin;
-  PetscValidHeaderSpecific(A,MAT_CLASSID,1);
-  PetscValidLogicalCollectiveReal(A,bias,2);
-  PetscAssertPointer(A_biased,3);
+  PetscValidHeaderSpecific(A, MAT_CLASSID, 1);
+  PetscValidLogicalCollectiveReal(A, bias, 2);
+  PetscAssertPointer(A_biased, 3);
 
-  PetscCall(PetscObjectGetComm((PetscObject) A,&comm));
-  PetscCallMPI(MPI_Comm_size(comm,&comm_size));
-  PetscCallMPI(MPI_Comm_rank(comm,&comm_rank));
+  PetscCall(PetscObjectGetComm((PetscObject)A, &comm));
+  PetscCallMPI(MPI_Comm_size(comm, &comm_size));
+  PetscCallMPI(MPI_Comm_rank(comm, &comm_rank));
 
   /* Create matrix context */
   PetscCall(PetscNew(&ctx));
-  ctx->inner    = A;
-  ctx->bias = bias;
+  ctx->inner = A;
+  ctx->bias  = bias;
 
-  PetscCall(MatGetLocalSize(A,&m,&n));
-  PetscCall(MatGetSize(A,&M,&N));
+  PetscCall(MatGetLocalSize(A, &m, &n));
+  PetscCall(MatGetSize(A, &M, &N));
 
   if (comm_rank == comm_size - 1) n += 1;
 
-  PetscCall(MatCreateShell(comm,m,n,M,N+1,ctx,&A_biased_inner));
+  PetscCall(MatCreateShell(comm, m, n, M, N + 1, ctx, &A_biased_inner));
   /* Set shell matrix functions */
-  PetscCall(MatShellSetOperation(A_biased_inner,MATOP_DESTROY         ,(void(*)(void))MatDestroy_Biased));
-  PetscCall(MatShellSetOperation(A_biased_inner,MATOP_MULT            ,(void(*)(void))MatMult_Biased));
-  PetscCall(MatShellSetOperation(A_biased_inner,MATOP_MULT_TRANSPOSE  ,(void(*)(void))MatMultTranspose_Biased));
-  PetscCall(MatShellSetOperation(A_biased_inner,MATOP_CREATE_SUBMATRIX,(void(*)(void))MatCreateSubMatrix_Biased));
-  PetscCall(PetscObjectComposeFunction((PetscObject) A_biased_inner,"MatGetOwnershipIS_C",MatGetOwnershipIS_Biased));
+  PetscCall(MatShellSetOperation(A_biased_inner, MATOP_DESTROY, (void (*)(void))MatDestroy_Biased));
+  PetscCall(MatShellSetOperation(A_biased_inner, MATOP_MULT, (void (*)(void))MatMult_Biased));
+  PetscCall(MatShellSetOperation(A_biased_inner, MATOP_MULT_TRANSPOSE, (void (*)(void))MatMultTranspose_Biased));
+  PetscCall(MatShellSetOperation(A_biased_inner, MATOP_CREATE_SUBMATRIX, (void (*)(void))MatCreateSubMatrix_Biased));
+  PetscCall(PetscObjectComposeFunction((PetscObject)A_biased_inner, "MatGetOwnershipIS_C", MatGetOwnershipIS_Biased));
 
   /* Set the default vector type for the shell to be the same as for the matrix A */
-  PetscCall(MatGetVecType(A,&vtype));
-  PetscCall(MatShellSetVecType(A_biased_inner,vtype));
+  PetscCall(MatGetVecType(A, &vtype));
+  PetscCall(MatShellSetVecType(A_biased_inner, vtype));
 
   /* Set name of biased mat */
-  PetscCall(PetscObjectGetName((PetscObject) A,&A_name));
-  PetscCall(PetscStrncpy(A_name_inner,A_name,sizeof(A_name_inner)));
-  PetscCall(PetscStrlcat(A_name_inner,"_biased",sizeof(A_name_inner)));
-  PetscCall(PetscObjectSetName((PetscObject) A_biased_inner,A_name_inner));
+  PetscCall(PetscObjectGetName((PetscObject)A, &A_name));
+  PetscCall(PetscStrncpy(A_name_inner, A_name, sizeof(A_name_inner)));
+  PetscCall(PetscStrlcat(A_name_inner, "_biased", sizeof(A_name_inner)));
+  PetscCall(PetscObjectSetName((PetscObject)A_biased_inner, A_name_inner));
   /* Set prefix of biased mat */
-  PetscCall(PetscObjectGetOptionsPrefix((PetscObject) A,&A_prefix));
-  PetscCall(PetscObjectSetOptionsPrefix((PetscObject) A_biased_inner,A_prefix));
-  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject) A_biased_inner,"biased_"));
+  PetscCall(PetscObjectGetOptionsPrefix((PetscObject)A, &A_prefix));
+  PetscCall(PetscObjectSetOptionsPrefix((PetscObject)A_biased_inner, A_prefix));
+  PetscCall(PetscObjectAppendOptionsPrefix((PetscObject)A_biased_inner, "biased_"));
 
   *A_biased = A_biased_inner;
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -166,9 +166,9 @@ PetscErrorCode SVMViewBinaryClassificationReport(SVM svm, PetscInt *cmat, PetscR
   /* Print confusion matrix */
   PetscCall(PetscViewerASCIIPrintf(v, "Confusion matrix:\n"));
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v, "TP = %4" PetscInt_FMT "", cmat[0]));
+  PetscCall(PetscViewerASCIIPrintf(v, "TP = %4" PetscInt_FMT, cmat[0]));
   PetscCall(PetscViewerASCIIPrintf(v, "FP = %4" PetscInt_FMT "\n", cmat[1]));
-  PetscCall(PetscViewerASCIIPrintf(v, "FN = %4" PetscInt_FMT "", cmat[2]));
+  PetscCall(PetscViewerASCIIPrintf(v, "FN = %4" PetscInt_FMT, cmat[2]));
   PetscCall(PetscViewerASCIIPrintf(v, "TN = %4" PetscInt_FMT "\n", cmat[3]));
   PetscCall(PetscViewerASCIIPopTab(v));
 

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -1,55 +1,55 @@
 #include "report.h"
 
-PetscErrorCode BinaryConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt confusion_mat[])
+PetscErrorCode BinaryConfusionMatrix(SVM svm, Vec y_pred, Vec y_known, PetscInt confusion_mat[])
 {
-  PetscInt TP,FP,TN,FN; // confusion matrix values
+  PetscInt TP, FP, TN, FN; // confusion matrix values
   PetscInt N;
 
-  Vec      y_known_sub;
-  Vec      y_pred_sub;
+  Vec y_known_sub;
+  Vec y_pred_sub;
 
-  Vec      vec_label;
-  IS       is_label;
+  Vec vec_label;
+  IS  is_label;
 
-  IS       is_eq;
+  IS is_eq;
 
   const PetscReal *labels = NULL;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetLabels(svm,&labels));
-  PetscCall(VecDuplicate(y_pred,&vec_label));
+  PetscCall(SVMGetLabels(svm, &labels));
+  PetscCall(VecDuplicate(y_pred, &vec_label));
 
   /* TN and FN samples */
-  PetscCall(VecSet(vec_label,labels[0]));
+  PetscCall(VecSet(vec_label, labels[0]));
 
-  PetscCall(VecWhichEqual(y_known,vec_label,&is_label));
-  PetscCall(VecGetSubVector(y_known,is_label,&y_known_sub));
-  PetscCall(VecGetSubVector(y_pred,is_label,&y_pred_sub));
-  PetscCall(VecWhichEqual(y_known_sub,y_pred_sub,&is_eq));
+  PetscCall(VecWhichEqual(y_known, vec_label, &is_label));
+  PetscCall(VecGetSubVector(y_known, is_label, &y_known_sub));
+  PetscCall(VecGetSubVector(y_pred, is_label, &y_pred_sub));
+  PetscCall(VecWhichEqual(y_known_sub, y_pred_sub, &is_eq));
 
-  PetscCall(ISGetSize(is_eq,&TN));
-  PetscCall(VecGetSize(y_known_sub,&N));
+  PetscCall(ISGetSize(is_eq, &TN));
+  PetscCall(VecGetSize(y_known_sub, &N));
   FN = N - TN;
 
-  PetscCall(VecRestoreSubVector(y_known,is_label,&y_known_sub));
-  PetscCall(VecRestoreSubVector(y_pred,is_label,&y_pred_sub));
+  PetscCall(VecRestoreSubVector(y_known, is_label, &y_known_sub));
+  PetscCall(VecRestoreSubVector(y_pred, is_label, &y_pred_sub));
   PetscCall(ISDestroy(&is_label));
   PetscCall(ISDestroy(&is_eq));
 
   /* TP and FP samples */
-  PetscCall(VecSet(vec_label,labels[1]));
+  PetscCall(VecSet(vec_label, labels[1]));
 
-  PetscCall(VecWhichEqual(y_known,vec_label,&is_label));
-  PetscCall(VecGetSubVector(y_known,is_label,&y_known_sub));
-  PetscCall(VecGetSubVector(y_pred,is_label,&y_pred_sub));
-  PetscCall(VecWhichEqual(y_known_sub,y_pred_sub,&is_eq));
+  PetscCall(VecWhichEqual(y_known, vec_label, &is_label));
+  PetscCall(VecGetSubVector(y_known, is_label, &y_known_sub));
+  PetscCall(VecGetSubVector(y_pred, is_label, &y_pred_sub));
+  PetscCall(VecWhichEqual(y_known_sub, y_pred_sub, &is_eq));
 
-  PetscCall(ISGetSize(is_eq,&TP));
-  PetscCall(VecGetSize(y_known_sub,&N));
+  PetscCall(ISGetSize(is_eq, &TP));
+  PetscCall(VecGetSize(y_known_sub, &N));
   FP = N - TP;
 
-  PetscCall(VecRestoreSubVector(y_known,is_label,&y_known_sub));
-  PetscCall(VecRestoreSubVector(y_pred,is_label,&y_pred_sub));
+  PetscCall(VecRestoreSubVector(y_known, is_label, &y_known_sub));
+  PetscCall(VecRestoreSubVector(y_pred, is_label, &y_pred_sub));
   PetscCall(ISDestroy(&is_label));
   PetscCall(ISDestroy(&is_eq));
 
@@ -63,10 +63,10 @@ PetscErrorCode BinaryConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt con
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,PetscInt *cmat, PetscReal *scores)
+PetscErrorCode SVMGetBinaryClassificationReport(SVM svm, Vec y_pred, Vec y_known, PetscInt *cmat, PetscReal *scores)
 {
-  PetscInt  confusion_mat[4];
-  PetscInt  TP,FP,TN,FN;
+  PetscInt confusion_mat[4];
+  PetscInt TP, FP, TN, FN;
 
   PetscReal accuracy[2];
   PetscReal auc_roc;
@@ -76,60 +76,60 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   PetscReal jaccard_index[3];
 
   PetscReal specifity;
-  PetscReal TPR,FPR;
-  PetscReal x[3],y[3],dx;
+  PetscReal TPR, FPR;
+  PetscReal x[3], y[3], dx;
 
-  PetscInt  i;
+  PetscInt i;
 
   PetscFunctionBegin;
-  PetscCall(BinaryConfusionMatrix(svm,y_pred,y_known,confusion_mat));
+  PetscCall(BinaryConfusionMatrix(svm, y_pred, y_known, confusion_mat));
 
   TP = confusion_mat[0];
   FP = confusion_mat[1];
   FN = confusion_mat[2];
   TN = confusion_mat[3];
 
-  if (cmat != NULL) {
-    PetscCall(PetscMemcpy(cmat,confusion_mat,4 * sizeof(PetscInt)));
-  }
+  if (cmat != NULL) { PetscCall(PetscMemcpy(cmat, confusion_mat, 4 * sizeof(PetscInt))); }
 
-  if (scores == NULL) {
-    PetscFunctionReturn(PETSC_SUCCESS);
-  }
+  if (scores == NULL) { PetscFunctionReturn(PETSC_SUCCESS); }
 
-  precision[0] = (PetscReal) TN / (PetscReal) (TN + FP); /* precision (negative class) */
-  precision[1] = (PetscReal) TP / (PetscReal) (TP + FN); /* precision (positive class) */
-  precision[2] = (precision[0] + precision[1]) / 2.;     /* precision (average)        */
+  precision[0] = (PetscReal)TN / (PetscReal)(TN + FP); /* precision (negative class) */
+  precision[1] = (PetscReal)TP / (PetscReal)(TP + FN); /* precision (positive class) */
+  precision[2] = (precision[0] + precision[1]) / 2.;   /* precision (average)        */
 
-  sensitivity[0] = (PetscReal) TN / (PetscReal) (TN + FN); /* sensitivity (negative class) */
-  sensitivity[1] = (PetscReal) TP / (PetscReal) (TP + FP); /* sensitivity (positive class) */
+  sensitivity[0] = (PetscReal)TN / (PetscReal)(TN + FN);   /* sensitivity (negative class) */
+  sensitivity[1] = (PetscReal)TP / (PetscReal)(TP + FP);   /* sensitivity (positive class) */
   sensitivity[2] = (sensitivity[0] + sensitivity[1]) / 2.; /* sensitivity (average)        */
 
   F1[0] = 2. * (precision[0] * sensitivity[0]) / (precision[0] + sensitivity[0]); /* F1 (negative class) */
   F1[1] = 2. * (precision[1] * sensitivity[1]) / (precision[1] + sensitivity[1]); /* F1 (positive class) */
   F1[2] = (F1[0] + F1[1]) / 2.;                                                   /* F1 (average) */
 
-  jaccard_index[0] = (PetscReal) TN / (PetscReal) (TN + FN + FP); /* Jaccard index (negative class) */
-  jaccard_index[1] = (PetscReal) TP / (PetscReal) (TP + FP + FN); /* Jaccard index (positive class) */
-  jaccard_index[2] = (jaccard_index[0] + jaccard_index[1]) / 2.;  /* Jaccard index (average) */
+  jaccard_index[0] = (PetscReal)TN / (PetscReal)(TN + FN + FP);  /* Jaccard index (negative class) */
+  jaccard_index[1] = (PetscReal)TP / (PetscReal)(TP + FP + FN);  /* Jaccard index (positive class) */
+  jaccard_index[2] = (jaccard_index[0] + jaccard_index[1]) / 2.; /* Jaccard index (average) */
 
   /* Area under curve (trapezoidal rule) */
-  specifity = (PetscReal) TN / (PetscReal) (TN + FP);
+  specifity = (PetscReal)TN / (PetscReal)(TN + FP);
 
   FPR = 1. - specifity;
   TPR = sensitivity[0];
 
-  x[0] = 0.; x[1] = FPR; x[2] = 1.;
-  y[0] = 0.; y[1] = TPR; y[2] = 1.;
+  x[0] = 0.;
+  x[1] = FPR;
+  x[2] = 1.;
+  y[0] = 0.;
+  y[1] = TPR;
+  y[2] = 1.;
 
   auc_roc = 0.;
   for (i = 0; i < 2; ++i) {
-    dx = x[i+1] - x[i];
-    auc_roc += ((y[i] + y[i+1]) / 2.) * dx;
+    dx = x[i + 1] - x[i];
+    auc_roc += ((y[i] + y[i + 1]) / 2.) * dx;
   }
 
   /* Accuracy */
-  accuracy[0] = (PetscReal) (TP + TN) / (PetscReal) (TP + TN + FP + FN);
+  accuracy[0] = (PetscReal)(TP + TN) / (PetscReal)(TP + TN + FP + FN);
 
   /* Set scores */
   scores[0] = accuracy[0];
@@ -156,32 +156,32 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SVMViewBinaryClassificationReport(SVM svm,PetscInt *cmat,PetscReal *scores,PetscViewer v)
+PetscErrorCode SVMViewBinaryClassificationReport(SVM svm, PetscInt *cmat, PetscReal *scores, PetscViewer v)
 {
   const PetscReal *labels;
 
   PetscFunctionBegin;
-  PetscCall(SVMGetLabels(svm,&labels));
+  PetscCall(SVMGetLabels(svm, &labels));
 
   /* Print confusion matrix */
-  PetscCall(PetscViewerASCIIPrintf(v,"Confusion matrix:\n"));
+  PetscCall(PetscViewerASCIIPrintf(v, "Confusion matrix:\n"));
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v,"TP = %4" PetscInt_FMT ""  ,cmat[0]));
-  PetscCall(PetscViewerASCIIPrintf(v,"FP = %4" PetscInt_FMT "\n",cmat[1]));
-  PetscCall(PetscViewerASCIIPrintf(v,"FN = %4" PetscInt_FMT ""  ,cmat[2]));
-  PetscCall(PetscViewerASCIIPrintf(v,"TN = %4" PetscInt_FMT "\n",cmat[3]));
+  PetscCall(PetscViewerASCIIPrintf(v, "TP = %4" PetscInt_FMT "", cmat[0]));
+  PetscCall(PetscViewerASCIIPrintf(v, "FP = %4" PetscInt_FMT "\n", cmat[1]));
+  PetscCall(PetscViewerASCIIPrintf(v, "FN = %4" PetscInt_FMT "", cmat[2]));
+  PetscCall(PetscViewerASCIIPrintf(v, "TN = %4" PetscInt_FMT "\n", cmat[3]));
   PetscCall(PetscViewerASCIIPopTab(v));
 
   /* Print classification report */
-  PetscCall(PetscViewerASCIIPrintf(v,"Classification report:\n"));
+  PetscCall(PetscViewerASCIIPrintf(v, "Classification report:\n"));
   /* Header */
   PetscCall(PetscViewerASCIIPushTab(v));
-  PetscCall(PetscViewerASCIIPrintf(v,"label\tprecision\trecall\tF1\tJaccard index\n"));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[0],scores[1],scores[4],scores[7],scores[10]));
-  PetscCall(PetscViewerASCIIPrintf(v,"%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n",labels[1],scores[2],scores[5],scores[8],scores[11]));
-  PetscCall(PetscViewerASCIIPrintf(v,"mean  \t%.4f\t\t%.4f\t%.4f\t%.4f\n"          ,scores[3],scores[6],scores[9],scores[12]));
-  PetscCall(PetscViewerASCIIPrintf(v,"accuracy = %.4f\n",(double) scores[0]));
-  PetscCall(PetscViewerASCIIPrintf(v,"auc_roc  = %.4f\n",(double) scores[15]));
+  PetscCall(PetscViewerASCIIPrintf(v, "label\tprecision\trecall\tF1\tJaccard index\n"));
+  PetscCall(PetscViewerASCIIPrintf(v, "%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n", labels[0], scores[1], scores[4], scores[7], scores[10]));
+  PetscCall(PetscViewerASCIIPrintf(v, "%.1f  \t%.4f\t\t%.4f\t%.4f\t%.4f\n", labels[1], scores[2], scores[5], scores[8], scores[11]));
+  PetscCall(PetscViewerASCIIPrintf(v, "mean  \t%.4f\t\t%.4f\t%.4f\t%.4f\n", scores[3], scores[6], scores[9], scores[12]));
+  PetscCall(PetscViewerASCIIPrintf(v, "accuracy = %.4f\n", (double)scores[0]));
+  PetscCall(PetscViewerASCIIPrintf(v, "auc_roc  = %.4f\n", (double)scores[15]));
   PetscCall(PetscViewerASCIIPopTab(v));
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/svm/utils/report.c
+++ b/src/svm/utils/report.c
@@ -1,4 +1,3 @@
-
 #include "report.h"
 
 PetscErrorCode BinaryConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt confusion_mat[])
@@ -17,7 +16,6 @@ PetscErrorCode BinaryConfusionMatrix(SVM svm,Vec y_pred,Vec y_known,PetscInt con
   const PetscReal *labels = NULL;
 
   PetscFunctionBegin;
-
   PetscCall(SVMGetLabels(svm,&labels));
   PetscCall(VecDuplicate(y_pred,&vec_label));
 
@@ -155,7 +153,6 @@ PetscErrorCode SVMGetBinaryClassificationReport(SVM svm,Vec y_pred,Vec y_known,P
   scores[13] = -1.;
   scores[14] = -1.;
   scores[15] = auc_roc;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/svm/utils/report.h
+++ b/src/svm/utils/report.h
@@ -1,10 +1,6 @@
-
-#if !defined(__PERMONSVMREPORT_H)
-#define	__PERMONSVMREPORT_H
+#pragma once
 
 #include <permonsvm.h>
 
 FLLOP_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM,Vec,Vec,PetscInt *,PetscReal *);
 FLLOP_EXTERN PetscErrorCode SVMViewBinaryClassificationReport(SVM,PetscInt *,PetscReal *,PetscViewer);
-
-#endif //__REPORT_H

--- a/src/svm/utils/report.h
+++ b/src/svm/utils/report.h
@@ -2,5 +2,5 @@
 
 #include <permonsvm.h>
 
-PERMON_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM,Vec,Vec,PetscInt *,PetscReal *);
-PERMON_EXTERN PetscErrorCode SVMViewBinaryClassificationReport(SVM,PetscInt *,PetscReal *,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM, Vec, Vec, PetscInt *, PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMViewBinaryClassificationReport(SVM, PetscInt *, PetscReal *, PetscViewer);

--- a/src/svm/utils/report.h
+++ b/src/svm/utils/report.h
@@ -2,5 +2,5 @@
 
 #include <permonsvm.h>
 
-FLLOP_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM,Vec,Vec,PetscInt *,PetscReal *);
-FLLOP_EXTERN PetscErrorCode SVMViewBinaryClassificationReport(SVM,PetscInt *,PetscReal *,PetscViewer);
+PERMON_EXTERN PetscErrorCode SVMGetBinaryClassificationReport(SVM,Vec,Vec,PetscInt *,PetscReal *);
+PERMON_EXTERN PetscErrorCode SVMViewBinaryClassificationReport(SVM,PetscInt *,PetscReal *,PetscViewer);

--- a/src/tutorials/ex1.c
+++ b/src/tutorials/ex1.c
@@ -1,4 +1,3 @@
-
 static char help[] = "Trains binary SVM classification model using precomputed Gramian matrix.\n\
 Input parameters:\n\
   -f       : training dataset file\n\

--- a/src/tutorials/ex1.c
+++ b/src/tutorials/ex1.c
@@ -6,53 +6,51 @@ Input parameters:\n\
 
 #include <permonsvm.h>
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-  SVM            svm;
+  SVM svm;
 
-  char           training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char           kernel_file[PETSC_MAX_PATH_LEN]   = "";
-  char           test_file[PETSC_MAX_PATH_LEN]     = "";
-  PetscBool      test_file_set = PETSC_FALSE,kernel_file_set = PETSC_FALSE;
+  char      training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char      kernel_file[PETSC_MAX_PATH_LEN]   = "";
+  char      test_file[PETSC_MAX_PATH_LEN]     = "";
+  PetscBool test_file_set = PETSC_FALSE, kernel_file_set = PETSC_FALSE;
 
-  PetscViewer    viewer;
+  PetscViewer viewer;
 
-  PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+  PetscCall(PermonInitialize(&argc, &argv, (char *)0, help));
 
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_kernel",kernel_file,sizeof(kernel_file),&kernel_file_set));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),&test_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training", training_file, sizeof(training_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_kernel", kernel_file, sizeof(kernel_file), &kernel_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test", test_file, sizeof(test_file), &test_file_set));
 
   /* Create SVM object */
-  PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
-  PetscCall(SVMSetType(svm,SVM_BINARY));
+  PetscCall(SVMCreate(PETSC_COMM_WORLD, &svm));
+  PetscCall(SVMSetType(svm, SVM_BINARY));
   PetscCall(SVMSetFromOptions(svm));
 
   /* Load training dataset */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, training_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadTrainingDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load Gramian matrix */
   if (kernel_file_set) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,kernel_file,FILE_MODE_READ,&viewer));
-    PetscCall(SVMLoadGramian(svm,viewer));
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, kernel_file, FILE_MODE_READ, &viewer));
+    PetscCall(SVMLoadGramian(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   /* Load test dataset */
   if (test_file_set) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
-    PetscCall(SVMLoadTestDataset(svm,viewer));
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, test_file, FILE_MODE_READ, &viewer));
+    PetscCall(SVMLoadTestDataset(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   /* Train classification model */
   PetscCall(SVMTrain(svm));
   /* Test performance of SVM model */
-  if (test_file_set) {
-    PetscCall(SVMTest(svm));
-  }
+  if (test_file_set) { PetscCall(SVMTest(svm)); }
 
   /* Free memory */
   PetscCall(SVMDestroy(&svm));

--- a/src/tutorials/ex2.c
+++ b/src/tutorials/ex2.c
@@ -5,57 +5,55 @@ Input parameters:\n\
   -f       : training dataset file\n\
   -f_test  : test dataset file\n";
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-  SVM            svm;
+  SVM svm;
 
-  char           training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char           test_file[PETSC_MAX_PATH_LEN]     = "data/heart_scale.t.bin";
+  char training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char test_file[PETSC_MAX_PATH_LEN]     = "data/heart_scale.t.bin";
 
-  PetscViewer    viewer;
-  PetscBool      test_file_set = PETSC_FALSE;
+  PetscViewer viewer;
+  PetscBool   test_file_set = PETSC_FALSE;
 
-  PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+  PetscCall(PermonInitialize(&argc, &argv, (char *)0, help));
 
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),&test_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training", training_file, sizeof(training_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test", test_file, sizeof(test_file), &test_file_set));
 
   /* Create SVM object */
-  PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
-  PetscCall(SVMSetType(svm,SVM_BINARY));
+  PetscCall(SVMCreate(PETSC_COMM_WORLD, &svm));
+  PetscCall(SVMSetType(svm, SVM_BINARY));
 
   /* Set hyper-parameter optimization will be performed */
-  PetscCall(SVMSetHyperOpt(svm,PETSC_TRUE));
+  PetscCall(SVMSetHyperOpt(svm, PETSC_TRUE));
 
   /* Set k-fold cross-validation on 3 folds */
-  PetscCall(SVMSetCrossValidationType(svm,CROSS_VALIDATION_KFOLD));
-  PetscCall(SVMSetNfolds(svm,3));
+  PetscCall(SVMSetCrossValidationType(svm, CROSS_VALIDATION_KFOLD));
+  PetscCall(SVMSetNfolds(svm, 3));
 
   /* Perform grid-search on S = {3^-2, 3^-1.5, ... 3^-0.5, 1, 3^0.5 ..., 3^1.5, 3^2} */
-  PetscCall(SVMSetPenaltyType(svm,1));
-  PetscCall(SVMGridSearchSetBaseLogC(svm,3));
-  PetscCall(SVMGridSearchSetStrideLogC(svm,-2,2,0.5));
+  PetscCall(SVMSetPenaltyType(svm, 1));
+  PetscCall(SVMGridSearchSetBaseLogC(svm, 3));
+  PetscCall(SVMGridSearchSetStrideLogC(svm, -2, 2, 0.5));
 
   PetscCall(SVMSetFromOptions(svm));
 
   /* Load training dataset */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, training_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadTrainingDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load test dataset */
   if (test_file_set) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
-    PetscCall(SVMLoadTestDataset(svm,viewer));
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, test_file, FILE_MODE_READ, &viewer));
+    PetscCall(SVMLoadTestDataset(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   /* Train SVM model */
   PetscCall(SVMTrain(svm));
   /* Test performance of SVM model */
-  if (test_file_set) {
-    PetscCall(SVMTest(svm));
-  }
+  if (test_file_set) { PetscCall(SVMTest(svm)); }
 
   /* Free memory */
   PetscCall(SVMDestroy(&svm));

--- a/src/tutorials/ex3.c
+++ b/src/tutorials/ex3.c
@@ -8,58 +8,52 @@ Input parameters:\n\
 
 #include <permonsvm.h>
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-  SVM            svm;
+  SVM svm;
 
-  char           training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char           test_file[PETSC_MAX_PATH_LEN]     = "";
-  PetscBool      test_file_set = PETSC_FALSE;
-  PetscBool      training_result_view=PETSC_FALSE,test_result_view=PETSC_FALSE;
+  char      training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char      test_file[PETSC_MAX_PATH_LEN]     = "";
+  PetscBool test_file_set                     = PETSC_FALSE;
+  PetscBool training_result_view = PETSC_FALSE, test_result_view = PETSC_FALSE;
 
-  PetscViewer    viewer;
+  PetscViewer viewer;
 
-  PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+  PetscCall(PermonInitialize(&argc, &argv, (char *)0, help));
 
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),&test_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training", training_file, sizeof(training_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test", test_file, sizeof(test_file), &test_file_set));
 
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-view_training_predictions",&training_result_view));
-  PetscCall(PetscOptionsHasName(NULL,NULL,"-view_test_predictions",&test_result_view));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-view_training_predictions", &training_result_view));
+  PetscCall(PetscOptionsHasName(NULL, NULL, "-view_test_predictions", &test_result_view));
 
   /* Create SVM object */
-  PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
-  PetscCall(SVMSetType(svm,SVM_BINARY));
+  PetscCall(SVMCreate(PETSC_COMM_WORLD, &svm));
+  PetscCall(SVMSetType(svm, SVM_BINARY));
   PetscCall(SVMSetFromOptions(svm));
 
   /* Load training dataset */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, training_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadTrainingDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load test dataset */
   if (test_file_set) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
-    PetscCall(SVMLoadTestDataset(svm,viewer));
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, test_file, FILE_MODE_READ, &viewer));
+    PetscCall(SVMLoadTestDataset(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   /* Train classification model */
   PetscCall(SVMTrain(svm));
   /* Test performance of SVM model */
-  if (test_file_set) {
-    PetscCall(SVMTest(svm));
-  }
+  if (test_file_set) { PetscCall(SVMTest(svm)); }
 
   /* Print predictions on training samples into stdout */
-  if (training_result_view) {
-    PetscCall(SVMViewTrainingPredictions(svm,NULL));
-  }
+  if (training_result_view) { PetscCall(SVMViewTrainingPredictions(svm, NULL)); }
 
   /* Print predictions on test samples  into stdout */
-  if (test_file_set && test_result_view) {
-    PetscCall(SVMViewTestPredictions(svm,NULL));
-  }
+  if (test_file_set && test_result_view) { PetscCall(SVMViewTestPredictions(svm, NULL)); }
 
   /* Free memory */
   PetscCall(SVMDestroy(&svm));

--- a/src/tutorials/ex3.c
+++ b/src/tutorials/ex3.c
@@ -1,4 +1,3 @@
-
 static char help[] = "Trains binary SVM classification model. Predictions on training and test datasets are printed into\
 stdout then.\n\
 Input parameters:\n\

--- a/src/tutorials/ex4.c
+++ b/src/tutorials/ex4.c
@@ -8,33 +8,33 @@ Input parameters:\n\
 
 #include <permonsvm.h>
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-  SVM         svm;
+  SVM svm;
 
-  char        training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char        test_file[PETSC_MAX_PATH_LEN]     = "data/heart_scale.t.bin";
+  char training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char test_file[PETSC_MAX_PATH_LEN]     = "data/heart_scale.t.bin";
 
   PetscViewer viewer;
 
-  PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+  PetscCall(PermonInitialize(&argc, &argv, (char *)0, help));
 
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training", training_file, sizeof(training_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test", test_file, sizeof(test_file), NULL));
 
   /* Create SVM object */
-  PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
-  PetscCall(SVMSetType(svm,SVM_BINARY));
+  PetscCall(SVMCreate(PETSC_COMM_WORLD, &svm));
+  PetscCall(SVMSetType(svm, SVM_BINARY));
   PetscCall(SVMSetFromOptions(svm));
 
   /* Load training dataset */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, training_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadTrainingDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load test dataset */
-  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadTestDataset(svm,viewer));
+  PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, test_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadTestDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Train classification model */

--- a/src/tutorials/ex4.c
+++ b/src/tutorials/ex4.c
@@ -1,4 +1,3 @@
-
 static char help[] = "Trains binary L2-loss SVM classification model that training process was stopped using terminating condition\
 based on duality gap.\n\
 Input parameters:\n\

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -6,48 +6,48 @@ static char help[] = "";
 #define bin      "bin"
 #define SVMLight "svmlight"
 
-PetscErrorCode GetFilenameExtension(const char *filename,char **extension)
+PetscErrorCode GetFilenameExtension(const char *filename, char **extension)
 {
-  char   *extension_inner;
+  char *extension_inner;
 
   PetscFunctionBegin;
-  PetscCall(PetscStrrchr(filename,'.',&extension_inner));
+  PetscCall(PetscStrrchr(filename, '.', &extension_inner));
   *extension = extension_inner;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode ViewerOpen(const char *filename,PetscFileMode file_mode,PetscViewer *viewer)
+PetscErrorCode ViewerOpen(const char *filename, PetscFileMode file_mode, PetscViewer *viewer)
 {
-  PetscViewer  inner_viewer;
+  PetscViewer inner_viewer;
 
-  char        *extension=NULL;
-  PetscBool    ishdf5,isbinary,issvmlight;
+  char     *extension = NULL;
+  PetscBool ishdf5, isbinary, issvmlight;
 
   PetscFunctionBegin;
-  PetscCall(GetFilenameExtension(filename,&extension));
-  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-  PetscCall(PetscStrcmp(extension,bin,&isbinary));
-  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+  PetscCall(GetFilenameExtension(filename, &extension));
+  PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+  PetscCall(PetscStrcmp(extension, bin, &isbinary));
+  PetscCall(PetscStrcmp(extension, SVMLight, &issvmlight));
 
   if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,filename,file_mode,&inner_viewer));
+    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD, filename, file_mode, &inner_viewer));
 #else
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+    SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
   } else if (isbinary) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,filename,file_mode,&inner_viewer));
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, filename, file_mode, &inner_viewer));
   } else if (issvmlight) {
-    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,filename,&inner_viewer));
+    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD, filename, &inner_viewer));
   } else {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
+    SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "File type %s not supported", extension);
   }
 
   *viewer = inner_viewer;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
   SVM         svm;
   PetscViewer viewer;
@@ -59,45 +59,45 @@ int main(int argc,char **argv)
   char test_result_file[PETSC_MAX_PATH_LEN]     = "";
 
   PetscBool training_result_file_set = PETSC_FALSE;
-  PetscBool test_result_file_set = PETSC_FALSE;
+  PetscBool test_result_file_set     = PETSC_FALSE;
 
-  PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+  PetscCall(PermonInitialize(&argc, &argv, (char *)0, help));
 
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_calib",calibration_file,sizeof(calibration_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training_predictions",training_result_file,sizeof(training_result_file),&training_result_file_set));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test_predictions",test_result_file,sizeof(test_result_file),&test_result_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training", training_file, sizeof(training_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_calib", calibration_file, sizeof(calibration_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test", test_file, sizeof(test_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_training_predictions", training_result_file, sizeof(training_result_file), &training_result_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test_predictions", test_result_file, sizeof(test_result_file), &test_result_file_set));
 
   /* Create SVM object */
-  PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
-  PetscCall(SVMSetType(svm,SVM_PROBABILITY));
+  PetscCall(SVMCreate(PETSC_COMM_WORLD, &svm));
+  PetscCall(SVMSetType(svm, SVM_PROBABILITY));
   PetscCall(SVMSetFromOptions(svm));
 
-  PetscCall(ViewerOpen(training_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(ViewerOpen(training_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadTrainingDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
-  PetscCall(ViewerOpen(calibration_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadCalibrationDataset(svm,viewer));
+  PetscCall(ViewerOpen(calibration_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadCalibrationDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
-  PetscCall(ViewerOpen(test_file,FILE_MODE_READ,&viewer));
-  PetscCall(SVMLoadTestDataset(svm,viewer));
+  PetscCall(ViewerOpen(test_file, FILE_MODE_READ, &viewer));
+  PetscCall(SVMLoadTestDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   PetscCall(SVMTrain(svm));
   PetscCall(SVMTest(svm));
 
   if (training_result_file_set) {
-    PetscCall(ViewerOpen(training_result_file,FILE_MODE_WRITE,&viewer));
-    PetscCall(SVMViewTrainingPredictions(svm,viewer));
+    PetscCall(ViewerOpen(training_result_file, FILE_MODE_WRITE, &viewer));
+    PetscCall(SVMViewTrainingPredictions(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   if (test_result_file_set) {
-    PetscCall(ViewerOpen(test_result_file,FILE_MODE_WRITE,&viewer));
-    PetscCall(SVMViewTestPredictions(svm,viewer));
+    PetscCall(ViewerOpen(test_result_file, FILE_MODE_WRITE, &viewer));
+    PetscCall(SVMViewTestPredictions(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -1,4 +1,3 @@
-
 static char help[] = "";
 
 #include <permonsvm.h>
@@ -45,7 +44,6 @@ PetscErrorCode ViewerOpen(const char *filename,PetscFileMode file_mode,PetscView
   }
 
   *viewer = inner_viewer;
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/tutorials/ex5.c
+++ b/src/tutorials/ex5.c
@@ -63,7 +63,6 @@ int main(int argc,char **argv)
   PetscBool training_result_file_set = PETSC_FALSE;
   PetscBool test_result_file_set = PETSC_FALSE;
 
-
   PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
 
   PetscCall(PetscOptionsGetString(NULL,NULL,"-f_training",training_file,sizeof(training_file),NULL));

--- a/src/tutorials/exbinfile.c
+++ b/src/tutorials/exbinfile.c
@@ -100,7 +100,6 @@ int main(int argc,char **argv)
   return 0;
 }
 
-
 /*TEST
   testset:
     suffix: 1

--- a/src/tutorials/exbinfile.c
+++ b/src/tutorials/exbinfile.c
@@ -12,86 +12,84 @@ Input parameters include:\n\
 #define bin      "bin"
 #define SVMLight "svmlight"
 
-PetscErrorCode GetFilenameExtension(const char *filename,char **extension)
+PetscErrorCode GetFilenameExtension(const char *filename, char **extension)
 {
-  char           *extension_inner;
+  char *extension_inner;
 
   PetscFunctionBegin;
-  PetscCall(PetscStrrchr(filename,'.',&extension_inner));
+  PetscCall(PetscStrrchr(filename, '.', &extension_inner));
   *extension = extension_inner;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-  SVM            svm;
-  char           training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
-  char           test_file[PETSC_MAX_PATH_LEN]     = "";
-  char           *extension = NULL;
-  PetscViewer    viewer;
-  PetscBool      test_file_set = PETSC_FALSE;
-  PetscBool      ishdf5,isbinary,issvmlight;
+  SVM         svm;
+  char        training_file[PETSC_MAX_PATH_LEN] = "data/heart_scale.bin";
+  char        test_file[PETSC_MAX_PATH_LEN]     = "";
+  char       *extension                         = NULL;
+  PetscViewer viewer;
+  PetscBool   test_file_set = PETSC_FALSE;
+  PetscBool   ishdf5, isbinary, issvmlight;
 
-  PetscCall(PermonInitialize(&argc,&argv,(char *)0,help));
+  PetscCall(PermonInitialize(&argc, &argv, (char *)0, help));
 
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f",training_file,sizeof(training_file),NULL));
-  PetscCall(PetscOptionsGetString(NULL,NULL,"-f_test",test_file,sizeof(test_file),&test_file_set));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f", training_file, sizeof(training_file), NULL));
+  PetscCall(PetscOptionsGetString(NULL, NULL, "-f_test", test_file, sizeof(test_file), &test_file_set));
 
   /* Create SVM object */
-  PetscCall(SVMCreate(PETSC_COMM_WORLD,&svm));
-  PetscCall(SVMSetType(svm,SVM_BINARY));
+  PetscCall(SVMCreate(PETSC_COMM_WORLD, &svm));
+  PetscCall(SVMSetType(svm, SVM_BINARY));
   PetscCall(SVMSetFromOptions(svm));
 
   /* Load training dataset */
-  PetscCall(GetFilenameExtension(training_file,&extension));
-  PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-  PetscCall(PetscStrcmp(extension,bin,&isbinary));
-  PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+  PetscCall(GetFilenameExtension(training_file, &extension));
+  PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+  PetscCall(PetscStrcmp(extension, bin, &isbinary));
+  PetscCall(PetscStrcmp(extension, SVMLight, &issvmlight));
   if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
+    PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD, training_file, FILE_MODE_READ, &viewer));
 #else
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+    SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
   } else if (isbinary) {
-    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,training_file,FILE_MODE_READ,&viewer));
+    PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, training_file, FILE_MODE_READ, &viewer));
   } else if (issvmlight) {
-    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,training_file,&viewer));
+    PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD, training_file, &viewer));
   } else {
-    SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
+    SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "File type %s not supported", extension);
   }
-  PetscCall(SVMLoadTrainingDataset(svm,viewer));
+  PetscCall(SVMLoadTrainingDataset(svm, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
 
   /* Load test dataset */
   if (test_file_set) {
-    PetscCall(GetFilenameExtension(test_file,&extension));
-    PetscCall(PetscStrcmp(extension,h5,&ishdf5));
-    PetscCall(PetscStrcmp(extension,bin,&isbinary));
-    PetscCall(PetscStrcmp(extension,SVMLight,&issvmlight));
+    PetscCall(GetFilenameExtension(test_file, &extension));
+    PetscCall(PetscStrcmp(extension, h5, &ishdf5));
+    PetscCall(PetscStrcmp(extension, bin, &isbinary));
+    PetscCall(PetscStrcmp(extension, SVMLight, &issvmlight));
     if (ishdf5) {
 #if defined(PETSC_HAVE_HDF5)
-      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
+      PetscCall(PetscViewerHDF5Open(PETSC_COMM_WORLD, test_file, FILE_MODE_READ, &viewer));
 #else
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"PETSc is not configured with HDF5");
+      SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "PETSc is not configured with HDF5");
 #endif
     } else if (isbinary) {
-      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD,test_file,FILE_MODE_READ,&viewer));
+      PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, test_file, FILE_MODE_READ, &viewer));
     } else if (issvmlight) {
-      PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD,test_file,&viewer));
+      PetscCall(PetscViewerSVMLightOpen(PETSC_COMM_WORLD, test_file, &viewer));
     } else {
-      SETERRQ(PETSC_COMM_WORLD,PETSC_ERR_SUP,"File type %s not supported",extension);
+      SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_SUP, "File type %s not supported", extension);
     }
-    PetscCall(SVMLoadTestDataset(svm,viewer));
+    PetscCall(SVMLoadTestDataset(svm, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
   /* Train SVM model */
   PetscCall(SVMTrain(svm));
   /* Test performance of SVM model */
-  if (test_file_set) {
-    PetscCall(SVMTest(svm));
-  }
+  if (test_file_set) { PetscCall(SVMTest(svm)); }
 
   PetscCall(SVMDestroy(&svm));
   PetscCall(PermonFinalize());
@@ -127,4 +125,3 @@ int main(int argc,char **argv)
     args: -f $PERMON_SVM_DIR/src/tutorials/data/heart_scale.h5 -f_test $PERMON_SVM_DIR/src/tutorials/data/heart_scale.t.h5
     output_file: output/exbinfile_1.out
 TEST*/
-

--- a/src/tutorials/exbinfile.c
+++ b/src/tutorials/exbinfile.c
@@ -1,4 +1,3 @@
-
 static char help[] = "Computes binary SVM classification model.\n\
 Input parameters include:\n\
   -f      : training dataset file\n\


### PR DESCRIPTION
https://petsc.org/release/developers/style/

Running `make checkbadsource` catches some errors. The rest of the style is enforced by `.clang-format`, which can be executed using `make permonclangformat`. The clang-format version is currently fixed at 19.

Additionally, all instances of `FLLOP` have been renamed to `PERMON`. This includes option names and the `flloprc` file, now renamed to `permonrc`.